### PR TITLE
Add remaining dummy py_trees

### DIFF
--- a/ada_feeding/CMakeLists.txt
+++ b/ada_feeding/CMakeLists.txt
@@ -30,7 +30,6 @@ ament_python_install_package(${PROJECT_NAME})
 # Install Python executables
 install(PROGRAMS
   scripts/create_action_servers.py
-  scripts/run_tree.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -17,8 +17,8 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
     1. Individual actions:
         1. `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
         2. `ros2 action send_goal /AcquireFood ada_feeding_msgs/action/AcquireFood "{header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, detected_food: {roi: {x_offset: 0, y_offset: 0, height: 0, width: 0, do_rectify: false}, mask: {header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, format: '', data: []}, item_id: '', confidence: 0.0}}" --feedback`
-        3. `ros2 action send_goal /MoveToStagingLocation ada_feeding_msgs/action/MoveTo "{}" --feedback`
-        4. `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveToMouth "{detected_mouth_center: {header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, point: {x: 0.0, y: 0.0, z: 0.0}}}" --feedback`
+        3. `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`
+        4. `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveTo "{}" --feedback`
         5. `ros2 action send_goal /MoveToStowLocation ada_feeding_msgs/action/MoveTo "{}" --feedback`
     2. With the web app:
         1. Launch the perception nodes:

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -16,11 +16,14 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
 4. Test it:
     1. Individual actions:
         1. `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
-        2. **Not yet implemented** `ros2 action send_goal /AcquireFood ada_feeding_msgs/action/AcquireFood "{header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, detected_food: {roi: {x_offset: 0, y_offset: 0, height: 0, width: 0, do_rectify: false}, mask: {header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, format: '', data: []}, item_id: '', confidence: 0.0}}" --feedback`
+        2. `ros2 action send_goal /AcquireFood ada_feeding_msgs/action/AcquireFood "{header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, detected_food: {roi: {x_offset: 0, y_offset: 0, height: 0, width: 0, do_rectify: false}, mask: {header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, format: '', data: []}, item_id: '', confidence: 0.0}}" --feedback`
+        3. `ros2 action send_goal /MoveToStagingLocation ada_feeding_msgs/action/MoveTo "{}" --feedback`
+        4. `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveToMouth "{detected_mouth_center: {header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, point: {x: 0.0, y: 0.0, z: 0.0}}}" --feedback`
+        5. `ros2 action send_goal /MoveToStowLocation ada_feeding_msgs/action/MoveTo "{}" --feedback`
     2. With the web app:
         1. Launch the perception nodes:
-            1. Dummy nodes: `TODO`
-            2. Real nodes: `TODO`
+            1. Dummy nodes: `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml run_motion:=false`
+            2. Real nodes: **NOT YET IMPLEMENTED**
         2. Launch the web app ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp))
 
 ## Writing Behavior Trees That Can Be Wrapped Into Action Servers

--- a/ada_feeding/ada_feeding/behaviors/move_to_dummy.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to_dummy.py
@@ -134,10 +134,10 @@ class MoveToDummy(py_trees.behaviour.Behaviour):
         self.motion_start_time = None
 
         # Initialization the blackboard
-        self.blackboard = self.attach_blackboard_client(name=name)
+        self.blackboard = self.attach_blackboard_client(name=name + " Root")
         # Note that the dummy node doesn't actually access the goal, but this is
         # included for completeness
-        self.blackboard.register_key(key="goal", access=py_trees.common.Access.WRITE)
+        self.blackboard.register_key(key="goal", access=py_trees.common.Access.READ)
         self.blackboard.register_key(
             key="is_planning", access=py_trees.common.Access.WRITE
         )

--- a/ada_feeding/ada_feeding/behaviors/move_to_dummy.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to_dummy.py
@@ -135,6 +135,9 @@ class MoveToDummy(py_trees.behaviour.Behaviour):
 
         # Initialization the blackboard
         self.blackboard = self.attach_blackboard_client(name=name)
