### PR TITLE
Add Motion Time to the ROS Action Feedback Message

### DIFF
--- a/ada_feeding_msgs/action/AcquireFood.action
+++ b/ada_feeding_msgs/action/AcquireFood.action
@@ -22,6 +22,8 @@ uint8 status
 bool is_planning
 # The amount of time the robot has spent in planning (required)
 builtin_interfaces/Duration planning_time
+# The amount of time the robot has spent in motion (required if `is_planning == false`)
+builtin_interfaces/Duration motion_time
 # How far the robot initially was from the goal (required if `is_planning == false`)
 float64 motion_initial_distance
 # How far the robot currently is from the goal (required if `is_planning == false`)

--- a/ada_feeding_msgs/action/MoveTo.action
+++ b/ada_feeding_msgs/action/MoveTo.action
@@ -20,6 +20,8 @@ uint8 status
 bool is_planning
 # The amount of time the robot has spent in planning (required)
 builtin_interfaces/Duration planning_time
+# The amount of time the robot has spent in motion (required if `is_planning == false`)
+builtin_interfaces/Duration motion_time
 # How far the robot initially was from the goal (required if `is_planning == false`)
 float64 motion_initial_distance
 # How far the robot currently is from the goal (required if `is_planning == false`)

--- a/ada_feeding_msgs/action/MoveToMouth.action
+++ b/ada_feeding_msgs/action/MoveToMouth.action
@@ -20,6 +20,8 @@ uint8 status
 bool is_planning
 # The amount of time the robot has spent in planning (required)
 builtin_interfaces/Duration planning_time
+# The amount of time the robot has spent in motion (required if `is_planning == false`)
+builtin_interfaces/Duration motion_time
 # How far the robot initially was from the goal (required if `is_planning == false`)
 float64 motion_initial_distance
 # How far the robot currently is from the goal (required if `is_planning == false`)


### PR DESCRIPTION
This PR adds a a field for `motion_time` to the ROS actions feedback messages.

I tested this by running the dummy nodes in [feeding_web_interface](https://github.com/personalrobotics/feeding_web_interface) and ensuring that they still work and return feedback with `motion_time`. (Although right now `motion_time` is 0 because I haven't modified the dummy node implementation yet.)