### PR TITLE
Implement MVP MoveToMouth

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,13 +25,15 @@ clear-cache-post-run=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-allow-list=cv2
+extension-pkg-allow-list=cv2,
+                         tf2_py
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code. (This is an alternative name to extension-pkg-allow-list
 # for backward compatibility.)
-extension-pkg-whitelist=cv2
+extension-pkg-whitelist=cv2,
+                        tf2_py
 
 # Return non-zero exit code if any of these messages/categories are detected,
 # even if score is above --fail-under value. Syntax same as enable. Messages

--- a/ada_feeding/CMakeLists.txt
+++ b/ada_feeding/CMakeLists.txt
@@ -12,7 +12,6 @@ find_package(rcl_interfaces REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(pymoveit2 REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(py_trees_ros REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)

--- a/ada_feeding/CMakeLists.txt
+++ b/ada_feeding/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(ament_cmake_python REQUIRED)
 find_package(rcl_interfaces REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(pymoveit2 REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(py_trees_ros REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -19,8 +19,8 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
     1. Dummy node: `ros2 run ada_feeding dummy_ft_sensor.py`
     2. Real node: Follow the instructions in the [`forque_sensor_hardware` README](https://github.com/personalrobotics/forque_sensor_hardware/blob/main/README.md). Note that this is in the _main_ branch, which may not be the default branch.
 4. Launch MoveIt2:
-    1. Sim (RVIZ): `ros2 launch ada_moveit demo.launch.py sim:=mock`
-    2. Real Robot: `ros2 launch ada_moveit demo.launch.py`
+    1. Sim (RVIZ): `ros2 launch ada_moveit demo_feeding.launch.py sim:=mock`
+    2. Real Robot: `ros2 launch ada_moveit demo_feeding.launch.py`
 5. Launch the RealSense & Perception:
     1. Dummy nodes: `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml run_motion:=false run_web_bridge:=false`
     2. Real nodes: Follow the instructions in the [`ada_feeding_perception` README](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/ada_feeding_perception/README.md#usage)

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -18,11 +18,14 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
 3. Launch the force-torque sensor:
     1. Dummy node: `ros2 run ada_feeding dummy_ft_sensor.py`
     2. Real node: Follow the instructions in the [`forque_sensor_hardware` README](https://github.com/personalrobotics/forque_sensor_hardware/blob/main/README.md). Note that this is in the _main_ branch, which may not be the default branch.
-4. Run the action servers: `ros2 launch ada_feeding ada_feeding_launch.xml`
-5. Launch MoveIt2:
-    1. RVIZ: `ros2 launch ada_moveit demo_feeding.launch.py sim:=mock`
-    2. Real Robot: `ros2 launch ada_moveit demo_feeding.launch.py`
-6. Test it:
+4. Launch MoveIt2:
+    1. Sim (RVIZ): `ros2 launch ada_moveit demo.launch.py sim:=mock`
+    2. Real Robot: `ros2 launch ada_moveit demo.launch.py`
+5. Launch the RealSense & Perception:
+    1. Dummy nodes: `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml run_motion:=false run_web_bridge:=false`
+    2. Real nodes: Follow the instructions in the [`ada_feeding_perception` README](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/ada_feeding_perception/README.md#usage)
+6. Run the action servers: `ros2 launch ada_feeding ada_feeding_launch.xml`
+7. Test it:
     1. Test the individual actions with the command line interface:
         1. `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
         2. `ros2 action send_goal /AcquireFood ada_feeding_msgs/action/AcquireFood "{header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, detected_food: {roi: {x_offset: 0, y_offset: 0, height: 0, width: 0, do_rectify: false}, mask: {header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, format: '', data: []}, item_id: '', confidence: 0.0}}" --feedback`
@@ -30,10 +33,8 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
         4. `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveTo "{}" --feedback`
         5. `ros2 action send_goal /MoveToStowLocation ada_feeding_msgs/action/MoveTo "{}" --feedback`
     2. Test the individual actions with the web app:
-        1. Launch the perception nodes:
-            1. Dummy nodes: `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml run_motion:=false`
-            2. Real nodes: Follow the instructions in the [`ada_feeding_perception` README](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/ada_feeding_perception/README.md#usage)
-        2. Launch the web app ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp))
+        1. Launch the web app ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp))
+        2. Go through the web app, ensure the expected actions happen on the robot.
     3. Test the watchdog in isolation:
         1. Echo the watchdog topic: `ros2 topic echo /ada_watchdog`
         2. Induce errors in the force-torque sensor and verify the watchdog reacts appropiately. Errors could include:

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -8,6 +8,8 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
 - Install [ROS2 Humble](https://docs.ros.org/en/humble/Installation.html)
 - Install Python dependencies: `python3 -m pip install pyyaml py_trees pymongo tornado trimesh`
 - Install the code to command the real robot ([instructions here](https://github.com/personalrobotics/ada_ros2/blob/main/README.md))
+- Git clone the [PRL fork of pymoveit (branch: `amaln/fix_last_error_code`)](https://github.com/personalrobotics/pymoveit2) and the [PRL fork of py_trees_ros (branch: `amaln/service_client`)](https://github.com/personalrobotics/py_trees_ros/tree/amaln/service_client) into your ROS2 workspace's `src` folder.
+- Install additional dependencies: `sudo apt install ros-humble-py-trees-ros-interfaces`.
 - Install the web app into your workspace ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp)).
 
 ## Usage

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -8,7 +8,7 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
 - Install [ROS2 Humble](https://docs.ros.org/en/humble/Installation.html)
 - Install Python dependencies: `python3 -m pip install pyyaml py_trees pymongo tornado trimesh`
 - Install the code to command the real robot ([instructions here](https://github.com/personalrobotics/ada_ros2/blob/main/README.md))
-- Git clone the [PRL fork of pymoveit (branch: `amaln/fix_last_error_code`)](https://github.com/personalrobotics/pymoveit2) and the [PRL fork of py_trees_ros (branch: `amaln/service_client`)](https://github.com/personalrobotics/py_trees_ros/tree/amaln/service_client) into your ROS2 workspace's `src` folder.
+- Git clone the [PRL fork of pymoveit (branch: `amaln/allowed_collision_matrix`)](https://github.com/personalrobotics/pymoveit2) and the [PRL fork of py_trees_ros (branch: `amaln/service_client`)](https://github.com/personalrobotics/py_trees_ros/tree/amaln/service_client) into your ROS2 workspace's `src` folder.
 - Install additional dependencies: `sudo apt install ros-humble-py-trees-ros-interfaces`.
 - Install the web app into your workspace ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp)).
 

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -18,13 +18,13 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
 3. Launch the force-torque sensor:
     1. Dummy node: `ros2 run ada_feeding dummy_ft_sensor.py`
     2. Real node: Follow the instructions in the [`forque_sensor_hardware` README](https://github.com/personalrobotics/forque_sensor_hardware/blob/main/README.md). Note that this is in the _main_ branch, which may not be the default branch.
-4. Launch MoveIt2:
-    1. Sim (RVIZ): `ros2 launch ada_moveit demo_feeding.launch.py sim:=mock`
-    2. Real Robot: `ros2 launch ada_moveit demo_feeding.launch.py`
-5. Launch the RealSense & Perception:
+4. Launch the RealSense & Perception:
     1. Dummy nodes: `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml run_motion:=false run_web_bridge:=false`
     2. Real nodes: Follow the instructions in the [`ada_feeding_perception` README](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/ada_feeding_perception/README.md#usage)
-6. Run the action servers: `ros2 launch ada_feeding ada_feeding_launch.xml`
+5. Run the action servers: `ros2 launch ada_feeding ada_feeding_launch.xml`
+6. Launch MoveIt2:
+    1. Sim (RVIZ): `ros2 launch ada_moveit demo_feeding.launch.py sim:=mock`
+    2. Real Robot: `ros2 launch ada_moveit demo_feeding.launch.py`
 7. Test it:
     1. Test the individual actions with the command line interface:
         1. `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`

--- a/ada_feeding/ada_feeding/action_server_bt.py
+++ b/ada_feeding/ada_feeding/action_server_bt.py
@@ -25,6 +25,7 @@ class ActionServerBT(ABC):
         self,
         name: str,
         action_type: type,
+        tree_root_name: str,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -37,6 +38,9 @@ class ActionServerBT(ABC):
         ----------
         name: The name of the behavior tree.
         action_type: the type for the action, as a class
+        tree_root_name: The name of the tree. This is necessary because sometimes
+            trees create subtrees, but still need to track the top-level tree
+            name to read/write the correct blackboard variables.
         logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.

--- a/ada_feeding/ada_feeding/action_server_bt.py
+++ b/ada_feeding/ada_feeding/action_server_bt.py
@@ -20,6 +20,9 @@ class ActionServerBT(ABC):
     `create_action_server.py`
     """
 
+    # pylint: disable=too-many-arguments
+    # One over is fine.
+
     @abstractmethod
     def create_tree(
         self,

--- a/ada_feeding/ada_feeding/behaviors/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/__init__.py
@@ -5,3 +5,4 @@ from .compute_move_to_mouth_position import ComputeMoveToMouthPosition
 from .move_collision_object import MoveCollisionObject
 from .move_to import MoveTo
 from .move_to_dummy import MoveToDummy
+from .toggle_collision_object import ToggleCollisionObject

--- a/ada_feeding/ada_feeding/behaviors/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/__init__.py
@@ -2,5 +2,6 @@
 This package contains custom py_tree behaviors for the Ada Feeding project.
 """
 from .compute_move_to_mouth_position import ComputeMoveToMouthPosition
+from .move_collision_object import MoveCollisionObject
 from .move_to import MoveTo
 from .move_to_dummy import MoveToDummy

--- a/ada_feeding/ada_feeding/behaviors/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/__init__.py
@@ -1,5 +1,6 @@
 """
 This package contains custom py_tree behaviors for the Ada Feeding project.
 """
+from .compute_move_to_mouth_position import ComputeMoveToMouthPosition
 from .move_to import MoveTo
 from .move_to_dummy import MoveToDummy

--- a/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
+++ b/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the ComputeMoveToMouthPosition behavior, which computes the
+target position to move the robot's end effector to based on the detected mouth
+center. Specifically, it transforms the detected mouth center from the camera
+frame to the requested frame and then adds an offset.
+"""
+# Standard imports
+from typing import Tuple
+
+# Third-party imports
+from tf2_geometry_msgs import PointStamped
+import py_trees
+from rclpy.node import Node
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
+
+# Local imports
+
+class ComputeMoveToMouthPosition(py_trees.behaviour.Behaviour):
+    """
+    A behavior that computes the target position to move the robot's end effector
+    to based on the detected mouth center. Specifically, it transforms the
+    detected mouth center from the camera frame to the requested frame and then
+    adds an offset.
+    """
+    def __init__(
+        self,
+        name: str,
+        node: Node,
+        face_detection_input_key: str,
+        target_position_output_key: str,
+        target_position_frame_id: str,
+        target_position_offset: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+    ) -> None:
+        """
+        Initializes the behavior.
+
+        Parameters
+        ----------
+        name: The name of the behavior.
+        node: The ROS node.
+        face_detection_input_key: The key for the face detection input on the blackboard.
+        target_position_output_key: The key for the target position output on the blackboard.
+        target_position_frame_id: The frame ID for the target position.
+        target_position_offset: The offset to add to the target position, in `target_position_frame_id`
+        """
+        # Initiatilize the behavior
+        super().__init__(name=name)
+
+        # Store parameters
+        self.node = node
+        self.face_detection_input_key = face_detection_input_key
+        self.target_position_output_key = target_position_output_key
+        self.target_position_frame_id = target_position_frame_id
+
+        # Initialization the blackboard for this behavior
+        self.blackboard = self.attach_blackboard_client(
+            name=name + "ComputeMoveToMouthPosition", namespace=name
+        )
+        # Read the results of face detection
+        self.blackboard.register_key(
+            key=self.face_detection_input_key, access=py_trees.common.Access.READ
+        )
+        # Write the target position
+        self.blackboard.register_key(
+            key=self.target_position_output_key, access=py_trees.common.Access.WRITE
+        )
+    
+        
+    def setup(self, **kwargs) -> None:
+        """
+        Subscribe to tf2 transforms.
+        """
+        self.logger.info("%s [ComputeMoveToMouthPosition::setup()]" % self.name)
+        # Initialize the tf2 buffer and listener
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self.node)
+
+    def update(self) -> py_trees.common.Status:
+        """
+        Computes the target position to move the robot's end effector to based on
+        the detected mouth center. Specifically, it transforms the detected mouth
+        center from the camera frame to the requested frame and then adds an offset.
+        It immediately returns either SUCCESS or FAILURE, and never returns RUNNING.
+        """
+        self.logger.info("%s [ComputeMoveToMouthPosition::update()]" % self.name)
+        # Get the face detection message from the blackboard. If it doesn't
+        # exist, then return failure.
+        try:
+            face_detection = self.blackboard.get(self.face_detection_input_key)
+        except KeyError:
+            self.logger.error(
+                "%s [ComputeMoveToMouthPosition::update()] "
+                "Face detection message not found in blackboard" % self.name
+            )
+            return py_trees.common.Status.FAILURE
+
+        # Transform the face detection result to the base frame. If the
+        # transform doesn't exist, then return failure.
+        # raise Exception("%s | %s" % (type(face_detection.detected_mouth_center), type(PointStamped())))
+        try:
+            target_position = self.tf_buffer.transform(face_detection.detected_mouth_center, self.target_position_frame_id)
+            self.logger.info("%s [ComputeMoveToMouthPosition::update()] face_detection.detected_mouth_center %s target_position %s " % (self.name, face_detection.detected_mouth_center, target_position))
+        except Exception as e:
+            self.logger.error(
+                "%s [ComputeMoveToMouthPosition::update()] "
+                "Failed to transform face detection result to base frame: %s" % (self.name, e)
+            )
+            return py_trees.common.Status.FAILURE
+
+        # Write the target position to the blackboard
+        self.blackboard.set(self.target_position_output_key, (target_position.point.x, target_position.point.y, target_position.point.z))
+        return py_trees.common.Status.SUCCESS

--- a/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
+++ b/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
@@ -13,7 +13,7 @@ from typing import Tuple
 import py_trees
 from rclpy.node import Node
 from rclpy.time import Time
-from tf2_geometry_msgs import PointStamped # pylint: disable=unused-import
+from tf2_geometry_msgs import PointStamped  # pylint: disable=unused-import
 import tf2_py as tf2
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener

--- a/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
+++ b/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
@@ -10,13 +10,16 @@ frame to the requested frame and then adds an offset.
 from typing import Tuple
 
 # Third-party imports
-from tf2_geometry_msgs import PointStamped
 import py_trees
 from rclpy.node import Node
+from rclpy.time import Time
+import tf2_py as tf2
+from tf2_geometry_msgs import PointStamped
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
 # Local imports
+
 
 class ComputeMoveToMouthPosition(py_trees.behaviour.Behaviour):
     """
@@ -25,6 +28,7 @@ class ComputeMoveToMouthPosition(py_trees.behaviour.Behaviour):
     detected mouth center from the camera frame to the requested frame and then
     adds an offset.
     """
+
     def __init__(
         self,
         name: str,
@@ -54,6 +58,7 @@ class ComputeMoveToMouthPosition(py_trees.behaviour.Behaviour):
         self.face_detection_input_key = face_detection_input_key
         self.target_position_output_key = target_position_output_key
         self.target_position_frame_id = target_position_frame_id
+        self.target_position_offset = target_position_offset
 
         # Initialization the blackboard for this behavior
         self.blackboard = self.attach_blackboard_client(
@@ -67,8 +72,7 @@ class ComputeMoveToMouthPosition(py_trees.behaviour.Behaviour):
         self.blackboard.register_key(
             key=self.target_position_output_key, access=py_trees.common.Access.WRITE
         )
-    
-        
+
     def setup(self, **kwargs) -> None:
         """
         Subscribe to tf2 transforms.
@@ -99,17 +103,45 @@ class ComputeMoveToMouthPosition(py_trees.behaviour.Behaviour):
 
         # Transform the face detection result to the base frame. If the
         # transform doesn't exist, then return failure.
-        # raise Exception("%s | %s" % (type(face_detection.detected_mouth_center), type(PointStamped())))
         try:
-            target_position = self.tf_buffer.transform(face_detection.detected_mouth_center, self.target_position_frame_id)
-            self.logger.info("%s [ComputeMoveToMouthPosition::update()] face_detection.detected_mouth_center %s target_position %s " % (self.name, face_detection.detected_mouth_center, target_position))
+            try:
+                target_position = self.tf_buffer.transform(
+                    face_detection.detected_mouth_center, self.target_position_frame_id
+                )
+                self.logger.info(
+                    "%s [ComputeMoveToMouthPosition::update()] face_detection.detected_mouth_center %s target_position %s "
+                    % (self.name, face_detection.detected_mouth_center, target_position)
+                )
+            except tf2.ExtrapolationException as e:
+                # If the transform failed at the timestamp in the message, retry
+                # with the latest transform
+                self.logger.warning(
+                    "%s [ComputeMoveToMouthPosition::update()] "
+                    "Transform failed at timestamp in message: %s: %s. "
+                    "Retrying with latest transform."
+                    % (self.name, type(e), e)
+                )
+                face_detection.detected_mouth_center.header.stamp = Time().to_msg()
+                target_position = self.tf_buffer.transform(
+                    face_detection.detected_mouth_center,
+                    self.target_position_frame_id,
+                )
         except Exception as e:
             self.logger.error(
                 "%s [ComputeMoveToMouthPosition::update()] "
-                "Failed to transform face detection result to base frame: %s" % (self.name, e)
+                "Failed to transform face detection result to base frame: %s: %s"
+                % (self.name, type(e), e)
             )
             return py_trees.common.Status.FAILURE
 
         # Write the target position to the blackboard
-        self.blackboard.set(self.target_position_output_key, (target_position.point.x, target_position.point.y, target_position.point.z))
+        final_position = (
+            target_position.point.x + self.target_position_offset[0],
+            target_position.point.y + self.target_position_offset[1],
+            target_position.point.z + self.target_position_offset[2],
+        )
+        self.blackboard.set(
+            self.target_position_output_key,
+            final_position,
+        )
         return py_trees.common.Status.SUCCESS

--- a/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
+++ b/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
@@ -125,7 +125,7 @@ class ComputeMoveToMouthPosition(py_trees.behaviour.Behaviour):
                     face_detection.detected_mouth_center,
                     self.target_position_frame_id,
                 )
-        except Exception as e:
+        except tf2.ExtrapolationException as e:
             self.logger.error(
                 "%s [ComputeMoveToMouthPosition::update()] "
                 "Failed to transform face detection result to base frame: %s: %s"

--- a/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
+++ b/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
@@ -13,6 +13,7 @@ from typing import Tuple
 import py_trees
 from rclpy.node import Node
 from rclpy.time import Time
+from tf2_geometry_msgs import PointStamped # pylint: disable=unused-import
 import tf2_py as tf2
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener

--- a/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
+++ b/ada_feeding/ada_feeding/behaviors/compute_move_to_mouth_position.py
@@ -118,8 +118,7 @@ class ComputeMoveToMouthPosition(py_trees.behaviour.Behaviour):
                 self.logger.warning(
                     "%s [ComputeMoveToMouthPosition::update()] "
                     "Transform failed at timestamp in message: %s: %s. "
-                    "Retrying with latest transform."
-                    % (self.name, type(e), e)
+                    "Retrying with latest transform." % (self.name, type(e), e)
                 )
                 face_detection.detected_mouth_center.header.stamp = Time().to_msg()
                 target_position = self.tf_buffer.transform(

--- a/ada_feeding/ada_feeding/behaviors/move_collision_object.py
+++ b/ada_feeding/ada_feeding/behaviors/move_collision_object.py
@@ -24,6 +24,9 @@ class MoveCollisionObject(py_trees.behaviour.Behaviour):
     consists of a single mesh.
     """
 
+    # pylint: disable=too-many-instance-attributes, too-many-arguments
+    # A few over is fine. All are necessary.
+
     def __init__(
         self,
         name: str,
@@ -43,8 +46,10 @@ class MoveCollisionObject(py_trees.behaviour.Behaviour):
         name: The name of the behavior.
         node: The ROS node to associate the publishes with.
         collision_object_id: The ID for the collision object in the MoveIt planning scene.
-        collision_object_position_input_key: The key for the collision object pose input on the blackboard.
-        collision_object_orientation_input_key: The key for the collision object orientation input on the blackboard.
+        collision_object_position_input_key: The key for the collision object pose input
+            on the blackboard.
+        collision_object_orientation_input_key: The key for the collision object orientation
+            input on the blackboard.
         reverse_position_offset: The offset to *subtract from* to the collision object position.
         """
         # Initiatilize the behavior

--- a/ada_feeding/ada_feeding/behaviors/move_collision_object.py
+++ b/ada_feeding/ada_feeding/behaviors/move_collision_object.py
@@ -101,6 +101,7 @@ class MoveCollisionObject(py_trees.behaviour.Behaviour):
         Note that this behavior asusmes that the collision object to be moved
         consists of a single mesh.
         """
+        self.logger.info(f"{self.name} [MoveCollisionObject::update()]")
         # Get the pose to move the collision object to
         try:
             collision_object_position = self.blackboard.get(

--- a/ada_feeding/ada_feeding/behaviors/move_collision_object.py
+++ b/ada_feeding/ada_feeding/behaviors/move_collision_object.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the MoveCollisionObject behavior, which moves a collision
+object in MoveIt's planning scene to a specified pose.
+"""
+# Standard imports
+from typing import Tuple
+
+# Third-party imports
+from geometry_msgs.msg import Pose
+from moveit_msgs.msg import CollisionObject
+import py_trees
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+
+# Local imports
+
+
+class MoveCollisionObject(py_trees.behaviour.Behaviour):
+    """
+    A behavior that moves a collision object to a specified pose. This behavior
+    assumes that the collision object is already in MoveIt's planning scene and
+    consists of a single mesh.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        node: Node,
+        collision_object_id: str,
+        collision_object_position_input_key: str,
+        collision_object_orientation_input_key: str,
+        reverse_position_offset: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+    ) -> None:
+        """
+        Initializes the behavior. Requires the blackboard to pass it a position
+        (3-tuple) and orientation (4-tuple, quaternion) to move the collision
+        object to, as well as a frame_id for the pose.
+
+        Parameters
+        ----------
+        name: The name of the behavior.
+        node: The ROS node to associate the publishes with.
+        collision_object_id: The ID for the collision object in the MoveIt planning scene.
+        collision_object_position_input_key: The key for the collision object pose input on the blackboard.
+        collision_object_orientation_input_key: The key for the collision object orientation input on the blackboard.
+        reverse_position_offset: The offset to *subtract from* to the collision object position.
+        """
+        # Initiatilize the behavior
+        super().__init__(name=name)
+
+        # Store parameters
+        self.node = node
+        self.collision_object_id = collision_object_id
+        self.collision_object_position_input_key = collision_object_position_input_key
+        self.collision_object_orientation_input_key = (
+            collision_object_orientation_input_key
+        )
+        self.reverse_position_offset = reverse_position_offset
+
+        # Initialize the blackboard for this behavior
+        self.blackboard = self.attach_blackboard_client(
+            name=name + " MoveCollisionObject", namespace=name
+        )
+        # Read the position to move the collision object to
+        self.blackboard.register_key(
+            key=self.collision_object_position_input_key,
+            access=py_trees.common.Access.READ,
+        )
+        # Read the orientation to move the collision object to
+        self.blackboard.register_key(
+            key=self.collision_object_orientation_input_key,
+            access=py_trees.common.Access.READ,
+        )
+        # Read the frame ID for the pose to move the collision object to
+        self.blackboard.register_key(
+            key="frame_id",
+            access=py_trees.common.Access.READ,
+        )
+
+        # Create the publisher
+        self.publisher = self.node.create_publisher(
+            CollisionObject,
+            "/collision_object",
+            QoSProfile(reliability=ReliabilityPolicy.RELIABLE, depth=1),
+        )
+
+    def update(self) -> py_trees.common.Status:
+        """
+        Gets the name of the collision object to move and the pose to move it to
+        from the blackboard and publishes a message to MoveIt to move that object
+        to that pose. This behavior does not wait for the collision object to be
+        moved to the pose before returning success.
+
+        Note that this behavior asusmes that the collision object to be moved
+        consists of a single mesh.
+        """
+        # Get the pose to move the collision object to
+        try:
+            collision_object_position = self.blackboard.get(
+                self.collision_object_position_input_key
+            )
+            collision_object_orientation = self.blackboard.get(
+                self.collision_object_orientation_input_key
+            )
+        except KeyError:
+            # If the collision object pose is not on the blackboard, return failure
+            self.logger.error(
+                "The collision object pose is not on the blackboard. "
+                "Returning failure."
+            )
+            return py_trees.common.Status.FAILURE
+
+        # Create the collision object
+        collision_object = CollisionObject()
+        collision_object.id = self.collision_object_id
+        collision_object.header.frame_id = self.blackboard.frame_id
+        pose = Pose()
+        pose.position.x = collision_object_position[0] - self.reverse_position_offset[0]
+        pose.position.y = collision_object_position[1] - self.reverse_position_offset[1]
+        pose.position.z = collision_object_position[2] - self.reverse_position_offset[2]
+        pose.orientation.x = collision_object_orientation[0]
+        pose.orientation.y = collision_object_orientation[1]
+        pose.orientation.z = collision_object_orientation[2]
+        pose.orientation.w = collision_object_orientation[3]
+        collision_object.pose = pose
+        collision_object.operation = CollisionObject.MOVE
+
+        # Publish the collision object
+        self.publisher.publish(collision_object)
+
+        # Return success
+        return py_trees.common.Status.SUCCESS

--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -313,6 +313,10 @@ class MoveTo(py_trees.behaviour.Behaviour):
         rate = self.node.create_rate(self.terminate_rate_hz)
         # A termination request has not succeeded until the MoveIt2 action server is IDLE
         while self.moveit2.query_state() != MoveIt2State.IDLE:
+            self.node.get_logger().info(
+                f"MoveTo Update MoveIt2State not Idle {time.time()} {terminate_requested_time} "
+                f"{self.terminate_timeout_s}"
+            )
             # If the goal is executing, cancel it
             if self.moveit2.query_state() == MoveIt2State.EXECUTING:
                 self.moveit2.cancel_execution()

--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -137,12 +137,6 @@ class MoveTo(py_trees.behaviour.Behaviour):
             qos_profile=QoSPresetProfiles.SENSOR_DATA.value,
         )
 
-    def setup(self, **kwargs) -> None:
-        """
-        Create the MoveIt interface.
-        """
-        self.logger.info(f"{self.name} [MoveTo::setup()]")
-
     # pylint: disable=attribute-defined-outside-init
     # For attributes that are only used during the execution of the tree
     # and get reset before the next execution, it is reasonable to define

--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -268,15 +268,14 @@ class MoveTo(py_trees.behaviour.Behaviour):
                     # is already executing a trajectory, action server not
                     # available, goal was rejected, etc.)
                     self.logger.error(
-                        "%s [MoveTo::update()] Failed to execute trajectory before goal was accepted!"
-                        % self.name
+                        f"{self.name} [MoveTo::update()] Failed to execute trajectory before goal "
+                        "was accepted!"
                     )
                     return py_trees.common.Status.FAILURE
-                else:
-                    # If we get here, the goal finished executing within the
-                    # last tick.
-                    self.tree_blackboard.motion_curr_distance = 0.0
-                    return py_trees.common.Status.SUCCESS
+                # If we get here, the goal finished executing within the
+                # last tick.
+                self.tree_blackboard.motion_curr_distance = 0.0
+                return py_trees.common.Status.SUCCESS
         if self.motion_future is not None:
             self.tree_blackboard.motion_curr_distance = (
                 self.distance_to_goal.get_distance()

--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -99,19 +99,19 @@ class MoveTo(py_trees.behaviour.Behaviour):
         )
         # Feedback from MoveTo for the ROS2 Action Server
         self.tree_blackboard.register_key(
-            key="is_planning", access=py_trees.common.Access.EXCLUSIVE_WRITE
+            key="is_planning", access=py_trees.common.Access.WRITE
         )
         self.tree_blackboard.register_key(
-            key="planning_time", access=py_trees.common.Access.EXCLUSIVE_WRITE
+            key="planning_time", access=py_trees.common.Access.WRITE
         )
         self.tree_blackboard.register_key(
-            key="motion_time", access=py_trees.common.Access.EXCLUSIVE_WRITE
+            key="motion_time", access=py_trees.common.Access.WRITE
         )
         self.tree_blackboard.register_key(
-            key="motion_initial_distance", access=py_trees.common.Access.EXCLUSIVE_WRITE
+            key="motion_initial_distance", access=py_trees.common.Access.WRITE
         )
         self.tree_blackboard.register_key(
-            key="motion_curr_distance", access=py_trees.common.Access.EXCLUSIVE_WRITE
+            key="motion_curr_distance", access=py_trees.common.Access.WRITE
         )
 
         # Create MoveIt 2 interface for moving the Jaco arm. This must be done

--- a/ada_feeding/ada_feeding/behaviors/toggle_collision_object.py
+++ b/ada_feeding/ada_feeding/behaviors/toggle_collision_object.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the ToggleCollisionObject behavior, which (dis)allows
+collisions between the robot and a collision object already in
+MoveIt's planning scene.
+"""
+
+# Standard imports
+
+# Third-party imports
+import py_trees
+from pymoveit2 import MoveIt2
+from pymoveit2.robots import kinova
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.node import Node
+
+# Local imports
+
+
+class ToggleCollisionObject(py_trees.behaviour.Behaviour):
+    """
+    ToggleCollisionObject is a behavior that (dis)allows collisions
+    between the robot and a collision object already in MoveIt's planning
+    scene.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        node: Node,
+        collision_object_id: str,
+        allow: bool,
+    ) -> None:
+        """
+        Initializes the behavior.
+
+        Parameters
+        ----------
+        name: The name of the behavior.
+        node: The ROS node to associate the publishers with.
+        collision_object_id: The ID for the collision object in the MoveIt planning scene.
+        allow: If True, then collisions between the robot and collision object ID are
+            *allowed* e.g., a plan that collides with the object will be considered valid.
+            If False, then collisions between the robot and collision object ID are
+            *disallowed* e.g., a plan that collides with the object will be considered invalid.
+        """
+        # Initiatilize the behavior
+        super().__init__(name=name)
+
+        # Store parameters
+        self.node = node
+        self.collision_object_id = collision_object_id
+        self.allow = allow
+
+        # Create MoveIt 2 interface for moving the Jaco arm. This must be done
+        # in __init__ and not setup since the MoveIt2 interface must be
+        # initialized before the ROS2 node starts spinning.
+        callback_group = ReentrantCallbackGroup()
+        self.moveit2 = MoveIt2(
+            node=self.node,
+            joint_names=kinova.joint_names(),
+            base_link_name=kinova.base_link_name(),
+            end_effector_name="forkTip",
+            group_name=kinova.MOVE_GROUP_ARM,
+            callback_group=callback_group,
+        )
+
+    def update(self) -> py_trees.common.Status:
+        """
+        (Dis)allow collisions between the robot and a collision
+        object already in MoveIt's planning scene.
+
+        Returns
+        -------
+        status: The status of the behavior.
+        """
+        self.logger.info(f"{self.name} [ToggleCollisionObject::update()]")
+        # (Dis)allow collisions between the robot and the collision object
+        succ = self.moveit2.allow_collisions(self.collision_object_id, self.allow)
+
+        # Return success
+        if succ:
+            return py_trees.common.Status.SUCCESS
+        return py_trees.common.Status.FAILURE

--- a/ada_feeding/ada_feeding/helpers.py
+++ b/ada_feeding/ada_feeding/helpers.py
@@ -9,6 +9,23 @@ from typing import Any
 # Third-party imports
 import py_trees
 
+# These prefixes are used to separate namespaces from each other.
+# For example, if we have a behavior `foo` that has a position goal constraint,
+# an orientaiton path constraint, and a move to behavior, the namespaces
+# of each behavior (and their corresponding blackboards) will be:
+#   - foo.position_goal_constraint
+#   - foo.orientation_path_constraint
+#   - foo.move_to
+# Note that this norm can only be used if each MoveTo behavior has maximally
+# one constraint of each type. When creating a behavior with multiple constraints
+# of the same time, you'll have to create custom namespaces.
+POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX = "position_goal_constraint"
+ORIENTATION_GOAL_CONSTRAINT_NAMESPACE_PREFIX = "orientation_goal_constraint"
+JOINT_GOAL_CONSTRAINT_NAMESPACE_PREFIX = "joint_goal_constraint"
+POSITION_PATH_CONSTRAINT_NAMESPACE_PREFIX = "position_path_constraint"
+ORIENTATION_PATH_CONSTRAINT_NAMESPACE_PREFIX = "orientation_path_constraint"
+JOINT_PATH_CONSTRAINT_NAMESPACE_PREFIX = "joint_path_constraint"
+MOVE_TO_NAMESPACE_PREFIX = "move_to"
 
 def get_from_blackboard_with_default(
     blackboard: py_trees.blackboard.Client, key: str, default: Any

--- a/ada_feeding/ada_feeding/helpers.py
+++ b/ada_feeding/ada_feeding/helpers.py
@@ -27,6 +27,7 @@ ORIENTATION_PATH_CONSTRAINT_NAMESPACE_PREFIX = "orientation_path_constraint"
 JOINT_PATH_CONSTRAINT_NAMESPACE_PREFIX = "joint_path_constraint"
 MOVE_TO_NAMESPACE_PREFIX = "move_to"
 
+
 def get_from_blackboard_with_default(
     blackboard: py_trees.blackboard.Client, key: str, default: Any
 ) -> Any:

--- a/ada_feeding/ada_feeding/helpers.py
+++ b/ada_feeding/ada_feeding/helpers.py
@@ -4,7 +4,7 @@ Ada Feeding project.
 """
 
 # Standard imports
-from typing import Any
+from typing import Any, Set
 
 # Third-party imports
 import py_trees
@@ -48,6 +48,31 @@ def get_from_blackboard_with_default(
         return getattr(blackboard, key)
     except KeyError:
         return default
+
+
+# pylint: disable=dangerous-default-value
+# A mutable default value is okay since we don't change it in this function.
+def set_to_blackboard(
+    blackboard: py_trees.blackboard.Client,
+    key: str,
+    value: Any,
+    keys_to_not_write_to_blackboard: Set[str] = set(),
+) -> None:
+    """
+    Sets a value to the blackboard.
+
+    Parameters
+    ----------
+    blackboard: The blackboard client.
+    key: The key to set.
+    value: The value to set.
+    keys_to_not_write_to_blackboard: A set of keys that should not be written
+        to the blackboard. Note that the keys need to be exact e.g., "move_to.cartesian,"
+        "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
+        etc.
+    """
+    if key not in keys_to_not_write_to_blackboard:
+        blackboard.set(key, value)
 
 
 def import_from_string(import_string: str) -> Any:

--- a/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
+++ b/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
@@ -22,6 +22,7 @@ from ada_feeding.decorators import (
 from ada_feeding.helpers import (
     POSITION_PATH_CONSTRAINT_NAMESPACE_PREFIX,
     ORIENTATION_PATH_CONSTRAINT_NAMESPACE_PREFIX,
+    set_to_blackboard,
 )
 
 
@@ -30,6 +31,8 @@ from ada_feeding.helpers import (
 # pose path constraints to a behavior tree -- the point of putting them
 # into one function is to reduce the number of arguments/locals/statements
 # needed in other functions.
+# pylint: disable=dangerous-default-value
+# A mutable default value is okay since we don't change it in this function.
 def add_pose_path_constraints(
     child: py_trees.behaviour.Behaviour,
     name: str,
@@ -159,31 +162,67 @@ def add_pose_path_constraints(
 
     # Write the inputs to the pose path constraints to blackboard
     if position_path is not None:
-        if position_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(position_key, position_path)
-        if position_frame_id_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(position_frame_id_key, frame_id_path)
-        if position_target_link_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(position_target_link_key, target_link_path)
-        if position_tolerance_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(position_tolerance_key, tolerance_position_path)
-        if position_weight_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(position_weight_key, weight_position_path)
+        set_to_blackboard(
+            blackboard, position_key, position_path, keys_to_not_write_to_blackboard
+        )
+        set_to_blackboard(
+            blackboard,
+            position_frame_id_key,
+            frame_id_path,
+            keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            blackboard,
+            position_target_link_key,
+            target_link_path,
+            keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            blackboard,
+            position_tolerance_key,
+            tolerance_position_path,
+            keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            blackboard,
+            position_weight_key,
+            weight_position_path,
+            keys_to_not_write_to_blackboard,
+        )
     if quat_xyzw_path is not None:
-        if orientation_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(orientation_key, quat_xyzw_path)
-        if orientation_frame_id_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(orientation_frame_id_key, frame_id_path)
-        if orientation_target_link_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(orientation_target_link_key, target_link_path)
-        if orientation_tolerance_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(orientation_tolerance_key, tolerance_orientation_path)
-        if orientation_parameterization_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(
-                orientation_parameterization_key, parameterization_orientation_path
-            )
-        if orientation_weight_key not in keys_to_not_write_to_blackboard:
-            blackboard.set(orientation_weight_key, weight_orientation_path)
+        set_to_blackboard(
+            blackboard, orientation_key, quat_xyzw_path, keys_to_not_write_to_blackboard
+        )
+        set_to_blackboard(
+            blackboard,
+            orientation_frame_id_key,
+            frame_id_path,
+            keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            blackboard,
+            orientation_target_link_key,
+            target_link_path,
+            keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            blackboard,
+            orientation_tolerance_key,
+            tolerance_orientation_path,
+            keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            blackboard,
+            orientation_parameterization_key,
+            parameterization_orientation_path,
+            keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            blackboard,
+            orientation_weight_key,
+            weight_orientation_path,
+            keys_to_not_write_to_blackboard,
+        )
 
     # Add the position path constraint to the child behavior
     if position_path is not None:

--- a/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
+++ b/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
@@ -8,7 +8,7 @@ on it, and adds a SetPositionPathConstraint and/or SetOrientationPathConstraint.
 
 # Standard imports
 import logging
-from typing import Tuple, Optional, Union
+from typing import Set, Tuple, Optional, Union
 
 # Third-party imports
 import py_trees
@@ -18,6 +18,10 @@ from py_trees.blackboard import Blackboard
 from ada_feeding.decorators import (
     SetPositionPathConstraint,
     SetOrientationPathConstraint,
+)
+from ada_feeding.helpers import (
+    POSITION_PATH_CONSTRAINT_NAMESPACE_PREFIX,
+    ORIENTATION_PATH_CONSTRAINT_NAMESPACE_PREFIX,
 )
 
 
@@ -31,10 +35,10 @@ def add_pose_path_constraints(
     name: str,
     blackboard: py_trees.blackboard.Blackboard,
     logger: logging.Logger,
-    set_blackboard_variables: bool = False,
+    keys_to_not_write_to_blackboard: Set[str] = set(),
     # Optional parameters for the pose path constraint
-    position_path: Tuple[float, float, float] = None,
-    quat_xyzw_path: Tuple[float, float, float, float] = None,
+    position_path: Optional[Tuple[float, float, float]] = None,
+    quat_xyzw_path: Optional[Tuple[float, float, float, float]] = None,
     frame_id_path: Optional[str] = None,
     target_link_path: Optional[str] = None,
     tolerance_position_path: float = 0.001,
@@ -55,8 +59,10 @@ def add_pose_path_constraints(
     name: The name for the tree that this behavior is in.
     blackboard: The blackboard for the tree that this behavior is in.
     logger: The logger for the tree that this behavior is in.
-    set_blackboard_variables: Whether to set the blackboard variables for the
-        path constraint.
+    keys_to_not_write_to_blackboard: the keys to not write to the blackboard.
+        Note that the keys need to be exact e.g., "move_to.cartesian,"
+        "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
+        etc.
     position_path: the target position relative to frame_id for path constraints.
     quat_xyzw_path: the target orientation relative to frame_id for path constraints.
     frame_id_path: the frame id of the target pose for path constraints. If None,
@@ -73,36 +79,36 @@ def add_pose_path_constraints(
 
     # Separate blackboard namespaces for decorators
     if position_path is not None:
-        position_constraint_namespace_prefix = "position_path_constraint"
+        position_path_constraint_namespace_prefix = POSITION_PATH_CONSTRAINT_NAMESPACE_PREFIX
     if quat_xyzw_path is not None:
-        orientation_constraint_namespace_prefix = "orientation_path_constraint"
+        orientation_path_constraint_namespace_prefix = ORIENTATION_PATH_CONSTRAINT_NAMESPACE_PREFIX
 
     # Position constraints
     if position_path is not None:
         position_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "position"]
+            [position_path_constraint_namespace_prefix, "position"]
         )
         blackboard.register_key(key=position_key, access=py_trees.common.Access.WRITE)
         position_frame_id_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "frame_id"]
+            [position_path_constraint_namespace_prefix, "frame_id"]
         )
         blackboard.register_key(
             key=position_frame_id_key, access=py_trees.common.Access.WRITE
         )
         position_target_link_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "target_link"]
+            [position_path_constraint_namespace_prefix, "target_link"]
         )
         blackboard.register_key(
             key=position_target_link_key, access=py_trees.common.Access.WRITE
         )
         position_tolerance_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "tolerance"]
+            [position_path_constraint_namespace_prefix, "tolerance"]
         )
         blackboard.register_key(
             key=position_tolerance_key, access=py_trees.common.Access.WRITE
         )
         position_weight_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "weight"]
+            [position_path_constraint_namespace_prefix, "weight"]
         )
         blackboard.register_key(
             key=position_weight_key, access=py_trees.common.Access.WRITE
@@ -111,64 +117,74 @@ def add_pose_path_constraints(
     # Orientation constraints
     if quat_xyzw_path is not None:
         orientation_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "quat_xyzw"]
+            [orientation_path_constraint_namespace_prefix, "quat_xyzw"]
         )
         blackboard.register_key(
             key=orientation_key, access=py_trees.common.Access.WRITE
         )
         orientation_frame_id_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "frame_id"]
+            [orientation_path_constraint_namespace_prefix, "frame_id"]
         )
         blackboard.register_key(
             key=orientation_frame_id_key, access=py_trees.common.Access.WRITE
         )
         orientation_target_link_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "target_link"]
+            [orientation_path_constraint_namespace_prefix, "target_link"]
         )
         blackboard.register_key(
             key=orientation_target_link_key, access=py_trees.common.Access.WRITE
         )
         orientation_tolerance_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "tolerance"]
+            [orientation_path_constraint_namespace_prefix, "tolerance"]
         )
         blackboard.register_key(
             key=orientation_tolerance_key, access=py_trees.common.Access.WRITE
         )
         orientation_parameterization_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "parameterization"]
+            [orientation_path_constraint_namespace_prefix, "parameterization"]
         )
         blackboard.register_key(
             key=orientation_parameterization_key, access=py_trees.common.Access.WRITE
         )
         orientation_weight_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "weight"]
+            [orientation_path_constraint_namespace_prefix, "weight"]
         )
         blackboard.register_key(
             key=orientation_weight_key, access=py_trees.common.Access.WRITE
         )
 
     # Write the inputs to the pose path constraints to blackboard
-    if set_blackboard_variables:
-        if position_path is not None:
+    if position_path is not None:
+        if position_key not in keys_to_not_write_to_blackboard:
             blackboard.set(position_key, position_path)
+        if position_frame_id_key not in keys_to_not_write_to_blackboard:
             blackboard.set(position_frame_id_key, frame_id_path)
+        if position_target_link_key not in keys_to_not_write_to_blackboard:
             blackboard.set(position_target_link_key, target_link_path)
+        if position_tolerance_key not in keys_to_not_write_to_blackboard:
             blackboard.set(position_tolerance_key, tolerance_position_path)
+        if position_weight_key not in keys_to_not_write_to_blackboard:
             blackboard.set(position_weight_key, weight_position_path)
-        if quat_xyzw_path is not None:
+    if quat_xyzw_path is not None:
+        if orientation_key not in keys_to_not_write_to_blackboard:
             blackboard.set(orientation_key, quat_xyzw_path)
+        if orientation_frame_id_key not in keys_to_not_write_to_blackboard:
             blackboard.set(orientation_frame_id_key, frame_id_path)
+        if orientation_target_link_key not in keys_to_not_write_to_blackboard:
             blackboard.set(orientation_target_link_key, target_link_path)
+        if orientation_tolerance_key not in keys_to_not_write_to_blackboard:
             blackboard.set(orientation_tolerance_key, tolerance_orientation_path)
+        if orientation_parameterization_key not in keys_to_not_write_to_blackboard:
             blackboard.set(
                 orientation_parameterization_key, parameterization_orientation_path
             )
+        if orientation_weight_key not in keys_to_not_write_to_blackboard:
             blackboard.set(orientation_weight_key, weight_orientation_path)
 
     # Add the position path constraint to the child behavior
     if position_path is not None:
         position_path_constaint_name = Blackboard.separator.join(
-            [name, position_constraint_namespace_prefix]
+            [name, position_path_constraint_namespace_prefix]
         )
         position_constraint = SetPositionPathConstraint(
             position_path_constaint_name, child
@@ -180,7 +196,7 @@ def add_pose_path_constraints(
     # Add the orientation goal constraint to the position constriant behavior
     if quat_xyzw_path is not None:
         orientation_goal_constaint_name = Blackboard.separator.join(
-            [name, orientation_constraint_namespace_prefix]
+            [name, orientation_path_constraint_namespace_prefix]
         )
         orientation_constraint = SetOrientationPathConstraint(
             orientation_goal_constaint_name, position_constraint

--- a/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
+++ b/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
@@ -79,9 +79,13 @@ def add_pose_path_constraints(
 
     # Separate blackboard namespaces for decorators
     if position_path is not None:
-        position_path_constraint_namespace_prefix = POSITION_PATH_CONSTRAINT_NAMESPACE_PREFIX
+        position_path_constraint_namespace_prefix = (
+            POSITION_PATH_CONSTRAINT_NAMESPACE_PREFIX
+        )
     if quat_xyzw_path is not None:
-        orientation_path_constraint_namespace_prefix = ORIENTATION_PATH_CONSTRAINT_NAMESPACE_PREFIX
+        orientation_path_constraint_namespace_prefix = (
+            ORIENTATION_PATH_CONSTRAINT_NAMESPACE_PREFIX
+        )
 
     # Position constraints
     if position_path is not None:

--- a/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
+++ b/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
@@ -32,7 +32,7 @@ from .retry_call_ros_service import retry_call_ros_service
 
 def set_parameter_response_all_success(
     blackboard_value: SetParameters.Response,
-    _: SetParameters.Request,
+    _: SetParameters.Response,
 ) -> bool:
     """
     Checks that all the parameters were successfully set.

--- a/ada_feeding/ada_feeding/trees/__init__.py
+++ b/ada_feeding/ada_feeding/trees/__init__.py
@@ -20,4 +20,5 @@ from .move_to_pose_tree import MoveToPoseTree
 from .move_to_pose_with_pose_path_constraints_tree import (
     MoveToPoseWithPosePathConstraintsTree,
 )
+from .move_to_mouth_tree import MoveToMouthTree
 from .move_to_dummy_tree import MoveToDummyTree

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
@@ -17,6 +17,7 @@ from rclpy.node import Node
 # Local imports
 from ada_feeding.behaviors import MoveTo
 from ada_feeding.decorators import SetJointGoalConstraint
+from ada_feeding.helpers import set_to_blackboard
 from ada_feeding.trees import MoveToTree
 
 # pylint: disable=duplicate-code
@@ -33,7 +34,8 @@ class MoveToConfigurationTree(MoveToTree):
     # pylint: disable=too-many-instance-attributes, too-many-arguments
     # Many arguments is fine for this class since it has to be able to configure all parameters
     # of its constraints.
-
+    # pylint: disable=dangerous-default-value
+    # A mutable default value is okay since we don't change it in this function.
     def __init__(
         self,
         joint_positions: List[float],
@@ -137,18 +139,36 @@ class MoveToConfigurationTree(MoveToTree):
         )
 
         # Write the inputs to MoveToConfiguration to blackboard
-        if joint_positions_key not in self.keys_to_not_write_to_blackboard:
-            self.blackboard.set(joint_positions_key, self.joint_positions)
-        if tolerance_key not in self.keys_to_not_write_to_blackboard:
-            self.blackboard.set(tolerance_key, self.tolerance)
-        if weight_key not in self.keys_to_not_write_to_blackboard:
-            self.blackboard.set(weight_key, self.weight)
-        if planner_id_key not in self.keys_to_not_write_to_blackboard:
-            self.blackboard.set(planner_id_key, self.planner_id)
-        if allowed_planning_time_key not in self.keys_to_not_write_to_blackboard:
-            self.blackboard.set(
-                allowed_planning_time_key, self.allowed_planning_time
-            )
+        set_to_blackboard(
+            self.blackboard,
+            joint_positions_key,
+            self.joint_positions,
+            self.keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            self.blackboard,
+            tolerance_key,
+            self.tolerance,
+            self.keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            self.blackboard,
+            weight_key,
+            self.weight,
+            self.keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            self.blackboard,
+            planner_id_key,
+            self.planner_id,
+            self.keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            self.blackboard,
+            allowed_planning_time_key,
+            self.allowed_planning_time,
+            self.keys_to_not_write_to_blackboard,
+        )
 
         # Create the MoveTo behavior
         move_to_name = Blackboard.separator.join([name, move_to_namespace_prefix])

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
@@ -71,6 +71,7 @@ class MoveToConfigurationTree(MoveToTree):
     def create_move_to_tree(
         self,
         name: str,
+        tree_root_name: str,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -80,6 +81,9 @@ class MoveToConfigurationTree(MoveToTree):
         Parameters
         ----------
         name: The name of the behavior tree.
+        tree_root_name: The name of the tree. This is necessary because sometimes
+            trees create subtrees, but still need to track the top-level tree
+            name to read/write the correct blackboard variables.
         logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
@@ -135,7 +139,7 @@ class MoveToConfigurationTree(MoveToTree):
 
         # Create the MoveTo behavior
         move_to_name = Blackboard.separator.join([name, move_to_namespace_prefix])
-        move_to = MoveTo(move_to_name, name, node)
+        move_to = MoveTo(move_to_name, tree_root_name, node)
         move_to.logger = logger
 
         # Add the joint goal constraint to the MoveTo behavior

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -7,7 +7,7 @@ tree and provides functions to wrap that behavior tree in a ROS2 action server.
 
 # Standard imports
 import logging
-from typing import List
+from typing import List, Set
 
 # Third-party imports
 import py_trees
@@ -48,6 +48,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         t_x: float = 0.0,
         t_y: float = 0.0,
         t_z: float = 0.0,
+        keys_to_not_write_to_blackboard: Set[str] = set(),
     ):
         """
         Initializes tree-specific parameters.
@@ -71,6 +72,10 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         t_x: The magnitude of the x component of the torque threshold. No threshold if 0.0.
         t_y: The magnitude of the y component of the torque threshold. No threshold if 0.0.
         t_z: The magnitude of the z component of the torque threshold. No threshold if 0.0.
+        keys_to_not_write_to_blackboard: the keys to not write to the blackboard.
+            Note that the keys need to be exact e.g., "move_to.cartesian,"
+            "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
+            etc.
         """
 
         # pylint: disable=too-many-locals
@@ -99,9 +104,12 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         self.t_y = t_y
         self.t_z = t_z
 
+        self.keys_to_not_write_to_blackboard = keys_to_not_write_to_blackboard
+
     def create_move_to_tree(
         self,
         name: str,
+        tree_root_name: str,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -128,8 +136,9 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                 weight=self.weight_joint,
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
+                keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
             )
-            .create_tree(name, self.action_type, logger, node)
+            .create_tree(name, self.action_type, tree_root_name, logger, node)
             .root
         )
 

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -27,7 +27,8 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
     # pylint: disable=too-many-instance-attributes, too-many-arguments
     # Many arguments is fine for this class since it has to be able to configure all parameters
     # of its constraints.
-
+    # pylint: disable=dangerous-default-value
+    # A mutable default value is okay since we don't change it in this function.
     def __init__(
         self,
         # Required parameters for moving to a configuration

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
@@ -142,6 +142,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
                 weight=self.weight_joint_goal,
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
+                keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
             )
             .create_tree(name, self.action_type, tree_root_name, logger, node)
             .root

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
@@ -29,10 +29,11 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
     honoring pose path constraints.
     """
 
-    # pylint: disable=too-many-instance-attributes, too-many-arguments
+    # pylint: disable=too-many-instance-attributes, too-many-arguments, too-many-locals
     # Many arguments is fine for this class since it has to be able to configure all parameters
     # of its constraints.
-
+    # pylint: disable=dangerous-default-value
+    # A mutable default value is okay since we don't change it in this function.
     def __init__(
         self,
         # Required parameters for moving to a configuration

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -82,6 +82,10 @@ class MoveToDummyTree(ActionServerBT):
         -------
         tree: The behavior tree that moves the robot above the plate.
         """
+
+        # pylint: disable=too-many-arguments
+        # One over is fine.
+
         # Store the action type
         self.action_type = action_type
 

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -56,6 +56,7 @@ class MoveToDummyTree(ActionServerBT):
         self,
         name: str,
         action_type: type,
+        tree_root_name: str,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -70,6 +71,9 @@ class MoveToDummyTree(ActionServerBT):
         ----------
         name: The name of the behavior tree.
         action_type: the type for the action, as a class.
+        tree_root_name: The name of the tree. This is necessary because sometimes
+            trees create subtrees, but still need to track the top-level tree
+            name to read/write the correct blackboard variables.
         logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
@@ -89,7 +93,7 @@ class MoveToDummyTree(ActionServerBT):
             self.tree = py_trees.trees.BehaviourTree(root)
             # Create the blackboard
             self.blackboard = py_trees.blackboard.Client(
-                name=name + " Tree", namespace=name
+                name=name + " Tree", namespace=tree_root_name
             )
             self.blackboard.register_key(
                 key="goal", access=py_trees.common.Access.WRITE

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -11,7 +11,6 @@ import operator
 from typing import List
 
 # Third-party imports
-from ada_feeding_msgs.msg import FaceDetection
 import py_trees
 from py_trees.blackboard import Blackboard
 import py_trees_ros
@@ -19,6 +18,7 @@ from rclpy.node import Node
 from std_srvs.srv import SetBool
 
 # Local imports
+from ada_feeding_msgs.msg import FaceDetection
 from ada_feeding.behaviors import ComputeMoveToMouthPosition, MoveCollisionObject
 from ada_feeding.helpers import (
     POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX,
@@ -153,11 +153,13 @@ class MoveToMouthTree(MoveToTree):
             key_request=None,
             request=SetBool.Request(data=True),
             key_response=turn_face_detection_on_key_response,
-            response_check=py_trees.common.ComparisonExpression(
-                variable=turn_face_detection_on_key_response + ".success",
-                value=True,
-                operator=operator.eq,
-            ),
+            response_checks=[
+                py_trees.common.ComparisonExpression(
+                    variable=turn_face_detection_on_key_response + ".success",
+                    value=True,
+                    operator=operator.eq,
+                )
+            ],
             logger=logger,
         )
 
@@ -165,7 +167,7 @@ class MoveToMouthTree(MoveToTree):
         pre_moveto_config_name = Blackboard.separator.join(
             [name, pre_moveto_config_prefix]
         )
-        pre_moveto_config = pre_moveto_config(
+        pre_moveto_config_behavior = pre_moveto_config(
             name=pre_moveto_config_name,
             f_mag=self.force_threshold,
             t_mag=self.torque_threshold,
@@ -341,11 +343,13 @@ class MoveToMouthTree(MoveToTree):
             key_request=None,
             request=SetBool.Request(data=False),
             key_response=turn_face_detection_off_key_response,
-            response_check=py_trees.common.ComparisonExpression(
-                variable=turn_face_detection_off_key_response + ".success",
-                value=True,
-                operator=operator.eq,
-            ),
+            response_checks=[
+                py_trees.common.ComparisonExpression(
+                    variable=turn_face_detection_off_key_response + ".success",
+                    value=True,
+                    operator=operator.eq,
+                )
+            ],
             logger=logger,
         )
 
@@ -357,7 +361,7 @@ class MoveToMouthTree(MoveToTree):
                 turn_face_detection_on,
                 # For now, we only re-tare the F/T sensor once, since no large forces
                 # are expected during transfer.
-                pre_moveto_config,
+                pre_moveto_config_behavior,
                 move_to_staging_configuration,
                 detect_face,
                 compute_target_position,

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -398,8 +398,8 @@ class MoveToMouthTree(MoveToTree):
         )
 
         # Link all the behaviours together in a sequence with memory
-        root = py_trees.composites.Sequence(
-            name=name,
+        move_to_mouth = py_trees.composites.Sequence(
+            name=name + " Main",
             memory=True,
             children=[
                 turn_face_detection_on,
@@ -414,6 +414,20 @@ class MoveToMouthTree(MoveToTree):
                 move_to_target_pose,
                 # disallow_wheelchair_collision,
                 turn_face_detection_off,
+            ],
+        )
+        move_to_mouth.logger = logger
+
+        # If move_to_mouth fails, we still want to do some cleanup (e.g., turn
+        # face detection off).
+        root = py_trees.composites.Selector(
+            name=name,
+            memory=True,
+            children=[
+                move_to_mouth,
+                # Even though we are cleaning up the tree, it should still
+                # pass the failure up.
+                py_trees.decorators.SuccessIsFailure(name+" Cleanup", turn_face_detection_off),
             ],
         )
         root.logger = logger

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -45,6 +45,8 @@ class MoveToMouthTree(MoveToTree):
         orientation_constraint_quaternion: List[float] = None,
         orientation_constraint_tolerances: List[float] = None,
         planner_id: str = "RRTstarkConfigDefault",
+        allowed_planning_time_to_staging_configuration: float = 0.5,
+        allowed_planning_time_to_mouth: float = 0.5,
         toggle_face_detection_service_name: str = "/toggle_face_detection",
         face_detection_topic_name: str = "/face_detection",
         head_object_id: str = "head",
@@ -68,6 +70,10 @@ class MoveToMouthTree(MoveToTree):
             constraint, as a 3D rotation vector. If None, the orientation
             constraint is not used.
         planner_id: The planner ID to use for the MoveIt2 motion planning.
+        allowed_planning_time_to_staging_configuration: The allowed planning
+            time for the MoveIt2 motion planner to move to the staging config.
+        allowed_planning_time_to_mouth: The allowed planning time for the MoveIt2
+            motion planner to move to the user's mouth.
         toggle_face_detection_service_name: The name of the service to toggle
             face detection on and off.
         face_detection_topic_name: The name of the topic that publishes the
@@ -87,6 +93,8 @@ class MoveToMouthTree(MoveToTree):
         self.orientation_constraint_quaternion = orientation_constraint_quaternion
         self.orientation_constraint_tolerances = orientation_constraint_tolerances
         self.planner_id = planner_id
+        self.allowed_planning_time_to_staging_configuration = allowed_planning_time_to_staging_configuration
+        self.allowed_planning_time_to_mouth = allowed_planning_time_to_mouth
         self.toggle_face_detection_service_name = toggle_face_detection_service_name
         self.face_detection_topic_name = face_detection_topic_name
         self.head_object_id = head_object_id
@@ -156,6 +164,7 @@ class MoveToMouthTree(MoveToTree):
                 joint_positions_goal=self.staging_configuration,
                 tolerance_joint_goal=self.staging_configuration_tolerance,
                 planner_id=self.planner_id,
+                allowed_planning_time=self.allowed_planning_time_to_staging_configuration,
                 quat_xyzw_path=self.orientation_constraint_quaternion,
                 tolerance_orientation_path=self.orientation_constraint_tolerances,
                 parameterization_orientation_path=1,  # Rotation vector
@@ -282,6 +291,7 @@ class MoveToMouthTree(MoveToTree):
                 parameterization_orientation_goal=1,  # Rotation vector
                 cartesian=False,
                 planner_id=self.planner_id,
+                allowed_planning_time=self.allowed_planning_time_to_mouth,
                 quat_xyzw_path=self.orientation_constraint_quaternion,
                 tolerance_orientation_path=self.orientation_constraint_tolerances,
                 parameterization_orientation_path=1,  # Rotation vector

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the MoveToMouthTree behaviour tree and provides functions to
+wrap that behaviour tree in a ROS2 action server.
+"""
+
+# Standard imports
+import logging
+import operator
+from typing import List
+
+# Third-party imports
+import py_trees
+from py_trees.blackboard import Blackboard
+import py_trees_ros
+from rclpy.node import Node
+from std_srvs.srv import SetBool
+
+# Local imports
+from ada_feeding.behaviors import ComputeMoveToMouthPosition
+from ada_feeding.helpers import (
+    POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX,
+)
+from ada_feeding.idioms import retry_call_ros_service
+from ada_feeding.trees import (
+    MoveToTree, 
+    MoveToConfigurationWithPosePathConstraintsTree,
+    MoveToPoseWithPosePathConstraintsTree
+)
+from ada_feeding_msgs.msg import FaceDetection
+
+
+class MoveToMouthTree(MoveToTree):
+    """
+    A behaviour tree that moves the robot to a specified configuration.
+    """
+
+    def __init__(
+        self,
+        action_type_class_str: str,
+        staging_configuration: List[float],
+        staging_configuration_tolerance: float = 0.001,
+        mouth_pose_tolerance: float = 0.001,
+        orientation_constraint_quaternion: List[float] = None,
+        orientation_constraint_tolerances: List[float] = None,
+        planner_id: str = "RRTstarkConfigDefault",
+        toggle_face_detection_service_name: str = "/toggle_face_detection",
+        face_detection_topic_name: str = "/face_detection",
+    ):
+        """
+        Initializes tree-specific parameters.
+
+        Parameters
+        ----------
+        action_type_class_str: The type of action that this tree is implementing,
+            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
+            type can be anything, but the Feedback and Result must at a minimum
+            include the fields of ada_feeding_msgs.action.MoveTo
+        staging_configuration: The joint positions to move the robot arm to.
+            The user's face should be visible in this configuration.
+        staging_configuration_tolerance: The tolerance for the joint positions.
+        mouth_pose_tolerance: The tolerance for the movement to the mouth pose.
+        orientation_constraint_quaternion: The quaternion for the orientation
+            constraint. If None, the orientation constraint is not used.
+        orientation_constraint_tolerances: The tolerances for the orientation
+            constraint, as a 3D rotation vector. If None, the orientation
+            constraint is not used.
+        planner_id: The planner ID to use for the MoveIt2 motion planning.
+        toggle_face_detection_service_name: The name of the service to toggle
+            face detection on and off.
+        face_detection_topic_name: The name of the topic that publishes the
+            face detection results.
+        """
+        # Initialize MoveToTree
+        super().__init__(action_type_class_str)
+
+        # Store the parameters
+        self.action_type_class_str = action_type_class_str
+        self.staging_configuration = staging_configuration
+        assert len(self.staging_configuration) == 6, "Must provide 6 joint positions"
+        self.staging_configuration_tolerance = staging_configuration_tolerance
+        self.mouth_pose_tolerance = mouth_pose_tolerance
+        self.orientation_constraint_quaternion = orientation_constraint_quaternion
+        self.orientation_constraint_tolerances = orientation_constraint_tolerances
+        self.planner_id = planner_id
+        self.toggle_face_detection_service_name = toggle_face_detection_service_name
+        self.face_detection_topic_name = face_detection_topic_name
+
+    def create_move_to_tree(
+        self,
+        name: str,
+        tree_root_name: str,
+        logger: logging.Logger,
+        node: Node,
+    ) -> py_trees.trees.BehaviourTree:
+        """
+        Creates the MoveToMouth behaviour tree.
+
+        Parameters
+        ----------
+        name: The name of the behaviour tree.
+        tree_root_name: The name of the tree. This is necessary because sometimes
+            trees create subtrees, but still need to track the top-level tree
+            name to read/write the correct blackboard variables.
+        logger: The logger to use for the behaviour tree.
+        node: The ROS2 node that this tree is associated with. Necessary for
+            behaviours within the tree connect to ROS topics/services/actions.
+
+        Returns
+        -------
+        tree: The behaviour tree that moves the robot above the plate.
+        """
+        # Separate the namespace of each sub-behavior
+        turn_face_detection_on_prefix = "turn_face_detection_on"
+        move_to_staging_configuration_prefix = "move_to_staging_configuration"
+        get_face_prefix = "get_face"
+        check_face_prefix = "check_face"
+        compute_target_position_prefix = "compute_target_position"
+        move_to_target_pose_prefix = "move_to_target_pose"
+        turn_face_detection_off_prefix = "turn_face_detection_off"
+
+        # Create the behaviour to turn face detection on
+        turn_face_detection_on_name = Blackboard.separator.join(
+            [name, turn_face_detection_on_prefix]
+        )
+        turn_face_detection_on_key_response = Blackboard.separator.join(
+            [turn_face_detection_on_name, "response"]
+        )
+        turn_face_detection_on = retry_call_ros_service(
+            name=turn_face_detection_on_name,
+            service_type=SetBool,
+            service_name=self.toggle_face_detection_service_name,
+            key_request=None,
+            request=SetBool.Request(data=True),
+            key_response = turn_face_detection_on_name,
+            response_check=py_trees.common.ComparisonExpression(
+                variable=turn_face_detection_on_name+".success",
+                value= True,
+                operator=operator.eq
+            ),
+            logger=logger,
+        )
+
+        # Create the behaviour to move the robot to the staging configuration
+        move_to_staging_configuration_name = Blackboard.separator.join(
+            [name, move_to_staging_configuration_prefix]
+        )
+        move_to_staging_configuration = MoveToConfigurationWithPosePathConstraintsTree(
+            action_type_class_str=self.action_type_class_str,
+            joint_positions_goal=self.staging_configuration,
+            tolerance_joint_goal=self.staging_configuration_tolerance,
+            planner_id=self.planner_id,
+            quat_xyzw_path=self.orientation_constraint_quaternion,
+            tolerance_orientation_path=self.orientation_constraint_tolerances,
+            parameterization_orientation_path=1, # Rotation vector
+        ).create_tree(move_to_staging_configuration_name, tree_root_name, logger, node).root
+
+        # Create the behaviour to subscribe to the face detection topic until
+        # a face is detected
+        get_face_name = Blackboard.separator.join(
+            [name, get_face_prefix]
+        )
+        get_face = py_trees_ros.subscribers.ToBlackboard(
+            name=get_face_name,
+            topic_name=self.face_detection_topic_name,
+            topic_type=FaceDetection,
+            qos_profile=py_trees_ros.utilities.qos_profile_unlatched(),
+            blackboard_variables={
+                "face_detection": None,
+            },
+            initialise_variables = {
+                "face_detection": FaceDetection(),
+            }
+        )
+        get_face.logger = logger
+        check_face_name = Blackboard.separator.join(
+            [name, check_face_prefix]
+        )
+        check_face = py_trees.decorators.FailureIsRunning(
+            name=check_face_name,
+            child=py_trees.behaviours.CheckBlackboardVariableValue(
+                name=check_face_name,
+                check = py_trees.common.ComparisonExpression(
+                    variable="face_detection.is_face_detected",
+                    value=True,
+                    operator=operator.eq
+                )
+            )
+        )
+        check_face.logger = logger
+        detect_face = py_trees.composites.Sequence(
+            name=name,
+            memory=False,
+            children=[
+                get_face,
+                check_face,
+            ],
+        )
+        detect_face.logger = logger
+
+        # Create the behaviour to compute the target pose for the robot's end
+        # effector
+        compute_target_position_name = Blackboard.separator.join(
+            [name, compute_target_position_prefix]
+        )
+        compute_target_position = ComputeMoveToMouthPosition(
+            name=compute_target_position_name,
+            node=node,
+            face_detection_input_key="/face_detection",
+            target_position_output_key="/"+Blackboard.separator.join(
+                [name, move_to_target_pose_prefix, POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX, "position"]
+            ),
+            target_position_frame_id="j2n6s200_link_base",
+            # The target position is 5cm away from the mouth
+            target_position_offset = (0.0, -0.05, 0.0),
+        )
+        compute_target_position.logger = logger
+
+        # Create the behaviour to move the robot to the target pose
+        # We want to add a position goal, but it should come from the
+        # blackboard instead of being hardcoded. For now we won't add
+        # an orientation goal, but TODO consider adding one. We also
+        # add an orientation path constraint (e.g., to keep the fork straight).
+        move_to_target_pose_name = Blackboard.separator.join(
+            [name, move_to_target_pose_prefix]
+        )
+        move_to_target_pose = MoveToPoseWithPosePathConstraintsTree(
+            action_type_class_str=self.action_type_class_str,
+            position_goal=(0.0, 0.0, 0.0),
+            tolerance_position_goal = self.mouth_pose_tolerance,
+            cartesian=False,
+            planner_id=self.planner_id,
+            quat_xyzw_path=self.orientation_constraint_quaternion,
+            tolerance_orientation_path=self.orientation_constraint_tolerances,
+            parameterization_orientation_path=1, # Rotation vector
+            keys_to_not_write_to_blackboard={
+                Blackboard.separator.join(
+                    [POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX, "position"],
+                ),
+            }
+        ).create_tree(move_to_target_pose_name, tree_root_name, logger, node).root
+
+        # Create the behaviour to turn face detection off
+        turn_face_detection_off_name = Blackboard.separator.join(
+            [name, turn_face_detection_off_prefix]
+        )
+        turn_face_detection_off_key_response = Blackboard.separator.join(
+            [turn_face_detection_off_name, "response"]
+        )
+        turn_face_detection_off = retry_call_ros_service(
+            name=turn_face_detection_off_name,
+            service_type=SetBool,
+            service_name=self.toggle_face_detection_service_name,
+            key_request=None,
+            request=SetBool.Request(data=False),
+            key_response = turn_face_detection_off_key_response,
+            response_check=py_trees.common.ComparisonExpression(
+                variable=turn_face_detection_off_key_response+".success",
+                value= True,
+                operator=operator.eq
+            ),
+            logger=logger,
+        )
+
+        # Link all the behaviours together in a sequence with memory
+        root = py_trees.composites.Sequence(
+            name=name,
+            memory=True,
+            children=[
+                turn_face_detection_on,
+                move_to_staging_configuration,
+                detect_face,
+                compute_target_position,
+                move_to_target_pose,
+                turn_face_detection_off,
+            ],
+        )
+        root.logger = logger
+
+        # raise Exception(py_trees.display.unicode_blackboard())
+
+        tree = py_trees.trees.BehaviourTree(root)
+        return tree

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -40,6 +40,10 @@ class MoveToMouthTree(MoveToTree):
     A behaviour tree that moves the robot to a specified configuration.
     """
 
+    # pylint: disable=too-many-instance-attributes, too-many-arguments
+    # Bite transfer is a big part of the robot's behavior, so it makes
+    # sense that it has lots of attributes/arguments.
+
     def __init__(
         self,
         staging_configuration: List[float],
@@ -129,6 +133,11 @@ class MoveToMouthTree(MoveToTree):
         -------
         tree: The behaviour tree that moves the robot above the plate.
         """
+        # pylint: disable=too-many-locals
+        # This function creates all the behaviors of the tree, which is why
+        # it has so many locals.
+        # TODO: consider separating each behavior into its own function to simplify this.
+
         # Separate the namespace of each sub-behavior
         turn_face_detection_on_prefix = "turn_face_detection_on"
         pre_moveto_config_prefix = "pre_moveto_config"

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -231,7 +231,7 @@ class MoveToMouthTree(MoveToTree):
         # has the fork facing in the +y direction of the base line (towards the
         # back of the wheelchair), but eventually this should be variable
         # based on the `target_position_offset`, so the fork is always facing
-        # the mouth. We also add an orientation path constraint (e.g., to keep 
+        # the mouth. We also add an orientation path constraint (e.g., to keep
         # the fork straight).
         move_to_target_pose_name = Blackboard.separator.join(
             [name, move_to_target_pose_prefix]

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -133,9 +133,9 @@ class MoveToMouthTree(MoveToTree):
         -------
         tree: The behaviour tree that moves the robot above the plate.
         """
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals, too-many-statements
         # This function creates all the behaviors of the tree, which is why
-        # it has so many locals.
+        # it has so many locals/statements.
         # TODO: consider separating each behavior into its own function to simplify this.
 
         # Separate the namespace of each sub-behavior
@@ -427,7 +427,9 @@ class MoveToMouthTree(MoveToTree):
                 move_to_mouth,
                 # Even though we are cleaning up the tree, it should still
                 # pass the failure up.
-                py_trees.decorators.SuccessIsFailure(name+" Cleanup", turn_face_detection_off),
+                py_trees.decorators.SuccessIsFailure(
+                    name + " Cleanup", turn_face_detection_off
+                ),
             ],
         )
         root.logger = logger

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -46,8 +46,6 @@ class MoveToMouthTree(MoveToTree):
         planner_id: str = "RRTstarkConfigDefault",
         allowed_planning_time_to_staging_configuration: float = 0.5,
         allowed_planning_time_to_mouth: float = 0.5,
-        toggle_face_detection_service_name: str = "/toggle_face_detection",
-        face_detection_topic_name: str = "/face_detection",
         head_object_id: str = "head",
         force_threshold: float = 4.0,
         torque_threshold: float = 4.0,
@@ -71,10 +69,6 @@ class MoveToMouthTree(MoveToTree):
             time for the MoveIt2 motion planner to move to the staging config.
         allowed_planning_time_to_mouth: The allowed planning time for the MoveIt2
             motion planner to move to the user's mouth.
-        toggle_face_detection_service_name: The name of the service to toggle
-            face detection on and off.
-        face_detection_topic_name: The name of the topic that publishes the
-            face detection results.
         head_object_id: The ID of the head collision object in the MoveIt2
             planning scene.
         force_threshold: The force threshold (N) for the ForceGateController.
@@ -99,8 +93,6 @@ class MoveToMouthTree(MoveToTree):
             allowed_planning_time_to_staging_configuration
         )
         self.allowed_planning_time_to_mouth = allowed_planning_time_to_mouth
-        self.toggle_face_detection_service_name = toggle_face_detection_service_name
-        self.face_detection_topic_name = face_detection_topic_name
         self.head_object_id = head_object_id
         self.force_threshold = force_threshold
         self.torque_threshold = torque_threshold
@@ -149,7 +141,7 @@ class MoveToMouthTree(MoveToTree):
         turn_face_detection_on = retry_call_ros_service(
             name=turn_face_detection_on_name,
             service_type=SetBool,
-            service_name=self.toggle_face_detection_service_name,
+            service_name="~/toggle_face_detection",
             key_request=None,
             request=SetBool.Request(data=True),
             key_response=turn_face_detection_on_key_response,
@@ -203,7 +195,7 @@ class MoveToMouthTree(MoveToTree):
         get_face_name = Blackboard.separator.join([name, get_face_prefix])
         get_face = py_trees_ros.subscribers.ToBlackboard(
             name=get_face_name,
-            topic_name=self.face_detection_topic_name,
+            topic_name="~/face_detection",
             topic_type=FaceDetection,
             qos_profile=py_trees_ros.utilities.qos_profile_unlatched(),
             blackboard_variables={
@@ -339,7 +331,7 @@ class MoveToMouthTree(MoveToTree):
         turn_face_detection_off = retry_call_ros_service(
             name=turn_face_detection_off_name,
             service_type=SetBool,
-            service_name=self.toggle_face_detection_service_name,
+            service_name="~/toggle_face_detection",
             key_request=None,
             request=SetBool.Request(data=False),
             key_response=turn_face_detection_off_key_response,

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -24,6 +24,7 @@ from ada_feeding.helpers import (
     POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX,
     ORIENTATION_GOAL_CONSTRAINT_NAMESPACE_PREFIX,
     MOVE_TO_NAMESPACE_PREFIX,
+    set_to_blackboard,
 )
 from ada_feeding.trees import MoveToTree
 
@@ -41,7 +42,8 @@ class MoveToPoseTree(MoveToTree):
     # pylint: disable=too-many-instance-attributes, too-many-arguments
     # Many arguments is fine for this class since it has to be able to configure all parameters
     # of its constraints.
-
+    # pylint: disable=dangerous-default-value
+    # A mutable default value is okay since we don't change it in this function.
     def __init__(
         self,
         position: Optional[Tuple[float, float, float]] = None,
@@ -233,42 +235,91 @@ class MoveToPoseTree(MoveToTree):
 
         # Write the inputs to MoveToPose to blackboard
         if self.position is not None:
-            if position_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(position_key, self.position)
-            if position_frame_id_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(position_frame_id_key, self.frame_id)
-            if position_target_link_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(position_target_link_key, self.target_link)
-            if position_tolerance_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(position_tolerance_key, self.tolerance_position)
-            if position_weight_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(position_weight_key, self.weight_position)
+            set_to_blackboard(
+                self.blackboard,
+                position_key,
+                self.position,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                position_frame_id_key,
+                self.frame_id,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                position_target_link_key,
+                self.target_link,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                position_tolerance_key,
+                self.tolerance_position,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                position_weight_key,
+                self.weight_position,
+                self.keys_to_not_write_to_blackboard,
+            )
         if self.quat_xyzw is not None:
-            if orientation_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(orientation_key, self.quat_xyzw)
-            if orientation_frame_id_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(orientation_frame_id_key, self.frame_id)
-            if orientation_target_link_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(orientation_target_link_key, self.target_link)
-            if orientation_tolerance_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(
-                    orientation_tolerance_key, self.tolerance_orientation
-                )
-            if (
-                orientation_parameterization_key
-                not in self.keys_to_not_write_to_blackboard
-            ):
-                self.blackboard.set(
-                    orientation_parameterization_key, self.parameterization
-                )
-            if orientation_weight_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(orientation_weight_key, self.weight_orientation)
-        if cartesian_key not in self.keys_to_not_write_to_blackboard:
-            self.blackboard.set(cartesian_key, self.cartesian)
-        if planner_id_key not in self.keys_to_not_write_to_blackboard:
-            self.blackboard.set(planner_id_key, self.planner_id)
-        if allowed_planning_time_key not in self.keys_to_not_write_to_blackboard:
-            self.blackboard.set(allowed_planning_time_key, self.allowed_planning_time)
+            set_to_blackboard(
+                self.blackboard,
+                orientation_key,
+                self.quat_xyzw,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                orientation_frame_id_key,
+                self.frame_id,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                orientation_target_link_key,
+                self.target_link,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                orientation_tolerance_key,
+                self.tolerance_orientation,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                orientation_parameterization_key,
+                self.parameterization,
+                self.keys_to_not_write_to_blackboard,
+            )
+            set_to_blackboard(
+                self.blackboard,
+                orientation_weight_key,
+                self.weight_orientation,
+                self.keys_to_not_write_to_blackboard,
+            )
+        set_to_blackboard(
+            self.blackboard,
+            cartesian_key,
+            self.cartesian,
+            self.keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            self.blackboard,
+            planner_id_key,
+            self.planner_id,
+            self.keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            self.blackboard,
+            allowed_planning_time_key,
+            self.allowed_planning_time,
+            self.keys_to_not_write_to_blackboard,
+        )
 
         # Create the MoveTo behavior
         move_to_name = Blackboard.separator.join([name, move_to_namespace_prefix])

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -129,9 +129,13 @@ class MoveToPoseTree(MoveToTree):
         """
         # Separate blackboard namespaces for children
         if self.position is not None:
-            position_goal_constraint_namespace_prefix = POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX
+            position_goal_constraint_namespace_prefix = (
+                POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX
+            )
         if self.quat_xyzw is not None:
-            orientation_goal_constraint_namespace_prefix = ORIENTATION_GOAL_CONSTRAINT_NAMESPACE_PREFIX
+            orientation_goal_constraint_namespace_prefix = (
+                ORIENTATION_GOAL_CONSTRAINT_NAMESPACE_PREFIX
+            )
         move_to_namespace_prefix = MOVE_TO_NAMESPACE_PREFIX
 
         # Position constraints
@@ -197,7 +201,8 @@ class MoveToPoseTree(MoveToTree):
                 [orientation_goal_constraint_namespace_prefix, "parameterization"]
             )
             self.blackboard.register_key(
-                key=orientation_parameterization_key, access=py_trees.common.Access.WRITE
+                key=orientation_parameterization_key,
+                access=py_trees.common.Access.WRITE,
             )
             orientation_weight_key = Blackboard.separator.join(
                 [orientation_goal_constraint_namespace_prefix, "weight"]
@@ -246,9 +251,16 @@ class MoveToPoseTree(MoveToTree):
             if orientation_target_link_key not in self.keys_to_not_write_to_blackboard:
                 self.blackboard.set(orientation_target_link_key, self.target_link)
             if orientation_tolerance_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(orientation_tolerance_key, self.tolerance_orientation)
-            if orientation_parameterization_key not in self.keys_to_not_write_to_blackboard:
-                self.blackboard.set(orientation_parameterization_key, self.parameterization)
+                self.blackboard.set(
+                    orientation_tolerance_key, self.tolerance_orientation
+                )
+            if (
+                orientation_parameterization_key
+                not in self.keys_to_not_write_to_blackboard
+            ):
+                self.blackboard.set(
+                    orientation_parameterization_key, self.parameterization
+                )
             if orientation_weight_key not in self.keys_to_not_write_to_blackboard:
                 self.blackboard.set(orientation_weight_key, self.weight_orientation)
         if cartesian_key not in self.keys_to_not_write_to_blackboard:

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -7,7 +7,7 @@ wrap that behavior tree in a ROS2 action server.
 
 # Standard imports
 import logging
-from typing import Optional, Tuple, Union
+from typing import Optional, Set, Tuple, Union
 
 # Third-party imports
 import py_trees
@@ -19,6 +19,11 @@ from ada_feeding.behaviors import MoveTo
 from ada_feeding.decorators import (
     SetPositionGoalConstraint,
     SetOrientationGoalConstraint,
+)
+from ada_feeding.helpers import (
+    POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX,
+    ORIENTATION_GOAL_CONSTRAINT_NAMESPACE_PREFIX,
+    MOVE_TO_NAMESPACE_PREFIX,
 )
 from ada_feeding.trees import MoveToTree
 
@@ -39,8 +44,8 @@ class MoveToPoseTree(MoveToTree):
 
     def __init__(
         self,
-        position: Tuple[float, float, float],
-        quat_xyzw: Tuple[float, float, float, float],
+        position: Optional[Tuple[float, float, float]] = None,
+        quat_xyzw: Optional[Tuple[float, float, float, float]] = None,
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance_position: float = 0.001,
@@ -51,6 +56,7 @@ class MoveToPoseTree(MoveToTree):
         cartesian: bool = False,
         planner_id: str = "RRTstarkConfigDefault",
         allowed_planning_time: float = 0.5,
+        keys_to_not_write_to_blackboard: Set[str] = set(),
     ):
         """
         Initializes tree-specific parameters.
@@ -71,6 +77,10 @@ class MoveToPoseTree(MoveToTree):
         cartesian: whether to use cartesian path planning.
         planner_id: the planner to use for path planning.
         allowed_planning_time: the allowed planning time for path planning.
+        keys_to_not_write_to_blackboard: the keys to not write to the blackboard.
+            Note that the keys need to be exact e.g., "move_to.cartesian,"
+            "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
+            etc.
         """
         # Initialize MoveTo
         super().__init__()
@@ -88,6 +98,7 @@ class MoveToPoseTree(MoveToTree):
         self.cartesian = cartesian
         self.planner_id = planner_id
         self.allowed_planning_time = allowed_planning_time
+        self.keys_to_not_write_to_blackboard = keys_to_not_write_to_blackboard
 
     # pylint: disable=too-many-locals, too-many-statements
     # Unfortunately, many locals/statements are required here to isolate the keys
@@ -95,6 +106,7 @@ class MoveToPoseTree(MoveToTree):
     def create_move_to_tree(
         self,
         name: str,
+        tree_root_name: str,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -104,6 +116,9 @@ class MoveToPoseTree(MoveToTree):
         Parameters
         ----------
         name: The name of the behavior tree.
+        tree_root_name: The name of the tree. This is necessary because sometimes
+            trees create subtrees, but still need to track the top-level tree
+            name to read/write the correct blackboard variables.
         logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
@@ -113,79 +128,83 @@ class MoveToPoseTree(MoveToTree):
         tree: The behavior tree that moves the robot above the plate.
         """
         # Separate blackboard namespaces for children
-        position_constraint_namespace_prefix = "position_goal_constraint"
-        orientation_constraint_namespace_prefix = "orientation_goal_constraint"
-        move_to_namespace_prefix = "move_to"
+        if self.position is not None:
+            position_goal_constraint_namespace_prefix = POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX
+        if self.quat_xyzw is not None:
+            orientation_goal_constraint_namespace_prefix = ORIENTATION_GOAL_CONSTRAINT_NAMESPACE_PREFIX
+        move_to_namespace_prefix = MOVE_TO_NAMESPACE_PREFIX
 
         # Position constraints
-        position_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "position"]
-        )
-        self.blackboard.register_key(
-            key=position_key, access=py_trees.common.Access.WRITE
-        )
-        position_frame_id_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "frame_id"]
-        )
-        self.blackboard.register_key(
-            key=position_frame_id_key, access=py_trees.common.Access.WRITE
-        )
-        position_target_link_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "target_link"]
-        )
-        self.blackboard.register_key(
-            key=position_target_link_key, access=py_trees.common.Access.WRITE
-        )
-        position_tolerance_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "tolerance"]
-        )
-        self.blackboard.register_key(
-            key=position_tolerance_key, access=py_trees.common.Access.WRITE
-        )
-        position_weight_key = Blackboard.separator.join(
-            [position_constraint_namespace_prefix, "weight"]
-        )
-        self.blackboard.register_key(
-            key=position_weight_key, access=py_trees.common.Access.WRITE
-        )
+        if self.position is not None:
+            position_key = Blackboard.separator.join(
+                [position_goal_constraint_namespace_prefix, "position"]
+            )
+            self.blackboard.register_key(
+                key=position_key, access=py_trees.common.Access.WRITE
+            )
+            position_frame_id_key = Blackboard.separator.join(
+                [position_goal_constraint_namespace_prefix, "frame_id"]
+            )
+            self.blackboard.register_key(
+                key=position_frame_id_key, access=py_trees.common.Access.WRITE
+            )
+            position_target_link_key = Blackboard.separator.join(
+                [position_goal_constraint_namespace_prefix, "target_link"]
+            )
+            self.blackboard.register_key(
+                key=position_target_link_key, access=py_trees.common.Access.WRITE
+            )
+            position_tolerance_key = Blackboard.separator.join(
+                [position_goal_constraint_namespace_prefix, "tolerance"]
+            )
+            self.blackboard.register_key(
+                key=position_tolerance_key, access=py_trees.common.Access.WRITE
+            )
+            position_weight_key = Blackboard.separator.join(
+                [position_goal_constraint_namespace_prefix, "weight"]
+            )
+            self.blackboard.register_key(
+                key=position_weight_key, access=py_trees.common.Access.WRITE
+            )
 
         # Orientation constraints
-        orientation_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "quat_xyzw"]
-        )
-        self.blackboard.register_key(
-            key=orientation_key, access=py_trees.common.Access.WRITE
-        )
-        orientation_frame_id_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "frame_id"]
-        )
-        self.blackboard.register_key(
-            key=orientation_frame_id_key, access=py_trees.common.Access.WRITE
-        )
-        orientation_target_link_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "target_link"]
-        )
-        self.blackboard.register_key(
-            key=orientation_target_link_key, access=py_trees.common.Access.WRITE
-        )
-        orientation_tolerance_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "tolerance"]
-        )
-        self.blackboard.register_key(
-            key=orientation_tolerance_key, access=py_trees.common.Access.WRITE
-        )
-        orientation_parameterization_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "parameterization"]
-        )
-        self.blackboard.register_key(
-            key=orientation_parameterization_key, access=py_trees.common.Access.WRITE
-        )
-        orientation_weight_key = Blackboard.separator.join(
-            [orientation_constraint_namespace_prefix, "weight"]
-        )
-        self.blackboard.register_key(
-            key=orientation_weight_key, access=py_trees.common.Access.WRITE
-        )
+        if self.quat_xyzw is not None:
+            orientation_key = Blackboard.separator.join(
+                [orientation_goal_constraint_namespace_prefix, "quat_xyzw"]
+            )
+            self.blackboard.register_key(
+                key=orientation_key, access=py_trees.common.Access.WRITE
+            )
+            orientation_frame_id_key = Blackboard.separator.join(
+                [orientation_goal_constraint_namespace_prefix, "frame_id"]
+            )
+            self.blackboard.register_key(
+                key=orientation_frame_id_key, access=py_trees.common.Access.WRITE
+            )
+            orientation_target_link_key = Blackboard.separator.join(
+                [orientation_goal_constraint_namespace_prefix, "target_link"]
+            )
+            self.blackboard.register_key(
+                key=orientation_target_link_key, access=py_trees.common.Access.WRITE
+            )
+            orientation_tolerance_key = Blackboard.separator.join(
+                [orientation_goal_constraint_namespace_prefix, "tolerance"]
+            )
+            self.blackboard.register_key(
+                key=orientation_tolerance_key, access=py_trees.common.Access.WRITE
+            )
+            orientation_parameterization_key = Blackboard.separator.join(
+                [orientation_goal_constraint_namespace_prefix, "parameterization"]
+            )
+            self.blackboard.register_key(
+                key=orientation_parameterization_key, access=py_trees.common.Access.WRITE
+            )
+            orientation_weight_key = Blackboard.separator.join(
+                [orientation_goal_constraint_namespace_prefix, "weight"]
+            )
+            self.blackboard.register_key(
+                key=orientation_weight_key, access=py_trees.common.Access.WRITE
+            )
 
         # MoveTo inputs
         cartesian_key = Blackboard.separator.join(
@@ -208,43 +227,65 @@ class MoveToPoseTree(MoveToTree):
         )
 
         # Write the inputs to MoveToPose to blackboard
-        self.blackboard.set(position_key, self.position)
-        self.blackboard.set(position_frame_id_key, self.frame_id)
-        self.blackboard.set(position_target_link_key, self.target_link)
-        self.blackboard.set(position_tolerance_key, self.tolerance_position)
-        self.blackboard.set(position_weight_key, self.weight_position)
-        self.blackboard.set(orientation_key, self.quat_xyzw)
-        self.blackboard.set(orientation_frame_id_key, self.frame_id)
-        self.blackboard.set(orientation_target_link_key, self.target_link)
-        self.blackboard.set(orientation_tolerance_key, self.tolerance_orientation)
-        self.blackboard.set(orientation_parameterization_key, self.parameterization)
-        self.blackboard.set(orientation_weight_key, self.weight_orientation)
-        self.blackboard.set(cartesian_key, self.cartesian)
-        self.blackboard.set(planner_id_key, self.planner_id)
-        self.blackboard.set(allowed_planning_time_key, self.allowed_planning_time)
+        if self.position is not None:
+            if position_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(position_key, self.position)
+            if position_frame_id_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(position_frame_id_key, self.frame_id)
+            if position_target_link_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(position_target_link_key, self.target_link)
+            if position_tolerance_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(position_tolerance_key, self.tolerance_position)
+            if position_weight_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(position_weight_key, self.weight_position)
+        if self.quat_xyzw is not None:
+            if orientation_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(orientation_key, self.quat_xyzw)
+            if orientation_frame_id_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(orientation_frame_id_key, self.frame_id)
+            if orientation_target_link_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(orientation_target_link_key, self.target_link)
+            if orientation_tolerance_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(orientation_tolerance_key, self.tolerance_orientation)
+            if orientation_parameterization_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(orientation_parameterization_key, self.parameterization)
+            if orientation_weight_key not in self.keys_to_not_write_to_blackboard:
+                self.blackboard.set(orientation_weight_key, self.weight_orientation)
+        if cartesian_key not in self.keys_to_not_write_to_blackboard:
+            self.blackboard.set(cartesian_key, self.cartesian)
+        if planner_id_key not in self.keys_to_not_write_to_blackboard:
+            self.blackboard.set(planner_id_key, self.planner_id)
+        if allowed_planning_time_key not in self.keys_to_not_write_to_blackboard:
+            self.blackboard.set(allowed_planning_time_key, self.allowed_planning_time)
 
         # Create the MoveTo behavior
         move_to_name = Blackboard.separator.join([name, move_to_namespace_prefix])
-        move_to = MoveTo(move_to_name, name, node)
+        move_to = MoveTo(move_to_name, tree_root_name, node)
         move_to.logger = logger
 
         # Add the position goal constraint to the MoveTo behavior
-        position_goal_constaint_name = Blackboard.separator.join(
-            [name, position_constraint_namespace_prefix]
-        )
-        position_constraint = SetPositionGoalConstraint(
-            position_goal_constaint_name, move_to
-        )
-        position_constraint.logger = logger
+        if self.position is not None:
+            position_goal_constaint_name = Blackboard.separator.join(
+                [name, position_goal_constraint_namespace_prefix]
+            )
+            position_constraint = SetPositionGoalConstraint(
+                position_goal_constaint_name, move_to
+            )
+            position_constraint.logger = logger
+        else:
+            position_constraint = move_to
 
         # Add the orientation goal constraint to the MoveTo behavior
-        orientation_goal_constaint_name = Blackboard.separator.join(
-            [name, orientation_constraint_namespace_prefix]
-        )
-        root = SetOrientationGoalConstraint(
-            orientation_goal_constaint_name, position_constraint
-        )
-        root.logger = logger
+        if self.quat_xyzw is not None:
+            orientation_goal_constaint_name = Blackboard.separator.join(
+                [name, orientation_goal_constraint_namespace_prefix]
+            )
+            root = SetOrientationGoalConstraint(
+                orientation_goal_constaint_name, position_constraint
+            )
+            root.logger = logger
+        else:
+            root = position_constraint
 
         tree = py_trees.trees.BehaviourTree(root)
         return tree

--- a/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
@@ -32,7 +32,8 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
     # pylint: disable=too-many-instance-attributes, too-many-arguments, too-many-locals
     # Many arguments is fine for this class since it has to be able to configure all parameters
     # of its constraints.
-
+    # pylint: disable=dangerous-default-value
+    # A mutable default value is okay since we don't change it in this function.
     def __init__(
         self,
         # Required parameters for moving to a pose

--- a/ada_feeding/ada_feeding/trees/move_to_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_tree.py
@@ -81,7 +81,9 @@ class MoveToTree(ActionServerBT, ABC):
             name=name + " Tree", namespace=tree_root_name
         )
         # Goal that is passed from the ROS2 Action Server
-        self.blackboard_tree_root.register_key(key="goal", access=py_trees.common.Access.WRITE)
+        self.blackboard_tree_root.register_key(
+            key="goal", access=py_trees.common.Access.WRITE
+        )
         # Feedback from MoveToConfiguration for the ROS2 Action Server
         self.blackboard_tree_root.register_key(
             key="is_planning", access=py_trees.common.Access.READ
@@ -191,7 +193,9 @@ class MoveToTree(ActionServerBT, ABC):
                 feedback_msg.motion_initial_distance = (
                     self.blackboard_tree_root.motion_initial_distance
                 )
-                feedback_msg.motion_curr_distance = self.blackboard_tree_root.motion_curr_distance
+                feedback_msg.motion_curr_distance = (
+                    self.blackboard_tree_root.motion_curr_distance
+                )
         return feedback_msg
 
     def get_result(self, tree: py_trees.trees.BehaviourTree) -> object:

--- a/ada_feeding/ada_feeding/trees/move_to_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_tree.py
@@ -169,17 +169,12 @@ class MoveToTree(ActionServerBT, ABC):
         -------
         feedback: The ROS feedback message to be sent to the action client.
         """
-<<<<<<< HEAD
         feedback_msg = self.action_type.Feedback()
         if self.blackboard.exists("is_planning"):
             feedback_msg.is_planning = self.blackboard.is_planning
             planning_time = self.blackboard.planning_time
-=======
-        feedback_msg = self.action_type_class.Feedback()
-        if self.blackboard_tree_root.exists("is_planning"):
             feedback_msg.is_planning = self.blackboard_tree_root.is_planning
             planning_time = self.blackboard_tree_root.planning_time
->>>>>>> 679292a ([WIP] MoveToMouth mostly done)
             feedback_msg.planning_time.sec = int(planning_time)
             feedback_msg.planning_time.nanosec = int(
                 (planning_time - int(planning_time)) * 1e9

--- a/ada_feeding/ada_feeding/trees/move_to_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_tree.py
@@ -174,9 +174,9 @@ class MoveToTree(ActionServerBT, ABC):
         feedback: The ROS feedback message to be sent to the action client.
         """
         feedback_msg = self.action_type.Feedback()
-        if self.blackboard.exists("is_planning"):
-            feedback_msg.is_planning = self.blackboard.is_planning
-            planning_time = self.blackboard.planning_time
+        if self.blackboard_tree_root.exists("is_planning"):
+            feedback_msg.is_planning = self.blackboard_tree_root.is_planning
+            planning_time = self.blackboard_tree_root.planning_time
             feedback_msg.is_planning = self.blackboard_tree_root.is_planning
             planning_time = self.blackboard_tree_root.planning_time
             feedback_msg.planning_time.sec = int(planning_time)

--- a/ada_feeding/ada_feeding/trees/move_to_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_tree.py
@@ -57,6 +57,10 @@ class MoveToTree(ActionServerBT, ABC):
         -------
         tree: The behavior tree that moves the robot above the plate.
         """
+
+        # pylint: disable=too-many-arguments
+        # One over is fine for this function.
+
         self.create_blackboard(name, tree_root_name)
 
         # Import the action type

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -74,7 +74,7 @@ ada_feeding_action_servers:
         - staging_configuration
         - orientation_constraint_quaternion
         - orientation_constraint_tolerances
-        - allowed_planning_time
+        - allowed_planning_time_to_staging_configuration
       tree_kwargs: # optional
         staging_configuration:
           -  2.74709 # j2n6s200_joint_1
@@ -92,7 +92,7 @@ ada_feeding_action_servers:
           - 0.6 # x, rad
           - 3.14159 # y, rad
           - 0.5 # z, rad
-        allowed_planning_time: 1.0 # secs
+        allowed_planning_time_to_staging_configuration: 1.0 # secs
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the MoveToStowLocation action

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -69,35 +69,29 @@ ada_feeding_action_servers:
     # implemented.
     MoveToMouth: # required
       action_type: ada_feeding_msgs.action.MoveTo # required
-      tree_class: ada_feeding.trees.MoveToConfigurationWithPosePathConstraintsTree # required
+      tree_class: ada_feeding.trees.MoveToMouthTree # required
       tree_kws: # optional
-        - joint_positions_goal
-        - weight_joint_goal
-        - quat_xyzw_path
-        - tolerance_orientation_path
-        - parameterization_orientation_path
-        - weight_orientation_path
+        - staging_configuration
+        - orientation_constraint_quaternion
+        - orientation_constraint_tolerances
         - allowed_planning_time
       tree_kwargs: # optional
-        joint_positions_goal:
+        staging_configuration:
           -  2.74709 # j2n6s200_joint_1
           -  2.01400 # j2n6s200_joint_2
           -  1.85257 # j2n6s200_joint_3
           - -2.83523 # j2n6s200_joint_4
           - -1.61925 # j2n6s200_joint_5
           - -2.67325 # j2n6s200_joint_6
-        weight_joint_goal: 1.0
-        quat_xyzw_path: # perpendicular to the base link
+        orientation_constraint_quaternion: # perpendicular to the base link
           - 0.707168 # x
           - 0.0 # y
           - 0.0 # z
           - 0.707168 # w
-        tolerance_orientation_path: # Note that tolerances are w.r.t. the axes in quat_xyzw_path
+        orientation_constraint_tolerances: # Note that tolerances are w.r.t. the axes in quat_xyzw_path
           - 0.6 # x, rad
           - 3.14159 # y, rad
           - 0.5 # z, rad
-        parameterization_orientation_path: 1 # 0: Euler, 1: Rotation Vector
-        weight_orientation_path: 1.0
         allowed_planning_time: 1.0 # secs
       tick_rate: 10 # Hz, optional, default: 30
 

--- a/ada_feeding/config/ada_planning_scene.yaml
+++ b/ada_feeding/config/ada_planning_scene.yaml
@@ -3,7 +3,7 @@ ada_planning_scene:
   ros__parameters:
     object_ids: # list of objects to add to the planning scene
       - wheelchair
-      - wheelchair_collision
+      # - wheelchair_collision
       - table
       - head
     # For each object, specify the filename of the mesh, and the position and

--- a/ada_feeding/config/ada_planning_scene.yaml
+++ b/ada_feeding/config/ada_planning_scene.yaml
@@ -3,7 +3,7 @@ ada_planning_scene:
   ros__parameters:
     object_ids: # list of objects to add to the planning scene
       - wheelchair
-      # - wheelchair_collision
+      - wheelchair_collision
       - table
       - head
     # For each object, specify the filename of the mesh, and the position and

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -21,6 +21,8 @@
     <remap from="~/toggle_watchdog_listener" to="/ada_watchdog_listener/toggle_watchdog_listener" />
     <remap from="~/re_tare_ft" to="/wireless_ft/set_bias" />
     <remap from="~/set_force_gate_controller_parameters" to="/jaco_arm_controller/set_parameters" />
+    <remap from="~/toggle_face_detection" to="/toggle_face_detection" />
+    <remap from="~/face_detection" to="/face_detection" />
   </node>
 
   <!-- Populate the planning scene -->

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -15,7 +15,7 @@
   </node>
 
   <!-- Launch the action servers necessary to move the robot -->
-  <node pkg="ada_feeding" exec="create_action_servers.py" name="ada_feeding_action_servers">
+  <node pkg="ada_feeding" exec="create_action_servers.py" name="ada_feeding_action_servers" respawn="true">
     <param from="$(find-pkg-share ada_feeding)/config/ada_feeding_action_servers.yaml"/>
     <remap from="~/watchdog" to="/ada_watchdog/watchdog" />
     <remap from="~/toggle_watchdog_listener" to="/ada_watchdog_listener/toggle_watchdog_listener" />

--- a/ada_feeding/package.xml
+++ b/ada_feeding/package.xml
@@ -19,7 +19,7 @@
   <exec_depend>moveit_msgs</exec_depend>
   <exec_depend>pymoveit2</exec_depend>
 
-  <depend>std_srvs</depend>
+  <exec_depend>std_srvs</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ada_feeding/package.xml
+++ b/ada_feeding/package.xml
@@ -19,6 +19,8 @@
   <exec_depend>moveit_msgs</exec_depend>
   <exec_depend>pymoveit2</exec_depend>
 
+  <depend>std_srvs</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -340,9 +340,13 @@ class CreateActionServers(Node):
         # Initialize the ActionServerBT object once
         tree_action_server = self._tree_classes[tree_class](**tree_kwargs)
         # Create the tree once
+<<<<<<< HEAD
         tree = tree_action_server.create_tree(
             server_name, action_type, self.get_logger(), self
         )
+=======
+        tree = tree_action_server.create_tree(server_name, server_name, self.get_logger(), self)
+>>>>>>> 679292a ([WIP] MoveToMouth mostly done)
 
         async def execute_callback(goal_handle: ServerGoalHandle) -> Awaitable:
             """

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -436,7 +436,7 @@ class CreateActionServers(Node):
                     f"Error running tree: \n{traceback.format_exc()}\n{exc}"
                 )
                 goal_handle.abort()
-                result = self._action_types[action_type].Result()
+                result = action_type.Result()
 
             # Unset the goal and return the result
             with self.active_goal_request_lock:

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -408,7 +408,10 @@ class CreateActionServers(Node):
                             result = tree_action_server.get_result(tree)
                             break
                         if tree.root.status in set(
-                            (py_trees.common.Status.FAILURE, py_trees.common.Status.INVALID)
+                            (
+                                py_trees.common.Status.FAILURE,
+                                py_trees.common.Status.INVALID,
+                            )
                         ):
                             self.get_logger().info("Goal failed")
                             goal_handle.abort()

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -387,7 +387,7 @@ class CreateActionServers(Node):
 
                         # Check if the watchdog has failed
                         if not self.watchdog_listener.ok():
-                            self.get_logger().info("Watchdog failed, aborting goal")
+                            self.get_logger().warn("Watchdog failed, aborting goal")
                             tree_action_server.preempt_goal(
                                 tree
                             )  # blocks until the preempt succeeds
@@ -399,7 +399,7 @@ class CreateActionServers(Node):
                         tree.tick()
                         feedback_msg = tree_action_server.get_feedback(tree)
                         goal_handle.publish_feedback(feedback_msg)
-                        self.get_logger().info(f"Publishing feedback {feedback_msg}")
+                        self.get_logger().debug(f"Publishing feedback {feedback_msg}")
 
                         # Check the tree status
                         if tree.root.status == py_trees.common.Status.SUCCESS:

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -363,7 +363,7 @@ class CreateActionServers(Node):
             # All exceptions need printing at shutdown
             try:
                 # Setup the behavior tree class
-                tree.setup()  # TODO: consider adding a timeout here
+                tree.setup(node=self)  # TODO: consider adding a timeout here
 
                 # Send the goal to the behavior tree
                 tree_action_server.send_goal(tree, goal_handle.request)

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -340,13 +340,9 @@ class CreateActionServers(Node):
         # Initialize the ActionServerBT object once
         tree_action_server = self._tree_classes[tree_class](**tree_kwargs)
         # Create the tree once
-<<<<<<< HEAD
         tree = tree_action_server.create_tree(
-            server_name, action_type, self.get_logger(), self
+            server_name, action_type, server_name, self.get_logger(), self
         )
-=======
-        tree = tree_action_server.create_tree(server_name, server_name, self.get_logger(), self)
->>>>>>> 679292a ([WIP] MoveToMouth mostly done)
 
         async def execute_callback(goal_handle: ServerGoalHandle) -> Awaitable:
             """
@@ -363,79 +359,81 @@ class CreateActionServers(Node):
                 f"with request {goal_handle.request}"
             )
 
-            # Setup the behavior tree class
-            tree.setup(node=self)  # TODO: consider adding a timeout here
-
-            # Send the goal to the behavior tree
-            tree_action_server.send_goal(tree, goal_handle.request)
-
-            # Execute the behavior tree
-            rate = self.create_rate(tick_rate)
-            result = None
-            try:
-                while rclpy.ok():
-                    # Check if the goal has been canceled
-                    if goal_handle.is_cancel_requested:
-                        # Note that the body of this conditional may be called
-                        # multiple times until the preemption is complete.
-                        self.get_logger().info("Goal canceled")
-                        tree_action_server.preempt_goal(
-                            tree
-                        )  # blocks until the preempt succeeds
-                        goal_handle.canceled()
-                        result = tree_action_server.get_result(tree)
-                        break
-
-                    # Check if the watchdog has failed
-                    if not self.watchdog_listener.ok():
-                        self.get_logger().info("Watchdog failed, aborting goal")
-                        tree_action_server.preempt_goal(
-                            tree
-                        )  # blocks until the preempt succeeds
-                        goal_handle.abort()
-                        result = tree_action_server.get_result(tree)
-                        break
-
-                    # Tick the tree once and publish feedback
-                    tree.tick()
-                    feedback_msg = tree_action_server.get_feedback(tree)
-                    goal_handle.publish_feedback(feedback_msg)
-                    self.get_logger().info(f"Publishing feedback {feedback_msg}")
-
-                    # Check the tree status
-                    if tree.root.status == py_trees.common.Status.SUCCESS:
-                        self.get_logger().info("Goal succeeded")
-                        goal_handle.succeed()
-                        result = tree_action_server.get_result(tree)
-                        break
-                    if tree.root.status in set(
-                        (py_trees.common.Status.FAILURE, py_trees.common.Status.INVALID)
-                    ):
-                        self.get_logger().info("Goal failed")
-                        goal_handle.abort()
-                        result = tree_action_server.get_result(tree)
-                        break
-
-                    # Sleep
-                    rate.sleep()
-            except KeyboardInterrupt:
-                pass
-
-            # If we have gotten here without a result, that means something
-            # went wrong. Abort the goal.
-            if result is None:
-                goal_handle.abort()
-                result = action_type.Result()
-
-            # Shutdown the tree
             # pylint: disable=broad-exception-caught
             # All exceptions need printing at shutdown
             try:
+                # Setup the behavior tree class
+                tree.setup()  # TODO: consider adding a timeout here
+
+                # Send the goal to the behavior tree
+                tree_action_server.send_goal(tree, goal_handle.request)
+
+                # Execute the behavior tree
+                rate = self.create_rate(tick_rate)
+                result = None
+                try:
+                    while rclpy.ok():
+                        # Check if the goal has been canceled
+                        if goal_handle.is_cancel_requested:
+                            # Note that the body of this conditional may be called
+                            # multiple times until the preemption is complete.
+                            self.get_logger().info("Goal canceled")
+                            tree_action_server.preempt_goal(
+                                tree
+                            )  # blocks until the preempt succeeds
+                            goal_handle.canceled()
+                            result = tree_action_server.get_result(tree)
+                            break
+
+                        # Check if the watchdog has failed
+                        if not self.watchdog_listener.ok():
+                            self.get_logger().info("Watchdog failed, aborting goal")
+                            tree_action_server.preempt_goal(
+                                tree
+                            )  # blocks until the preempt succeeds
+                            goal_handle.abort()
+                            result = tree_action_server.get_result(tree)
+                            break
+
+                        # Tick the tree once and publish feedback
+                        tree.tick()
+                        feedback_msg = tree_action_server.get_feedback(tree)
+                        goal_handle.publish_feedback(feedback_msg)
+                        self.get_logger().info(f"Publishing feedback {feedback_msg}")
+
+                        # Check the tree status
+                        if tree.root.status == py_trees.common.Status.SUCCESS:
+                            self.get_logger().info("Goal succeeded")
+                            goal_handle.succeed()
+                            result = tree_action_server.get_result(tree)
+                            break
+                        if tree.root.status in set(
+                            (py_trees.common.Status.FAILURE, py_trees.common.Status.INVALID)
+                        ):
+                            self.get_logger().info("Goal failed")
+                            goal_handle.abort()
+                            result = tree_action_server.get_result(tree)
+                            break
+
+                        # Sleep
+                        rate.sleep()
+                except KeyboardInterrupt:
+                    pass
+
+                # If we have gotten here without a result, that means something
+                # went wrong. Abort the goal.
+                if result is None:
+                    goal_handle.abort()
+                    result = action_type.Result()
+
+                # Shutdown the tree
                 tree.shutdown()
             except Exception as exc:
                 self.get_logger().error(
-                    f"Error shutting down tree: \n{traceback.format_exc()}\n{exc}"
+                    f"Error running tree: \n{traceback.format_exc()}\n{exc}"
                 )
+                goal_handle.abort()
+                result = self._action_types[action_type].Result()
 
             # Unset the goal and return the result
             with self.active_goal_request_lock:

--- a/ada_feeding_perception/README.md
+++ b/ada_feeding_perception/README.md
@@ -19,7 +19,7 @@ For testing, be sure to unzip `test/food_img.zip`.
 
 1. Build your workspace: `colcon build`
 2. Source your workspace: `source install/setup.bash`
-3. Run the action servers: `ros2 launch ada_feeding_perception ada_feeding_perception_launch.xml`
+3. Run the perception nodes: `ros2 launch ada_feeding_perception ada_feeding_perception_launch.xml`
 4. Launch the motion nodes:
     1. Dummy nodes: `ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml run_real_sense:=false run_face_detection:=false run_food_detection:=false`
     2. Real nodes: `ros2 launch ada_feeding ada_feeding_launch.xml`


### PR DESCRIPTION
# Description

This PR implements the MVP MoveToMouth. Specifically, it implements a py_tree that:
1. Toggles on face detection.
2. Moves the arm to the side-staging location (move to configuration with orientation path constraints to keep the fork straight).
3. Waits for a face to be detected.
4. Moves the face mesh in the planning scene to the detected mouth center position.
5. Computes the pose goal for the robot to move towards from the detected mouth center.
6. Moves the robot to that pose, with the orientation path constraint to keep the fork straight.
7. Toggles off face detection.

In order to implement this, this PR also makes the following changes to existing behaviors, decorators, and trees:
1. Change permissions on the feedback for the action from `EXCLUSIVE_WRITE` to `WRITE` to account for the fact that one tree may have multiple move_to actions.
    1. Note that the feedback may render poorly on the app to have multiple "thinking/moving" progress bars. We may need to come up with another way of rendering progress for actions with multiple robot motions.
2. Adds a `tree_root_name` parameter to every `MoveToTree`, because we were ended up with trees with multiple nested namespaces for behaviors, but the `MoveTo` behaviors must write to the top-level tree namespace in order for it to be read. Therefore, each tree's `name` parameter can be as nested as one wants, but the `tree_root_name` parameter must be the same.
3. Adds an optional `keys_to_not_write_to_blackboard` set to every MoveToTree, to allow us to specify certain keys that should not be hardcoded into the blackboard when initializing the tree, and will instead be written to the blackboard by another behavior.
4. Improves error handling:
    1. Allows `create_action_servers.py` to not crash when there are arbitrary exceptions in the trees.
    2. Allow `move_to` to deal with the scenario where a call to MoveIt finishes before a second tick of the tree.

# Testing procedure

Pull the latest code in [pymoveit2 branch `amaln/allowed_collision_matrix`](https://github.com/personalrobotics/pymoveit2/tree/amaln/allowed_collision_matrix).

As of now, this PR has only been tested in sim, with dummy face detection (waiting on #36 ). **Before merging, it must be tested on the real robot, with actual face detection**.

## Initialization
1. Ensure you are on the right branch of each of the dependencies and have the latest code. [PRL fork of pymoveit (branch: `amaln/allowed_collision_matrix`)](https://github.com/personalrobotics/pymoveit2), [PRL fork of py_trees_ros (branch: `amaln/service_client`)](https://github.com/personalrobotics/py_trees_ros/tree/amaln/service_client), and [feeding_web_interface (branch: `main`)](https://github.com/personalrobotics/feeding_web_interface).
2. Build your workspace: `colcon build`
3. Run the code.
    1. Sim
        1. Launch the F/T Sensor: `ros2 run ada_feeding dummy_ft_sensor.py`
        2. Launch the Dummy RealSense Node: `ros2 run feeding_web_app_ros2_test DummyRealSense`
        3. Launch Dummy FaceDetection: `ros2 run feeding_web_app_ros2_test FaceDetection`
        4. Launch the feeding nodes: `ros2 launch ada_feeding ada_feeding_launch.xml`
        5. Launch MoveIt: `ros2 launch ada_moveit demo_feeding.launch.py sim:=mock`
    2. Real Robot
        1. Launch the F/T Sensor: `ros2 run forque_sensor_hardware forque_sensor_hardware --ros-args -p host:=xxx.xxx.x.xx` (replace the x's with the correct IP)
        2. Launch the RealSense: See [the README in `ada_feeding_perception`](https://github.com/personalrobotics/ada_feeding/tree/ros2-devel/ada_feeding_perception)
        3. Launch Face Detection: `ros2 launch ada_feeding_perception ada_feeding_perception_launch.xml`
        4. Launch the feeding nodes: `ros2 launch ada_feeding ada_feeding_launch.xml`
        5. Launch MoveIt: `ros2 launch ada_moveit demo_feeding.launch.py`

## Testing
Reset the robot to the resting position: `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback` (you must do this every time before calling `MoveToMouth`). Then call the `MoveToMouth` action: `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveTo "{}" --feedback`. Verify the following, in both sim and real.

- [x] It successfully runs the completion. This includes that it:
    - [x] Toggles on face detection.
    - [x] Moves the arm to the side-staging location.
    - [x] Waits for a face to be detected.
    - [x] Moves the face mesh in the planning scene to the detected mouth center position.
    - [x] Moves the robot to in front of the mouth.
    - [x] Toggles off face detection.
    - [x] Throughout all motions, the fork is kept mostly straight.
- [ ] You can terminate it at any of the above stages and it terminates cleanly.
    - [ ] Toggles on face detection.
    - [ ] Moves the arm to the side-staging location.
    - [ ] Waits for a face to be detected.
    - [ ] Moves the face mesh in the planning scene to the detected mouth center position.
    - [ ] Moves the robot to in front of the mouth.
    - [ ] Toggles off face detection.
    - [ ] Throughout all motions, the fork is kept mostly straight.

# Future Work
Currently, on the final approach to the user's mouth, the robot moves to a position 5cm away from their detected mouth center in the y direction of the base link (perpendicular to the wheelchair back), and an orientation within 0.5 radians of pointing straight at the wheelchair back. However:
1. Ideally, the fork should be perpendicular to the user's face, not to the wheelchair back. So if their face/mouth is rotated, the fork should also rotate accordingly (this requires FaceDetection perceiving the orientation of the user's face).
2. The fork should not be restricted to moving to a single point 5 cm in front of the user's mouth. Rather, it should be able to move anywhere that distance away from the mouth, within a range of angles (think in terms of spherical coordiantes centered on the mouth). In order to do this, we need to add many options for goal constraints to the MoveIt planning call. 

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address (most) warnings/errors: `pylint --recursive=y .`

# Before Merging
- [ ] `Squash & Merge`
