### PR TITLE
Added Watchdog, Implemented F/T Sensor Monitoring

### DIFF
--- a/ada_feeding/CMakeLists.txt
+++ b/ada_feeding/CMakeLists.txt
@@ -30,6 +30,7 @@ ament_python_install_package(${PROJECT_NAME})
 # Install Python executables
 install(PROGRAMS
   scripts/create_action_servers.py
+  scripts/ada_watchdog.py
   scripts/dummy_ft_sensor.py
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/ada_feeding/CMakeLists.txt
+++ b/ada_feeding/CMakeLists.txt
@@ -30,6 +30,7 @@ ament_python_install_package(${PROJECT_NAME})
 # Install Python executables
 install(PROGRAMS
   scripts/create_action_servers.py
+  scripts/dummy_ft_sensor.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -34,6 +34,12 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
             - Terminating the node.
             - Disconnecting the physical force-torque sensor from power.
             - Inducing corruption by causing the dummy note to output zero-variance values: `ros2 param set /dummy_ft_sensor std  [0.1, 0.1, 0.0, 0.1, 0.1, 0.1]`
+    4. Test the watchdog with the action servers:
+        1. Launch the force-torque sensor (see above).
+        2. Start an action, induce errors in the force-torque sensor (see above), and ensure the action gets aborted.
+        3. While there are errors in the force-torque sensor, ensure no new goals get accepted.
+        4. Terminate the watchdog node and ensure in-progress actions get aborted and incoming goals get rejected.
+        5. Launch the action servers without the watchdog node running and ensure it rejects all goals.
 
 ## Writing Behavior Trees That Can Be Wrapped Into Action Servers
 

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -23,8 +23,17 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
     2. With the web app:
         1. Launch the perception nodes:
             1. Dummy nodes: `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml run_motion:=false`
-            2. Real nodes: **NOT YET IMPLEMENTED**
+            2. Real nodes: Follow the instructions in the [`ada_feeding_perception` README](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/ada_feeding_perception/README.md#usage)
         2. Launch the web app ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp))
+    3. Test the watchdog in isolation:
+        1. Launch the force-torque sensor:
+            1. Dummy node: `ros2 run ada_feeding dummy_ft_sensor.py`
+            2. Real node: Follow the instructions in the [`forque_sensor_hardware` README](https://github.com/personalrobotics/forque_sensor_hardware/blob/main/README.md). Note that this is in the _main_ branch, which may not be the default branch.
+        2. Echo the watchdog topic: `ros2 topic echo /ada_watchdog`
+        3. Induce errors in the force-torque sensor and verify the watchdog reacts appropiately. Errors could include:
+            - Terminating the node.
+            - Disconnecting the physical force-torque sensor from power.
+            - Inducing corruption by causing the dummy note to output zero-variance values: `ros2 param set /dummy_ft_sensor std  [0.1, 0.1, 0.0, 0.1, 0.1, 0.1]`
 
 ## Writing Behavior Trees That Can Be Wrapped Into Action Servers
 

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -1,6 +1,10 @@
 # NOTE: You have to change this node name if you change the node name in the launchfile.
 ada_feeding_action_servers:
   ros__parameters:
+    # Parameters to specify the watchdog topic and timeout
+    watchdog_topic: /ada_watchdog
+    watchdog_timeout_sec: 0.5 # If we haven't received a message from the watchdog in this time, stop all robot motions
+
     # A list of the names of the action servers to create. Each one must have
     # it's own parameters (below) specifying action_type and tree_class.
     server_names:

--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -1,0 +1,13 @@
+# NOTE: You have to change this node name if you change the node name in the launchfile.
+ada_watchdog:
+  ros__parameters:
+    # The topic to subscribe to for force-torque messages, of type geometry_msgs/WrenchStamped
+    ft_topic: /wireless_ft/ftSensor1
+    # If the force_torque sensor has not published a message in this amount of time,
+    # or any of its dimensions are zero-variance in this amount of time, the watchdog 
+    # will trigger a fault.
+    ft_timeout_sec: 0.5
+    # The topic to publish to for the watchdog, of type diagnostic_msgs/DiagnosticStatus
+    watchdog_topc: /ada_watchdog
+    # The rate at which to publish the watchdog message
+    publish_rate_hz: 60.0

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -1,5 +1,13 @@
 <launch>
+
+  <!-- Launch the watchdog -->
+  <node pkg="ada_feeding" exec="ada_watchdog.py" name="ada_watchdog">
+    <param from="$(find-pkg-share ada_feeding)/config/ada_watchdog.yaml"/>
+  </node>
+
+  <!-- Launch the action servers necessary to move the robot -->
   <node pkg="ada_feeding" exec="create_action_servers.py" name="ada_feeding_action_servers">
     <param from="$(find-pkg-share ada_feeding)/config/ada_feeding_action_servers.yaml"/>
   </node>
+
 </launch>

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+This module contains a node, ADAWatchdog, which does the following:
+    1. Monitors the state of the force-torque sensor, to ensure it is still
+       publishing and its data is not zero-variance.
+    2. (TODO) Monitors the state of the physical e-stop button, to ensure it is
+       not pressed.
+This node publishes an output to the /ada_watchdog topic. Any node that moves
+the robot should subscribe to this topic and immediately stop if any of the
+watchdog conditions fail, or if the watchdog stops publishing.
+"""
+
+# Standard imports
+from threading import Lock
+
+# Third-party imports
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
+from geometry_msgs.msg import WrenchStamped
+import numpy as np
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+import rclpy
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.time import Time
+
+# Local imports
+
+
+class FTSensorCondition:
+    """
+    The FTSensorCondition class accumulates all force-torque sensor readings and
+    checks that the sensor is still publishing and its data is not zero-variance.
+    """
+
+    def __init__(self, timeout: Duration) -> None:
+        """
+        Initialize the force-torque sensor condition.
+
+        Parameters
+        ----------
+        timeout: the maximum time (s) that the force-torque sensor can go without
+            publishing or changing its data before the condition fails
+        """
+        # Configure parameters
+        self.timeout = timeout
+
+        # For each dimension of a single force-torque datapoint, store the most
+        # recent unique value and the time at which that value was received.
+        self.last_unique_values = None
+        self.last_unique_values_timestamp = None
+
+    def update(self, ft_msg: WrenchStamped) -> None:
+        """
+        Update the accumulators with the latest force-torque sensor reading.
+
+        Parameters
+        ----------
+        ft_msg: the message from the force-torque sensor
+        """
+        # Get the data from the message
+        ft_array = np.array(
+            [
+                ft_msg.wrench.force.x,
+                ft_msg.wrench.force.y,
+                ft_msg.wrench.force.z,
+                ft_msg.wrench.torque.x,
+                ft_msg.wrench.torque.y,
+                ft_msg.wrench.torque.z,
+            ]
+        )
+        ft_time = Time.from_msg(ft_msg.header.stamp)
+
+        # Update the last unique values
+        if self.last_unique_values is None:
+            self.last_unique_values = ft_array
+            self.last_unique_values_timestamp = np.repeat(ft_time, 6)
+        else:
+            # Update the last unique values
+            dimensions_that_havent_changed = np.isclose(
+                self.last_unique_values, ft_array
+            )
+            self.last_unique_values = np.where(
+                dimensions_that_havent_changed,
+                self.last_unique_values,
+                ft_array,
+            )
+            self.last_unique_values_timestamp = np.where(
+                dimensions_that_havent_changed,
+                self.last_unique_values_timestamp,
+                ft_time,
+            )
+
+    def check(self, now: Time) -> bool:
+        """
+        Check if the force-torque sensor is still publishing and its data is not
+        zero-variance.
+
+        Specifically, it returns True if over that last `self.timeout` seconds,
+        every dimension of the force-torque sensor data has changed. Inversely,
+        it returns False if either the force-torque sensor has not published
+        data within the last `timeout` seconds, or at least one dimension
+        of that data has not changed.
+
+        Parameters
+        ----------
+        now: the current time
+
+        Returns
+        -------
+        True if the force-torque sensor is still publishing and its data is not
+        zero-variance, False otherwise.
+        """
+        return np.all((now - self.last_unique_values_timestamp) <= self.timeout)
+
+
+class ADAWatchdog(Node):
+    """
+    A watchdog node for the ADA robot. This node monitors the state of the
+    force-torque sensor and the physical e-stop button (TODO), and publishes its
+    output to the /ada_watchdog topic.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the watchdog node.
+        """
+        super().__init__("ada_watchdog")
+
+        # Load parameters
+        self.load_parameters()
+
+        # Create a watchdog publisher
+        self.watchdog_publisher = self.create_publisher(
+            DiagnosticArray,
+            self.watchdog_topic.value,
+            1,
+        )
+
+        # Parameters for the force-torque conditions
+        self.ft_sensor_condition = FTSensorCondition(
+            Duration(seconds=self.ft_timeout_sec.value)
+        )
+        self.recv_first_ft_msg = False
+        self.ft_sensor_condition_lock = Lock()
+        ft_sensor_ok_message = (
+            "Over the last %f sec, the force-torque sensor has published data with nonzero variance"
+            % self.ft_timeout_sec.value
+        )
+        self.ft_ok_status = DiagnosticStatus(
+            level=DiagnosticStatus.OK,
+            name=self.ft_topic.value,
+            message=ft_sensor_ok_message,
+        )
+        ft_sensor_error_message = (
+            "Over the last %f sec, the force-torque sensor has either not published data or its data is zero-variance"
+            % self.ft_timeout_sec.value
+        )
+        self.ft_error_status = DiagnosticStatus(
+            level=DiagnosticStatus.ERROR,
+            name=self.ft_topic.value,
+            message=ft_sensor_error_message,
+        )
+
+        # Create the watchdog output
+        self.watchdog_output = DiagnosticArray()
+
+        # Subscribe to the force-torque sensor topic
+        self.ft_sensor_subscription = self.create_subscription(
+            WrenchStamped,
+            self.ft_topic.value,
+            self.ft_sensor_callback,
+            1,
+        )
+
+        # Publish at the specified rate
+        timer_period = 1.0 / self.publish_rate_hz.value  # seconds
+        self.timer = self.create_timer(
+            timer_period, self.check_and_publish_watchdog_output
+        )
+
+    def load_parameters(self) -> None:
+        """
+        Load parameters from the parameter server.
+        """
+        self.ft_topic = self.declare_parameter(
+            "ft_topic",
+            "/wireless_ft/ftSensor1",
+            ParameterDescriptor(
+                name="ft_topic",
+                type=ParameterType.PARAMETER_STRING,
+                description="The name of topic that the force-torque sensor is publishing on",
+                read_only=True,
+            ),
+        )
+        self.ft_timeout_sec = self.declare_parameter(
+            "ft_timeout_sec",
+            0.5,
+            ParameterDescriptor(
+                name="ft_timeout_sec",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description="The number of seconds within which the force-torque sensor must have: (a) published messages; and (b) had them be nonzero-variance",
+                read_only=True,
+            ),
+        )
+        self.watchdog_topic = self.declare_parameter(
+            "watchdog_topic",
+            "/ada_watchdog",
+            ParameterDescriptor(
+                name="watchdog_topic",
+                type=ParameterType.PARAMETER_STRING,
+                description="The name of the topic for the watchdog to publish on",
+                read_only=True,
+            ),
+        )
+        self.publish_rate_hz = self.declare_parameter(
+            "publish_rate_hz",
+            30.0,
+            ParameterDescriptor(
+                name="publish_rate_hz",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description="The target rate (Hz) for the watchdog to publish its output",
+                read_only=True,
+            ),
+        )
+
+    def ft_sensor_callback(self, ft_msg: WrenchStamped) -> None:
+        """
+        Callback function for the force-torque sensor topic. This function
+        stores the latest force-torque sensor reading, to be checked in
+        check_watchdog_conditions().
+
+        Parameters
+        ----------
+        ft_msg: the message from the force-torque sensor
+        """
+        with self.ft_sensor_condition_lock:
+            self.ft_sensor_condition.update(ft_msg)
+            self.recv_first_ft_msg = True
+
+    def check_and_publish_watchdog_output(self) -> None:
+        """
+        Checks the watchdog conditions and publishes its output.
+        """
+        # Only publish if we've received the first force-torque sensor message
+        recv_first_ft_msg = False
+        with self.ft_sensor_condition_lock:
+            recv_first_ft_msg = self.recv_first_ft_msg
+        if recv_first_ft_msg:
+            # Check the force-torque sensor conditions
+            now = self.get_clock().now()
+            ft_condition = self.ft_sensor_condition.check(now)
+
+            # Generate the watchdog output
+            self.watchdog_output.header.stamp = now.to_msg()
+            self.watchdog_output.status = []
+            if ft_condition:
+                self.watchdog_output.status.append(self.ft_ok_status)
+            else:
+                self.watchdog_output.status.append(self.ft_error_status)
+
+            # Publish the watchdog output
+            self.watchdog_publisher.publish(self.watchdog_output)
+
+
+def main(args=None):
+    """
+    Launch the ROS node and spin.
+    """
+    rclpy.init(args=args)
+
+    ada_watchdog = ADAWatchdog()
+    rclpy.spin(ada_watchdog)
+
+
+if __name__ == "__main__":
+    main()

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -169,7 +169,7 @@ class ADAWatchdog(Node):
             WrenchStamped,
             self.ft_topic.value,
             self.ft_sensor_callback,
-            1,
+            rclpy.qos.QoSPresetProfiles.SENSOR_DATA.value,
         )
 
         # Publish at the specified rate

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -245,21 +245,27 @@ class ADAWatchdog(Node):
         recv_first_ft_msg = False
         with self.ft_sensor_condition_lock:
             recv_first_ft_msg = self.recv_first_ft_msg
+
+        # Configure the output message
+        now = self.get_clock().now()
+        self.watchdog_output.header.stamp = now.to_msg()
+        self.watchdog_output.status = []
+
+        # Return the output
         if recv_first_ft_msg:
             # Check the force-torque sensor conditions
-            now = self.get_clock().now()
             ft_condition = self.ft_sensor_condition.check(now)
 
             # Generate the watchdog output
-            self.watchdog_output.header.stamp = now.to_msg()
-            self.watchdog_output.status = []
             if ft_condition:
                 self.watchdog_output.status.append(self.ft_ok_status)
             else:
                 self.watchdog_output.status.append(self.ft_error_status)
+        else:
+            self.watchdog_output.status.append(self.ft_error_status)
 
-            # Publish the watchdog output
-            self.watchdog_publisher.publish(self.watchdog_output)
+        # Publish the watchdog output
+        self.watchdog_publisher.publish(self.watchdog_output)
 
 
 def main(args=None):

--- a/ada_feeding/scripts/dummy_ft_sensor.py
+++ b/ada_feeding/scripts/dummy_ft_sensor.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+This module contains a node, DummyForceTorqueSensor, which publishes sample data
+to mimic the force-torque sensor on the robot. By setting parameters, users can
+toggle the sensor on and off (i.e., to mimic communication with the sensor
+dying) and/or start publishing zero-variance values (i.e., to mimic the sensor
+getting corrupted). The node is intended to be used to test the ADAWatchdog
+node.
+
+Usage:
+- Run the node: `ros2 run ada_feeding dummy_ft_sensor`
+- Subscribe to the sensor data: `ros2 topic echo /wireless_ft/ftSensor1`
+- Turn the sensor off: `ros2 param set /dummy_ft_sensor is_on False`
+- Start publishing zero-variance data: `ros2 param set /dummy_ft_sensor std [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]`
+- Start publishing data where one dimension is zero-variance: `ros2 param set /dummy_ft_sensor std [0.0, 0.1, 0.1, 0.1, 0.1, 0.1]`
+"""
+
+# Third-party imports
+from geometry_msgs.msg import WrenchStamped
+import numpy as np
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+
+
+class DummyForceTorqueSensor(Node):
+    """
+    The DummyForceTorqueSensor class publishes sample data to mimic the
+    force-torque sensor on the robot. By setting parameters, users can toggle
+    the sensor on and off (i.e., to mimic communication with the sensor dying)
+    and/or start publishing zero-variance values (i.e., to mimic the sensor
+    getting corrupted). The node is intended to be used to test the ADAWatchdog
+    node.
+    """
+
+    def __init__(self, rate_hz: float = 30.0) -> None:
+        """
+        Initialize the dummy force-torque sensor node.
+
+        Parameters
+        ----------
+        mean: the mean of the force-torque sensor data
+        std: the standard deviation of the force-torque sensor data
+        rate_hz: the rate (Hz) at which to publish the force-torque sensor data
+        """
+        super().__init__("dummy_ft_sensor")
+
+        # get the mean and standard deviaion of the distribution
+        self.mean = self.declare_parameter(
+            "mean",
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ParameterDescriptor(
+                name="mean",
+                type=ParameterType.PARAMETER_DOUBLE_ARRAY,
+                description="The mean of the force-torque sensor data",
+            ),
+        )
+        self.std = self.declare_parameter(
+            "std",
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            ParameterDescriptor(
+                name="std",
+                type=ParameterType.PARAMETER_DOUBLE_ARRAY,
+                description="The standard deviation of the force-torque sensor data",
+            ),
+        )
+
+        # Create a parameter to toggle the sensor on and off
+        self.is_on = self.declare_parameter(
+            "is_on",
+            True,
+            ParameterDescriptor(
+                name="is_on",
+                type=ParameterType.PARAMETER_BOOL,
+                description="Whether or not the simulated force-torque sensor is on",
+            ),
+        )
+
+        # Create the publisher
+        self.ft_msg = WrenchStamped()
+        self.publisher_ = self.create_publisher(
+            WrenchStamped, "/wireless_ft/ftSensor1", 1
+        )
+
+        # Publish at the specified rate
+        timer_period = 1.0 / rate_hz  # seconds
+        self.timer = self.create_timer(timer_period, self.publish_msg)
+
+    def publish_msg(self) -> None:
+        """
+        Publish a message to the force-torque sensor topic.
+        """
+        # Only publish if the sensor is on
+        if self.get_parameter("is_on").value:
+            # Get the simulated data
+            ft_data = np.random.normal(
+                self.get_parameter("mean").value, self.get_parameter("std").value
+            )
+
+            # Generate the force-torque sensor message
+            self.ft_msg.header.stamp = self.get_clock().now().to_msg()
+            self.ft_msg.wrench.force.x = ft_data[0]
+            self.ft_msg.wrench.force.y = ft_data[1]
+            self.ft_msg.wrench.force.z = ft_data[2]
+            self.ft_msg.wrench.torque.x = ft_data[3]
+            self.ft_msg.wrench.torque.y = ft_data[4]
+            self.ft_msg.wrench.torque.z = ft_data[5]
+
+            # Publish the message
+            self.publisher_.publish(self.ft_msg)
+
+
+def main(args=None):
+    """
+    Launch the ROS node and spin.
+    """
+    rclpy.init(args=args)
+
+    dummy_ft_sensor = DummyForceTorqueSensor()
+    executor = MultiThreadedExecutor()
+    rclpy.spin(dummy_ft_sensor, executor=executor)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Added a watchdog node. This node checks the safety-critical conditions that must be met for the robot to proceed, and publishes a [`DiagnosticArray`](http://docs.ros.org/en/noetic/api/diagnostic_msgs/html/msg/DiagnosticArray.html) message with the results. `create_action_server.py` subscribes to the watchdog topic. If the watchdog ever publishes an error status or does not publish a message for 0.5 secs (configureable by parameter), it aborts any currently executing actions and rejects any future goals, until the watchdog publishes a non-error status.

This PR implements the F/T monitoring aspect of the watchdog. Specifically, it is implemented as follows:
- If, over the course of 0.5 secs (configurable by parameter), **any** of the dimensions of the F/T sensor message do not change, the watchdog fails.
- Inversely, for the watchdog to succeed, the F/T sensor must have published at least one message in the last 0.5 sec and **all** dimensions of that message must differ from the previous message.

The above implementation is based on the empirical finding that if the F/T sensor is corrupted (e.g., wire is broken) it publishes zero-variance data. (This was tru of the Net F/T wired sensor.)

# Testing procedure

## Testing Watchdog in Isolation

### Simulated Force-Torque Data
1. Run the dummy force-torque sensor: `ros2 run ada_feeding dummy_ft_sensor.py`
2. Run the watchdog: `ros2 run ada_feeding ada_watchdog.py`
3. Echo the watchdog output: `ros2 topic echo /ada_watchdog`
4. Verify the following:
    - [x] The watchdog is returning success (status level `\0`).
    - [x] Set a dimension of the force-torque output to zero-variance: `ros2 param set /dummy_ft_sensor std  [0.1, 0.1, 0.0, 0.1, 0.1, 0.1]`. The watchdog should return error (status level `\x02`).
    - [x] Set the force-torque output back nonzero-variance: `ros2 param set /dummy_ft_sensor std  [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]`. The watchdog should return success (status level `\0`).
    - [x] Terminate the force-torque sensor node. The watchdog should return error (status level `\x02`).

### Real Force-Torque Data
1. Launch the force-torque sensor: `ros2 run forque_sensor_hardware forque_sensor_hardware —ros-args -p host:=xxx.xxx.x.xx` (insert the IP address for the force-torque sensor)
    - Note that forque_sensor_hardware must be on the `main` branch, which is _not the default branch_!
2. Run the watchdog: `ros2 run ada_feeding ada_watchdog.py`
3. Echo the watchdog output: `ros2 topic echo /ada_watchdog`
4. Verify the following:
    - [x] The watchdog is returning success (status level `\0`).
    - [x] Terminate the force-torque sensor node. The watchdog should return error (status level `\x02`).

## Testing Watchdog with the Robot Motion Action Servers (`create_action_servers.py`)
1. Launch either the simulated or real force-torque sensor (see above).
2. Launch the ada_feeding nodes: `ros2 launch ada_feeding ada_feeding_launch.xml`
3. Verify the following:
    - Induce an error in the F/T sensor, and then send a goal request (e.g., `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`) and verify that it is rejected.
        - [x] Simulation
        - [x] Real
    - Ensure proper F/T sensor functioning. Send a goal request. While it is running, induce an error in the F/T sensor. Verify that the goal request gets aborted.
        - [x] Simulation
        - [x] Real
    - Restore proper F/T sensor function. Send a goal request. Verify that it succeeds.
        - [x] Simulation
        - [x] Real




# Before opening a pull request
- [X] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [X] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address (most) warnings/errors: `pylint --recursive=y .`

# Before Merging
- [x] `Squash & Merge`