+        # Note that the dummy node doesn't actually access the goal, but this is
+        # included for completeness
+        self.blackboard.register_key(key="goal", access=py_trees.common.Access.WRITE)
         self.blackboard.register_key(
             key="is_planning", access=py_trees.common.Access.WRITE
         )

--- a/ada_feeding/ada_feeding/behaviors/move_to_dummy.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to_dummy.py
@@ -181,6 +181,11 @@ class MoveToDummy(py_trees.behaviour.Behaviour):
         """
         self.logger.info("%s [MoveToDummy::initialise()]" % self.name)
 
+        # Reset local state variables
+        self.prev_response = None
+        self.planning_start_time = None
+        self.motion_start_time = None
+
         # Reset the blackboard
         self.blackboard.is_planning = False
         self.blackboard.planning_time = 0.0

--- a/ada_feeding/ada_feeding/behaviors/move_to_dummy.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to_dummy.py
@@ -142,6 +142,9 @@ class MoveToDummy(py_trees.behaviour.Behaviour):
             key="planning_time", access=py_trees.common.Access.WRITE
         )
         self.blackboard.register_key(
+            key="motion_time", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
             key="motion_initial_distance", access=py_trees.common.Access.WRITE
         )
         self.blackboard.register_key(
@@ -178,6 +181,7 @@ class MoveToDummy(py_trees.behaviour.Behaviour):
         # Reset the blackboard
         self.blackboard.is_planning = False
         self.blackboard.planning_time = 0.0
+        self.blackboard.motion_time = 0.0
         self.blackboard.motion_initial_distance = 0.0
         self.blackboard.motion_curr_distance = 0.0
 
@@ -228,8 +232,9 @@ class MoveToDummy(py_trees.behaviour.Behaviour):
                     #       `motion_curr_distance` should determine the distance
                     #       to the goal.
                     self.blackboard.motion_initial_distance = self.dummy_motion_time_s
-                self.blackboard.motion_curr_distance = self.dummy_motion_time_s - (
-                    time.time() - self.motion_start_time
+                self.blackboard.motion_time = time.time() - self.motion_start_time
+                self.blackboard.motion_curr_distance = (
+                    self.dummy_motion_time_s - self.blackboard.motion_time
                 )
 
         # If it hasn't finished, return running

--- a/ada_feeding/ada_feeding/helpers.py
+++ b/ada_feeding/ada_feeding/helpers.py
@@ -1,0 +1,44 @@
+"""
+This module defines a number of helper functions that are reused throughout the
+Ada Feeding project.
+"""
+
+# Standard imports
+from typing import Any
+
+
+def import_from_string(import_string: str) -> Any:
+    """
+    Imports a module from a string.
+
+    Parameters
+    ----------
+    import_string: The string to import, e.g., "ada_feeding_msgs.action.MoveTo"
+        This should be in the format "package.module.class"
+
+    Returns
+    -------
+    module: The imported module.
+
+    Raises
+    ------
+    NameError: If the import string is invalid.
+    ImportError: If the module cannot be imported.
+    """
+    try:
+        import_package, import_module, import_class = import_string.split(".", 3)
+    except Exception as exc:
+        raise NameError(
+            'Invalid import string %s. Except "package.module.class" e.g., "ada_feeding_msgs.action.MoveTo"'
+            % import_string
+        ) from exc
+    try:
+        return getattr(
+            getattr(
+                __import__("%s.%s" % (import_package, import_module)),
+                import_module,
+            ),
+            import_class,
+        )
+    except Exception as exc:
+        raise ImportError("Error importing %s" % (import_string)) from exc

--- a/ada_feeding/ada_feeding/trees/__init__.py
+++ b/ada_feeding/ada_feeding/trees/__init__.py
@@ -3,4 +3,4 @@ This package contains custom behavior trees that are used in the Ada Feeding
 project. Many of these trees implement the ActionServerBT interface, in order
 to be wrapped in a ROS action server. 
 """
