### PR TITLE
Implemented MoveToPose

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/__init__.py
@@ -3,4 +3,5 @@ This package contains custom py_tree behaviors for the Ada Feeding project.
 """
 from .move_to import MoveTo
 from .move_to_configuration import MoveToConfiguration
+from .move_to_pose import MoveToPose
 from .move_to_dummy import MoveToDummy

--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -397,7 +397,7 @@ class DistanceToGoal:
                 [
                     DistanceToGoal.joint_position_dist(
                         self.curr_joint_state.position[joint_state_i],
-                        traj_joint_state.positions[joint_traj_i]
+                        traj_joint_state.positions[joint_traj_i],
                     )
                     for (_, joint_state_i, joint_traj_i) in self.aligned_joint_indices
                 ]

--- a/ada_feeding/ada_feeding/behaviors/move_to_pose.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to_pose.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the MoveToPose behavior tree, which moves the Jaco
+arm to a specified end effector pose.
+"""
+# Standard imports
+from asyncio import Future
+
+# Third-party imports
+import py_trees
+
+# Local imports
+from ada_feeding.behaviors import MoveTo
+
+
+class MoveToPose(MoveTo):
+    """
+    A generic behavior for moving the Jaco arm a specified end effector pose.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        A generic behavior for moving the Jaco arm a specified joint configuration.
+        """
+        # Initiatilize the behavior
+        super().__init__(*args, **kwargs)
+
+        # Get inputs specific to MoveToPose from the Blackboard
+        self.blackboard.register_key(key="position", access=py_trees.common.Access.READ)
+        self.blackboard.register_key(
+            key="quat_xyzw", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="target_link", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(key="frame_id", access=py_trees.common.Access.READ)
+        self.blackboard.register_key(
+            key="tolerance_position", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="tolerance_orientation", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="weight_position", access=py_trees.common.Access.READ
+        )
+        self.blackboard.register_key(
+            key="weight_orientation", access=py_trees.common.Access.READ
+        )
+
+    def plan_async(self) -> Future:
+        """
+        Get the MoveToPose parameters from the blackboard and send an
+        asynchronous planning request to MoveIt.
+        """
+        # Get all parameters for planning, resorting to default values if unset.
+        position = self.blackboard.position  # required
+        quat_xyzw = self.blackboard.quat_xyzw  # required
+        try:
+            target_link = self.blackboard.target_link
+        except KeyError:
+            target_link = None  # default value
+        try:
+            frame_id = self.blackboard.frame_id
+        except KeyError:
+            frame_id = None  # default value
+        try:
+            tolerance_position = self.blackboard.tolerance_position
+        except KeyError:
+            tolerance_position = 0.001  # default value
+        try:
+            tolerance_orientation = self.blackboard.tolerance_orientation
+        except KeyError:
+            tolerance_orientation = 0.001  # default value
+        try:
+            weight_position = self.blackboard.weight_position
+        except KeyError:
+            weight_position = 1.0  # default value
+        try:
+            weight_orientation = self.blackboard.weight_orientation
+        except KeyError:
+            weight_orientation = 1.0  # default value
+
+        # Send a new goal to MoveIt
+        return self.moveit2.plan_async(
+            position=position,
+            quat_xyzw=quat_xyzw,
+            frame_id=frame_id,
+            tolerance_position=tolerance_position,
+            tolerance_orientation=tolerance_orientation,
+            weight_position=weight_position,
+            weight_orientation=weight_orientation,
+            cartesian=self.cartesian,
+        )

--- a/ada_feeding/ada_feeding/trees/__init__.py
+++ b/ada_feeding/ada_feeding/trees/__init__.py
@@ -5,4 +5,5 @@ to be wrapped in a ROS action server.
 """
 from .move_to_tree import MoveToTree
 from .move_to_configuration_tree import MoveToConfigurationTree
+from .move_to_pose_tree import MoveToPoseTree
 from .move_to_dummy_tree import MoveToDummyTree

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the MoveToPoseTree behavior tree and provides functions to
+wrap that behavior tree in a ROS2 action server.
+"""
+
+# Standard imports
+import logging
+from typing import Tuple
+
+# Third-party imports
+import py_trees
+from rclpy.node import Node
+
+# Local imports
+from ada_feeding.behaviors import MoveToPose
+from ada_feeding.trees import MoveToTree
+
+
+class MoveToPoseTree(MoveToTree):
+    """
+    A behavior tree that consists of a single behavior, MoveToPose.
+    """
+
+    def __init__(
+        self,
+        action_type_class: str,
+        position: Tuple[float, float, float],
+        quat_xyzw: Tuple[float, float, float, float],
+    ) -> None:
+        """
+        Initializes tree-specific parameters.
+
+        Parameters
+        ----------
+        action_type_class: The type of action that this tree is implementing,
+            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
+            type can be anything, but the Feedback and Result must at a minimum
+            include the fields of ada_feeding_msgs.action.MoveTo
+        position: the target end effector position relative to the base link.
+        quat_xyzw: the target end effector orientation relative to the base link.
+        """
+        # Initialize MoveTo
+        super().__init__(action_type_class)
+
+        # Store the parameters for the move to pose behavior
+        self.position = position
+        self.quat_xyzw = quat_xyzw
+
+    def create_move_to_tree(
+        self,
+        name: str,
+        logger: logging.Logger,
+        node: Node,
+    ) -> py_trees.trees.BehaviourTree:
+        """
+        Creates the MoveToPose behavior tree.
+
+        Parameters
+        ----------
+        name: The name of the behavior tree.
+        logger: The logger to use for the behavior tree.
+        node: The ROS2 node that this tree is associated with. Necessary for
+            behaviors within the tree connect to ROS topics/services/actions.
+
+        Returns
+        -------
+        tree: The behavior tree that moves the robot above the plate.
+        """
+        # Inputs for MoveToPose
+        self.blackboard.register_key(
+            key="position", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="quat_xyzw", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="target_link", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="frame_id", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="tolerance_position", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="tolerance_orientation", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="weight_position", access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key="weight_orientation", access=py_trees.common.Access.WRITE
+        )
+
+        # Write the inputs to MoveToPose to blackboard
+        self.blackboard.position = self.position
+        self.blackboard.quat_xyzw = self.quat_xyzw
+
+        # Create the tree
+        root = MoveToPose(name, node)
+        root.logger = logger
+        tree = py_trees.trees.BehaviourTree(root)
+
+        return tree

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -65,17 +65,27 @@ ada_feeding_action_servers:
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the MoveToMouth action
+    # TODO: This is a dummy MoveToMouth implementation used to test MoveToPose.
+    # It will be replaced with the actual MoveToMouth action once that is
+    # implemented.
     MoveToMouth: # required
       action_type: ada_feeding_msgs.action.MoveTo # required
-      tree_class: ada_feeding.trees.MoveToDummyTree # required
+      tree_class: ada_feeding.trees.MoveToPoseTree # required
       tree_kws: # optional
         - action_type_class
-        - dummy_plan_time
-        - dummy_motion_time
+        - position
+        - quat_xyzw
       tree_kwargs: # optional
         action_type_class: ada_feeding_msgs.action.MoveTo # required
-        dummy_plan_time: 1.0 # secs
-        dummy_motion_time: 10.0 # secs
+        position:
+          -  0.27971 # x
+          -  0.07175 # y
+          -  0.77314 # z
+        quat_xyzw:
+          -  0.00175 # x
+          -  0.70159 # y
+          -  0.71255 # z
+          - -0.00636 # w
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the MoveToStowLocation action


### PR DESCRIPTION
# Description

Implemented the `MoveToPose` behavior, and a `MoveToPoseTree` that consists solely of that behavior. Note that in our final application we don't anticipate having any actions that are solely one `MoveToPose` call; the `MoveToPoseTree` is solely for testing purposes.

# Testing procedure

To test this, I implemented a dummy `MoveToMouth` action that consists solely of a `MoveToPose` call (it should move the end effector to what we used to call the "staging location").

1. **Initialization**: Follow the initialization steps from #33.
2. **Command Line Interface**: For each of the following commands, run it and verify that it executes as expected. Then, run it and terminate it, and verify that the robot immediately stops moving.
    1. `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveTo "{}" --feedback`
        - [x] Successfully ran to completion
        - [x] Terminated successfully
3. **Web Interface**: For MoveToMouth, run it and verify that it executes as expected. Then, run it again, click pause, and verify that the robot stops immediately when the pause button is clicked. Finally, click "resume" and verify that the robot resumes its motion and completes it.
    1. **MoveToMouth**: You can reach this action by clicking "Skip Acquisition" on the BiteSelection page.
        - [x] Successfully ran to completion
        - [x] Successfully stopped when pause was clicked
        - [x] Successfully resumed when Resume was clicked

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address (most) warnings/errors: `pylint --recursive=y .`

# Before Merging
- [ ] `Squash & Merge`