-from .move_above_plate_dummy import MoveAbovePlate
+from .move_to_dummy_tree import MoveToDummyTree

--- a/ada_feeding/ada_feeding/trees/move_above_plate_dummy.py
+++ b/ada_feeding/ada_feeding/trees/move_above_plate_dummy.py
@@ -108,6 +108,11 @@ class MoveAbovePlate(ActionServerBT):
             feedback_msg.planning_time.nanosec = int(
                 (planning_time - int(planning_time)) * 1e9
             )
+            motion_time = tree.root.blackboard.motion_time
+            feedback_msg.motion_time.sec = int(motion_time)
+            feedback_msg.motion_time.nanosec = int(
+                (motion_time - int(motion_time)) * 1e9
+            )
             if not feedback_msg.is_planning:
                 feedback_msg.motion_initial_distance = (
                     tree.root.blackboard.motion_initial_distance

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -95,6 +95,7 @@ class MoveToDummyTree(ActionServerBT):
         success: Whether the goal was sent successfully.
         """
         # Write the goal to blackboard
+        tree.root.blackboard.goal = goal
         return True
 
     def get_feedback(self, tree: py_trees.trees.BehaviourTree) -> object:

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -13,27 +13,38 @@ import py_trees
 
 # Local imports
 from ada_feeding.behaviors import MoveToDummy
+from ada_feeding.helpers import import_from_string
 from ada_feeding import ActionServerBT
-from ada_feeding_msgs.action import MoveTo
 
 
-class MoveAbovePlate(ActionServerBT):
+class MoveToDummyTree(ActionServerBT):
     """
     A dummy behavior tree that mimics the interface of the MoveAbovePlate
     behavior tree.
     """
 
     def __init__(
-        self, dummy_plan_time: float = 2.5, dummy_motion_time: float = 7.5
+        self,
+        action_type_class: str,
+        dummy_plan_time: float = 2.5,
+        dummy_motion_time: float = 7.5,
     ) -> None:
         """
         Initializes tree-specific parameters.
 
         Parameters
         ----------
+        action_type_class: The type of action that this tree is implementing,
+            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
+            type can be anything, but the Feedback and Result must at a minimum
+            include the fields of ada_feeding_msgs.action.MoveTo
         dummy_plan_time: How many seconds this dummy node should spend in planning.
         dummy_motion_time: How many seconds this dummy node should spend in motion.
         """
+        # Import the action type
+        self.action_type_class = import_from_string(action_type_class)
+
+        # Set the dummy motion parameters
         self.dummy_plan_time = dummy_plan_time
         self.dummy_motion_time = dummy_motion_time
 
@@ -68,7 +79,7 @@ class MoveAbovePlate(ActionServerBT):
 
         return self.tree
 
-    def send_goal(self, tree: py_trees.trees.BehaviourTree, goal: MoveTo.Goal) -> bool:
+    def send_goal(self, tree: py_trees.trees.BehaviourTree, goal: object) -> bool:
         """
         Sends the goal from the action client to the behavior tree.
 
@@ -83,10 +94,10 @@ class MoveAbovePlate(ActionServerBT):
         -------
         success: Whether the goal was sent successfully.
         """
-        # For MoveAbovePlate, there is no goal to send
+        # Write the goal to blackboard
         return True
 
-    def get_feedback(self, tree: py_trees.trees.BehaviourTree) -> MoveTo.Feedback:
+    def get_feedback(self, tree: py_trees.trees.BehaviourTree) -> object:
         """
         Traverses the tree to generate a feedback message for the MoveTo action.
 
@@ -100,7 +111,7 @@ class MoveAbovePlate(ActionServerBT):
         -------
         feedback: The ROS feedback message to be sent to the action client.
         """
-        feedback_msg = MoveTo.Feedback()
+        feedback_msg = self.action_type_class.Feedback()
         if tree.root.blackboard.exists("is_planning"):
             feedback_msg.is_planning = tree.root.blackboard.is_planning
             planning_time = tree.root.blackboard.planning_time
@@ -122,7 +133,7 @@ class MoveAbovePlate(ActionServerBT):
                 )
         return feedback_msg
 
-    def get_result(self, tree: py_trees.trees.BehaviourTree) -> MoveTo.Result:
+    def get_result(self, tree: py_trees.trees.BehaviourTree) -> object:
         """
         Traverses the tree to generate a result message for the MoveTo action.
 
@@ -136,7 +147,7 @@ class MoveAbovePlate(ActionServerBT):
         -------
         result: The ROS result message to be sent to the action client.
         """
-        result = MoveTo.Result()
+        result = self.action_type_class.Result()
         # If the tree succeeded, return success
         if tree.root.status == py_trees.common.Status.SUCCESS:
             result.status = result.STATUS_SUCCESS

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -97,10 +97,6 @@ class MoveToDummyTree(ActionServerBT):
             self.blackboard.register_key(
                 key="motion_curr_distance", access=py_trees.common.Access.READ
             )
-            self.tree.root.logger.info(
-                "Root Blackboard \n%s" % self.tree.root.blackboard
-            )
-            self.tree.root.logger.info("Tree Blackboard \n%s" % self.blackboard)
 
         return self.tree
 

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -7,7 +7,7 @@ ada_feeding_action_servers:
       - MoveAbovePlate
       - AcquireFood
       - MoveToMouth
-      - MoveToStagingLocation
+      - MoveToRestingPosition
       - MoveToStowLocation
 
     # Parameters for the MoveAbovePlate action
@@ -38,22 +38,22 @@ ada_feeding_action_servers:
         dummy_motion_time: 10.0 # secs
       tick_rate: 10 # Hz, optional, default: 30
 
-    # Parameters for the MoveToMouth action
-    MoveToMouth: # required
-      action_type: ada_feeding_msgs.action.MoveToMouth # required
+   # Parameters for the MoveToRestingPosition action
+    MoveToRestingPosition: # required
+      action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToDummyTree # required
       tree_kws: # optional
         - action_type_class
         - dummy_plan_time
         - dummy_motion_time
       tree_kwargs: # optional
-        action_type_class: ada_feeding_msgs.action.MoveToMouth # required
+        action_type_class: ada_feeding_msgs.action.MoveTo # required
         dummy_plan_time: 1.0 # secs
         dummy_motion_time: 10.0 # secs
       tick_rate: 10 # Hz, optional, default: 30
 
-    # Parameters for the MoveToStagingLocation action
-    MoveToStagingLocation: # required
+    # Parameters for the MoveToMouth action
+    MoveToMouth: # required
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToDummyTree # required
       tree_kws: # optional

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -8,9 +8,10 @@ ada_feeding_action_servers:
     # Parameters for the MoveAbovePlate action
     MoveAbovePlate: # required
       action_type: ada_feeding_msgs.action.MoveTo # required
-      tree_class: ada_feeding.trees.MoveAbovePlate # required
-      tree_kws: ["dummy_plan_time", "dummy_motion_time"] # optional
+      tree_class: ada_feeding.trees.MoveToDummyTree # required
+      tree_kws: ["action_type_class", "dummy_plan_time", "dummy_motion_time"] # optional
       tree_kwargs: # optional
+        action_type_class: ada_feeding_msgs.action.MoveTo # required
         dummy_plan_time: 1.0 # secs
         dummy_motion_time: 10.0 # secs
       tick_rate: 10 # Hz, optional, default: 30

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -3,13 +3,77 @@ ada_feeding_action_servers:
   ros__parameters:
     # A list of the names of the action servers to create. Each one must have
     # it's own parameters (below) specifying action_type and tree_class.
-    server_names: [MoveAbovePlate]
+    server_names:
+      - MoveAbovePlate
+      - AcquireFood
+      - MoveToMouth
+      - MoveToStagingLocation
+      - MoveToStowLocation
 
     # Parameters for the MoveAbovePlate action
     MoveAbovePlate: # required
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToDummyTree # required
-      tree_kws: ["action_type_class", "dummy_plan_time", "dummy_motion_time"] # optional
+      tree_kws: # optional
+        - action_type_class
+        - dummy_plan_time
+        - dummy_motion_time
+      tree_kwargs: # optional
+        action_type_class: ada_feeding_msgs.action.MoveTo # required
+        dummy_plan_time: 1.0 # secs
+        dummy_motion_time: 10.0 # secs
+      tick_rate: 10 # Hz, optional, default: 30
+
+    # Parameters for the AcquireFood action
+    AcquireFood: # required
+      action_type: ada_feeding_msgs.action.AcquireFood # required
+      tree_class: ada_feeding.trees.MoveToDummyTree # required
+      tree_kws: # optional
+        - action_type_class
+        - dummy_plan_time
+        - dummy_motion_time
+      tree_kwargs: # optional
+        action_type_class: ada_feeding_msgs.action.AcquireFood # required
+        dummy_plan_time: 1.0 # secs
+        dummy_motion_time: 10.0 # secs
+      tick_rate: 10 # Hz, optional, default: 30
+
+    # Parameters for the MoveToMouth action
+    MoveToMouth: # required
+      action_type: ada_feeding_msgs.action.MoveToMouth # required
+      tree_class: ada_feeding.trees.MoveToDummyTree # required
+      tree_kws: # optional
+        - action_type_class
+        - dummy_plan_time
+        - dummy_motion_time
+      tree_kwargs: # optional
+        action_type_class: ada_feeding_msgs.action.MoveToMouth # required
+        dummy_plan_time: 1.0 # secs
+        dummy_motion_time: 10.0 # secs
+      tick_rate: 10 # Hz, optional, default: 30
+
+    # Parameters for the MoveToStagingLocation action
+    MoveToStagingLocation: # required
+      action_type: ada_feeding_msgs.action.MoveTo # required
+      tree_class: ada_feeding.trees.MoveToDummyTree # required
+      tree_kws: # optional
+        - action_type_class
+        - dummy_plan_time
+        - dummy_motion_time
+      tree_kwargs: # optional
+        action_type_class: ada_feeding_msgs.action.MoveTo # required
+        dummy_plan_time: 1.0 # secs
+        dummy_motion_time: 10.0 # secs
+      tick_rate: 10 # Hz, optional, default: 30
+
+    # Parameters for the MoveToStowLocation action
+    MoveToStowLocation: # required
+      action_type: ada_feeding_msgs.action.MoveTo # required
+      tree_class: ada_feeding.trees.MoveToDummyTree # required
+      tree_kws: # optional
+        - action_type_class
+        - dummy_plan_time
+        - dummy_motion_time
       tree_kwargs: # optional
         action_type_class: ada_feeding_msgs.action.MoveTo # required
         dummy_plan_time: 1.0 # secs

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -20,6 +20,7 @@ from rclpy.node import Node
 
 # Local imports
 from ada_feeding import ActionServerBT
+from ada_feeding.helpers import import_from_string
 
 
 class ActionServerParams:
@@ -197,47 +198,22 @@ class CreateActionServers(Node):
             )
 
             # Import the action type
-            try:
-                action_package, action_module, action_class = params.action_type.split(
-                    ".", 3
-                )
-            except Exception as exc:
-                raise NameError(
-                    'Invalid action type %s. Except "package.module.class" e.g., "ada_feeding_msgs.action.MoveTo"'
-                    % params.action_type
-                ) from exc
-            try:
-                self._action_types[params.action_type] = getattr(
-                    getattr(
-                        __import__("%s.%s" % (action_package, action_module)),
-                        action_module,
-                    ),
-                    action_class,
-                )
-            except Exception as exc:
-                raise ImportError("Error importing %s" % (params.action_type)) from exc
+            self._action_types[params.action_type] = import_from_string(
+                params.action_type
+            )
 
             # Import the behavior tree class
+            self._tree_classes[params.tree_class] = import_from_string(
+                params.tree_class
+            )
             try:
-                tree_package, tree_module, tree_class = params.tree_class.split(".", 3)
-            except Exception as exc:
-                raise NameError(
-                    'Invalid tree class %s. Except "package.module.class" e.g., "ada_feeding.trees.MoveAbovePlate"'
-                    % params.tree_class
-                ) from exc
-            try:
-                self._tree_classes[params.tree_class] = getattr(
-                    getattr(
-                        __import__("%s.%s" % (tree_package, tree_module)),
-                        tree_module,
-                    ),
-                    tree_class,
-                )
                 assert issubclass(
                     self._tree_classes[params.tree_class], ActionServerBT
                 ), ("Tree %s must subclass ActionServerBT" % params.tree_class)
-            except Exception as exc:
-                raise ImportError("Error importing %s" % (params.tree_class)) from exc
+            except Exception:
+                self.get_logger().warn(
+                    "%s\nSKIPPING THIS ACTION SERVER" % (traceback.format_exc())
+                )
 
             # Create the action server.
             action_server = ActionServer(

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -164,6 +164,13 @@ class CreateActionServers(Node):
             else:
                 tree_kwargs = {}
 
+            if action_type.value is None or tree_class.value is None:
+                self.get_logger().warn(
+                    "Skipping action server %s because it has no action type or tree class"
+                    % server_name
+                )
+                continue
+
             action_server_params.append(
                 ActionServerParams(
                     server_name=server_name,

--- a/ada_feeding/scripts/run_tree.py
+++ b/ada_feeding/scripts/run_tree.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python3


### PR DESCRIPTION
# Description

The primary purpose of this PR is to add the `py_trees` for the remaining motion actions (#20 already did it for `MoveAbovePlate`). In doing so, it also makes the following changes:
- Adds the new `motion_time` part of the feedback (#21 ).
- Made `move_to_dummy_tree` a generic function that could be used for multiple dummy motion nodes. Note that this only works for the dummy implementation; for the actual nodes we will likely have to construct different trees per action.
- Fixed how the tree interacted with the blackboard, and made it write the goal to blackboard.
- Fixed an initialization bug in the dummy behavior, whereby if we cancel an action while it is planning and then call the action again after a bit, the `planning_time` part of the feedback will be with regards to the first call.

# Testing procedure

1. Build the workspace: `colcon build`
2. Source the workspace: `source install/setup.bash`
3. Run the action server(s): `ros2 launch ada_feeding ada_feeding_launch.xml`
4. For each of the 5 actions individually, do the below. See README for commands to call each action\:
    - [x] Call it, ensure it runs to completion and returns the expected feedback.
    - [x] Once one call to it has successfully ended, call it again (above command) and ensure that works.
    - [x] Call it, and terminate the call, and ensure the cancel is handled as expected.
    - [x] Once one call to it has been canceled, call it again and ensure that works.
    - [x] Call it and call it again while that is executing, and ensure that the new goal is rejected and the first call behaves as expected.
    - [x] Terminate and then call it in quick succession and ensure it behaves as expected.
6. Test the code with two actions (`MoveAbovePlate` and `AcquireFood`):
    - [x] Call `MoveAbovePlate` and, while it is running, call `Acquire Food` and ensure the call to `AcquireFood` gets rejected.
    - [x] The same test as above but swap the two actions.
    - [x] After one action has succeeded, call another action, and ensure it works.
    - [x] Call one action, then cancel it and immediately call another action, ensure it behaves as exected.
7. Test the entire system together:
    1. Load the dummy perception nodes (requires [feeding_web_interface#58](https://github.com/personalrobotics/feeding_web_interface/pull/58)): `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml run_motion:=false`
    2. [Run the web app](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp).
    - [x] Ensure that the web app works as expected and is calling the movement actions as expected.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address (most) warnings/errors: `pylint --recursive=y .`

# Before Merging
- [ ] `Squash & Merge`