### PR TITLE
ROS launch topic remapping and action_type param

### DIFF
--- a/ada_feeding/ada_feeding/action_server_bt.py
+++ b/ada_feeding/ada_feeding/action_server_bt.py
@@ -24,6 +24,7 @@ class ActionServerBT(ABC):
     def create_tree(
         self,
         name: str,
+        action_type: str,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -35,6 +36,9 @@ class ActionServerBT(ABC):
         Parameters
         ----------
         name: The name of the behavior tree.
+        action_type: full name of a Python class for the associated action, 
+            can be converted to a type object with `import_from_string` in
+            helpers.py
         logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.

--- a/ada_feeding/ada_feeding/action_server_bt.py
+++ b/ada_feeding/ada_feeding/action_server_bt.py
@@ -36,7 +36,7 @@ class ActionServerBT(ABC):
         Parameters
         ----------
         name: The name of the behavior tree.
-        action_type: full name of a Python class for the associated action, 
+        action_type: full name of a Python class for the associated action,
             can be converted to a type object with `import_from_string` in
             helpers.py
         logger: The logger to use for the behavior tree.

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
@@ -27,7 +27,6 @@ class MoveToConfigurationTree(MoveToTree):
 
     def __init__(
         self,
-        action_type_class_str: str,
         joint_positions: List[float],
         tolerance: float = 0.001,
         weight: float = 1.0,
@@ -39,10 +38,6 @@ class MoveToConfigurationTree(MoveToTree):
 
         Parameters
         ----------
-        action_type_class_str: The type of action that this tree is implementing,
-            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
-            type can be anything, but the Feedback and Result must at a minimum
-            include the fields of ada_feeding_msgs.action.MoveTo
         joint_positions: The joint positions to move the robot arm to.
         tolerance: The tolerance for the joint positions.
         weight: The weight for the joint goal constraint.

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
@@ -27,7 +27,6 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
 
     def __init__(
         self,
-        action_type_class_str: str,
         # Required parameters for moving to a configuration
         joint_positions_goal: List[float],
         # Optional parameters for moving to a configuration
@@ -51,10 +50,6 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
 
         Parameters
         ----------
-        action_type_class_str: The type of action that this tree is implementing,
-            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
-            type can be anything, but the Feedback and Result must at a minimum
-            include the fields of ada_feeding_msgs.action.MoveTo
         joint_positions_goal: The joint positions for the goal constraint.
         tolerance_joint_goal: The tolerance for the joint goal constraint.
         weight_joint_goal: The weight for the joint goal constraint.
@@ -78,8 +73,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         weight_orientation_path: the weight for the end effector orientation path constraint.
         """
         # Initialize MoveToTree
-        self.action_type_class_str = action_type_class_str
-        super().__init__(action_type_class_str)
+        super().__init__()
 
         # Store the parameters for the joint goal constraint
         self.joint_positions_goal = joint_positions_goal
@@ -124,14 +118,13 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         # namespace as this tree
         move_to_configuration_root = (
             MoveToConfigurationTree(
-                action_type_class_str=self.action_type_class_str,
                 joint_positions=self.joint_positions_goal,
                 tolerance=self.tolerance_joint_goal,
                 weight=self.weight_joint_goal,
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
             )
-            .create_tree(name, logger, node)
+            .create_tree(name, self.action_type_class_str, logger, node)
             .root
         )
 

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -64,7 +64,7 @@ class MoveToDummyTree(ActionServerBT):
         Parameters
         ----------
         name: The name of the behavior tree.
-        action_type: full name of a Python class for the associated action, 
+        action_type: full name of a Python class for the associated action,
             can be converted to a type object with `import_from_string` in
             helpers.py
         logger: The logger to use for the behavior tree.

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -37,8 +37,7 @@ class MoveToDummyTree(ActionServerBT):
         dummy_plan_time: How many seconds this dummy node should spend in planning.
         dummy_motion_time: How many seconds this dummy node should spend in motion.
         """
-        self.action_type_class = None
-
+        
         # Set the dummy motion parameters
         self.dummy_plan_time = dummy_plan_time
         self.dummy_motion_time = dummy_motion_time

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -26,7 +26,6 @@ class MoveToDummyTree(ActionServerBT):
 
     def __init__(
         self,
-        action_type_class_str: str,
         dummy_plan_time: float = 2.5,
         dummy_motion_time: float = 7.5,
     ) -> None:
@@ -35,15 +34,10 @@ class MoveToDummyTree(ActionServerBT):
 
         Parameters
         ----------
-        action_type_class_str: The type of action that this tree is implementing,
-            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
-            type can be anything, but the Feedback and Result must at a minimum
-            include the fields of ada_feeding_msgs.action.MoveTo
         dummy_plan_time: How many seconds this dummy node should spend in planning.
         dummy_motion_time: How many seconds this dummy node should spend in motion.
         """
-        # Import the action type
-        self.action_type_class = import_from_string(action_type_class_str)
+        self.action_type_class = None
 
         # Set the dummy motion parameters
         self.dummy_plan_time = dummy_plan_time
@@ -56,6 +50,7 @@ class MoveToDummyTree(ActionServerBT):
     def create_tree(
         self,
         name: str,
+        action_type: str,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -69,6 +64,9 @@ class MoveToDummyTree(ActionServerBT):
         Parameters
         ----------
         name: The name of the behavior tree.
+        action_type: full name of a Python class for the associated action, 
+            can be converted to a type object with `import_from_string` in
+            helpers.py
         logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
@@ -77,6 +75,9 @@ class MoveToDummyTree(ActionServerBT):
         -------
         tree: The behavior tree that moves the robot above the plate.
         """
+        # Import the action type
+        self.action_type_class = import_from_string(action_type_class_str)
+
         # Create the behaviors in the tree
         if self.tree is None:
             root = MoveToDummy(name, self.dummy_plan_time, self.dummy_motion_time)

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -30,7 +30,6 @@ class MoveToPoseTree(MoveToTree):
 
     def __init__(
         self,
-        action_type_class_str: str,
         position: Tuple[float, float, float],
         quat_xyzw: Tuple[float, float, float, float],
         frame_id: Optional[str] = None,
@@ -49,10 +48,6 @@ class MoveToPoseTree(MoveToTree):
 
         Parameters
         ----------
-        action_type_class_str: The type of action that this tree is implementing,
-            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
-            type can be anything, but the Feedback and Result must at a minimum
-            include the fields of ada_feeding_msgs.action.MoveTo
         position: the target end effector position relative to the base link.
         quat_xyzw: the target end effector orientation relative to the base link.
         frame_id: the frame id of the target pose. If None, the base link is used.
@@ -69,7 +64,7 @@ class MoveToPoseTree(MoveToTree):
         allowed_planning_time: the allowed planning time for path planning.
         """
         # Initialize MoveTo
-        super().__init__(action_type_class_str)
+        super().__init__()
 
         # Store the parameters for the move to pose behavior
         self.position = position

--- a/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
@@ -26,7 +26,6 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
 
     def __init__(
         self,
-        action_type_class_str: str,
         # Required parameters for moving to a pose
         position_goal: Tuple[float, float, float],
         quat_xyzw_goal: Tuple[float, float, float, float],
@@ -57,10 +56,6 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
 
         Parameters
         ----------
-        action_type_class_str: The type of action that this tree is implementing,
-            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
-            type can be anything, but the Feedback and Result must at a minimum
-            include the fields of ada_feeding_msgs.action.MoveTo
         position_goal: the target position relative to frame_id.
         quat_xyzw_goal: the target orientation relative to frame_id.
         frame_id_goal: the frame id of the target pose. If None, the base link is used.
@@ -90,8 +85,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         weight_orientation_path: the weight for the orientation path.
         """
         # Initialize MoveToTree
-        self.action_type_class_str = action_type_class_str
-        super().__init__(action_type_class_str)
+        super().__init__()
 
         # Store the parameters for the move to pose behavior
         self.position_goal = position_goal
@@ -142,7 +136,6 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         # namespace as this tree
         move_to_pose_root = (
             MoveToPoseTree(
-                action_type_class_str=self.action_type_class_str,
                 position=self.position_goal,
                 quat_xyzw=self.quat_xyzw_goal,
                 frame_id=self.frame_id_goal,
@@ -156,7 +149,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
             )
-            .create_tree(name, logger, node)
+            .create_tree(name, self.action_type_class_str, logger, node)
             .root
         )
 

--- a/ada_feeding/ada_feeding/trees/move_to_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_tree.py
@@ -32,10 +32,10 @@ class MoveToTree(ActionServerBT, ABC):
     def __init__(
         self,
     ) -> None:
-        # Uninitialized attributes
-        self.action_type_class = None
-        self.action_type_class_str = ""
-        self.blackboard = None
+        """
+        Initializes tree-specific parameters.
+        """
+        pass
 
     def create_tree(
         self,

--- a/ada_feeding/ada_feeding/trees/move_to_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_tree.py
@@ -50,7 +50,7 @@ class MoveToTree(ActionServerBT, ABC):
         Parameters
         ----------
         name: The name of the behavior tree.
-        action_type: full name of a Python class for the associated action, 
+        action_type: full name of a Python class for the associated action,
             can be converted to a type object with `import_from_string` in
             helpers.py
         logger: The logger to use for the behavior tree.
@@ -62,7 +62,7 @@ class MoveToTree(ActionServerBT, ABC):
         tree: The behavior tree that moves the robot above the plate.
         """
         self.create_blackboard(name)
-        
+
         # Import the action type
         self.action_type_class = import_from_string(action_type_class_str)
         self.action_type_class_str = action_type_class_str

--- a/ada_feeding/ada_feeding/trees/move_to_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_tree.py
@@ -31,24 +31,16 @@ class MoveToTree(ActionServerBT, ABC):
 
     def __init__(
         self,
-        action_type_class_str: str,
     ) -> None:
-        """
-        Initializes tree-specific parameters.
-
-        Parameters
-        ----------
-        action_type_class_str: The type of action that this tree is implementing,
-            e.g., "ada_feeding_msgs.action.MoveTo". The input of this action
-            type can be anything, but the Feedback and Result must at a minimum
-            include the fields of ada_feeding_msgs.action.MoveTo
-        """
-        # Import the action type
-        self.action_type_class = import_from_string(action_type_class_str)
+        # Uninitialized attributes
+        self.action_type_class = None
+        self.action_type_class_str = ""
+        self.blackboard = None
 
     def create_tree(
         self,
         name: str,
+        action_type: str,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -58,6 +50,9 @@ class MoveToTree(ActionServerBT, ABC):
         Parameters
         ----------
         name: The name of the behavior tree.
+        action_type: full name of a Python class for the associated action, 
+            can be converted to a type object with `import_from_string` in
+            helpers.py
         logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
@@ -67,7 +62,12 @@ class MoveToTree(ActionServerBT, ABC):
         tree: The behavior tree that moves the robot above the plate.
         """
         self.create_blackboard(name)
-        return self.create_move_to_tree(name, logger, node)
+        
+        # Import the action type
+        self.action_type_class = import_from_string(action_type_class_str)
+        self.action_type_class_str = action_type_class_str
+
+        return self.create_move_to_tree(name, action_type_class_str, logger, node)
 
     def create_blackboard(self, name: str) -> None:
         """

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -1,9 +1,8 @@
 # NOTE: You have to change this node name if you change the node name in the launchfile.
 ada_feeding_action_servers:
   ros__parameters:
-    # Parameters to specify the watchdog topic and timeout
-    watchdog_topic: /ada_watchdog
-    watchdog_timeout_sec: 0.5 # If we haven't received a message from the watchdog in this time, stop all robot motions
+    # If we haven't received a message from the watchdog in this time, stop all robot motions
+    watchdog_timeout_sec: 0.5
 
     # A list of the names of the action servers to create. Each one must have
     # it's own parameters (below) specifying action_type and tree_class.
@@ -21,10 +20,8 @@ ada_feeding_action_servers:
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToConfigurationTree # required
       tree_kws: # optional
-        - action_type_class_str
         - joint_positions
       tree_kwargs: # optional
-        action_type_class_str: ada_feeding_msgs.action.MoveTo # required
         joint_positions: # required
           - -2.11666 # j2n6s200_joint_1
           -  3.34967 # j2n6s200_joint_2
@@ -39,11 +36,9 @@ ada_feeding_action_servers:
       action_type: ada_feeding_msgs.action.AcquireFood # required
       tree_class: ada_feeding.trees.MoveToDummyTree # required
       tree_kws: # optional
-        - action_type_class_str
         - dummy_plan_time
         - dummy_motion_time
       tree_kwargs: # optional
-        action_type_class_str: ada_feeding_msgs.action.AcquireFood # required
         dummy_plan_time: 1.0 # secs
         dummy_motion_time: 10.0 # secs
       tick_rate: 10 # Hz, optional, default: 30
@@ -53,10 +48,8 @@ ada_feeding_action_servers:
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToConfigurationTree # required
       tree_kws: # optional
-        - action_type_class_str
         - joint_positions
       tree_kwargs: # optional
-        action_type_class_str: ada_feeding_msgs.action.MoveTo # required
         joint_positions: # required
           - -1.94672 # j2n6s200_joint_1
           -  2.51268 # j2n6s200_joint_2
@@ -74,7 +67,6 @@ ada_feeding_action_servers:
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToConfigurationWithPosePathConstraintsTree # required
       tree_kws: # optional
-        - action_type_class_str
         - joint_positions_goal
         - weight_joint_goal
         - quat_xyzw_path
@@ -83,7 +75,6 @@ ada_feeding_action_servers:
         - weight_orientation_path
         - allowed_planning_time
       tree_kwargs: # optional
-        action_type_class_str: ada_feeding_msgs.action.MoveTo # required
         joint_positions_goal:
           -  2.74709 # j2n6s200_joint_1
           -  2.01400 # j2n6s200_joint_2
@@ -113,10 +104,8 @@ ada_feeding_action_servers:
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToConfigurationTree # required
       tree_kws: # optional
-        - action_type_class_str
         - joint_positions
       tree_kwargs: # optional
-        action_type_class_str: ada_feeding_msgs.action.MoveTo # required
         joint_positions: # required
           - -1.52101 # j2n6s200_joint_1
           -  2.60098 # j2n6s200_joint_2
@@ -131,11 +120,9 @@ ada_feeding_action_servers:
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToPoseTree # required
       tree_kws: # optional
-        - action_type_class_str
         - position
         - quat_xyzw
       tree_kwargs: # optional
-        action_type_class_str: ada_feeding_msgs.action.MoveTo # required
         position:
           -  0.27971 # x
           -  0.07175 # y
@@ -152,7 +139,6 @@ ada_feeding_action_servers:
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToPoseWithPosePathConstraintsTree # required
       tree_kws: # optional
-        - action_type_class_str
         - position_goal
         - quat_xyzw_goal
         - quat_xyzw_path
@@ -160,7 +146,6 @@ ada_feeding_action_servers:
         - parameterization_orientation_path
         - weight_orientation_path
       tree_kwargs: # optional
-        action_type_class_str: ada_feeding_msgs.action.MoveTo # required
         position_goal:
           - -0.00070 # x
           -  0.15619 # y

--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -1,13 +1,9 @@
 # NOTE: You have to change this node name if you change the node name in the launchfile.
 ada_watchdog:
   ros__parameters:
-    # The topic to subscribe to for force-torque messages, of type geometry_msgs/WrenchStamped
-    ft_topic: /wireless_ft/ftSensor1
     # If the force_torque sensor has not published a message in this amount of time,
     # or any of its dimensions are zero-variance in this amount of time, the watchdog 
     # will trigger a fault.
     ft_timeout_sec: 0.5
-    # The topic to publish to for the watchdog, of type diagnostic_msgs/DiagnosticStatus
-    watchdog_topc: /ada_watchdog
     # The rate at which to publish the watchdog message
     publish_rate_hz: 60.0

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -11,11 +11,13 @@
   <!-- Launch the watchdog -->
   <node pkg="ada_feeding" exec="ada_watchdog.py" name="ada_watchdog">
     <param from="$(find-pkg-share ada_feeding)/config/ada_watchdog.yaml"/>
+    <remap from="~/ft_topic" to="/wireless_ft/ftSensor1" />
   </node>
 
   <!-- Launch the action servers necessary to move the robot -->
   <node pkg="ada_feeding" exec="create_action_servers.py" name="ada_feeding_action_servers">
     <param from="$(find-pkg-share ada_feeding)/config/ada_feeding_action_servers.yaml"/>
+    <remap from="~/watchdog" to="/ada_watchdog/watchdog" />
   </node>
 
   <!-- Populate the planning scene -->

--- a/ada_feeding/scripts/ada_planning_scene.py
+++ b/ada_feeding/scripts/ada_planning_scene.py
@@ -64,7 +64,10 @@ class ADAPlanningScene(Node):
             descriptor=ParameterDescriptor(
                 name="assets_dir",
                 type=ParameterType.PARAMETER_STRING,
-                description="The absolute path to the directory to find the assets (e.g., STL mesh files).",
+                description=(
+                    "The absolute path to the directory to find the assets "
+                    "(e.g., STL mesh files)."
+                ),
                 read_only=True,
             ),
         )
@@ -84,32 +87,32 @@ class ADAPlanningScene(Node):
         # Read the object parameters
         for object_id in object_ids.value:
             filename = self.declare_parameter(
-                "%s.filename" % object_id,
+                f"{object_id}.filename",
                 descriptor=ParameterDescriptor(
                     name="filename",
                     type=ParameterType.PARAMETER_STRING,
-                    description="The filename of the mesh for the '%s' object."
-                    % object_id,
+                    description=f"The filename of the mesh for the '{object_id}' object.",
                     read_only=True,
                 ),
             )
             position = self.declare_parameter(
-                "%s.position" % object_id,
+                f"{object_id}.position",
                 descriptor=ParameterDescriptor(
                     name="position",
                     type=ParameterType.PARAMETER_DOUBLE_ARRAY,
-                    description="The position of the '%s' object in the planning scene."
-                    % object_id,
+                    description=f"The position of the '{object_id}' object in the planning scene.",
                     read_only=True,
                 ),
             )
             quat_xyzw = self.declare_parameter(
-                "%s.quat_xyzw" % object_id,
+                f"{object_id}.quat_xyzw",
                 descriptor=ParameterDescriptor(
                     name="quat_xyzw",
                     type=ParameterType.PARAMETER_DOUBLE_ARRAY,
-                    description="The orientation of the '%s' object in the planning scene."
-                    % object_id,
+                    description=(
+                        f"The orientation of the '{object_id}'"
+                        " object in the planning scene."
+                    ),
                     read_only=True,
                 ),
             )

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -120,6 +120,9 @@ class ADAWatchdog(Node):
     output to the watchdog topic.
     """
 
+    # pylint: disable=too-many-instance-attributes
+    # Eleven is fine in this case.
+
     def __init__(self) -> None:
         """
         Initialize the watchdog node.
@@ -143,8 +146,8 @@ class ADAWatchdog(Node):
         self.recv_first_ft_msg = False
         self.ft_sensor_condition_lock = Lock()
         ft_sensor_ok_message = (
-            "Over the last %f sec, the force-torque sensor has published data with nonzero variance"
-            % self.ft_timeout_sec.value
+            f"Over the last {self.ft_timeout_sec.value} sec, "
+            "the force-torque sensor has published data with nonzero variance"
         )
         self.ft_ok_status = DiagnosticStatus(
             level=DiagnosticStatus.OK,
@@ -152,8 +155,8 @@ class ADAWatchdog(Node):
             message=ft_sensor_ok_message,
         )
         ft_sensor_error_message = (
-            "Over the last %f sec, the force-torque sensor has either not published data or its data is zero-variance"
-            % self.ft_timeout_sec.value
+            f"Over the last {self.ft_timeout_sec.value} sec, the force-torque sensor"
+            "has either not published data or its data is zero-variance"
         )
         self.ft_error_status = DiagnosticStatus(
             level=DiagnosticStatus.ERROR,
@@ -188,7 +191,11 @@ class ADAWatchdog(Node):
             ParameterDescriptor(
                 name="ft_timeout_sec",
                 type=ParameterType.PARAMETER_DOUBLE,
-                description="The number of seconds within which the force-torque sensor must have: (a) published messages; and (b) had them be nonzero-variance",
+                description=(
+                    "The number of seconds within which the force-torque"
+                    "sensor must have: (a) published messages; and (b) had"
+                    "them be nonzero-variance"
+                ),
                 read_only=True,
             ),
         )

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -117,7 +117,7 @@ class ADAWatchdog(Node):
     """
     A watchdog node for the ADA robot. This node monitors the state of the
     force-torque sensor and the physical e-stop button (TODO), and publishes its
-    output to the /ada_watchdog topic.
+    output to the watchdog topic.
     """
 
     def __init__(self) -> None:
@@ -132,7 +132,7 @@ class ADAWatchdog(Node):
         # Create a watchdog publisher
         self.watchdog_publisher = self.create_publisher(
             DiagnosticArray,
-            self.watchdog_topic.value,
+            "~/watchdog",
             1,
         )
 
@@ -148,7 +148,7 @@ class ADAWatchdog(Node):
         )
         self.ft_ok_status = DiagnosticStatus(
             level=DiagnosticStatus.OK,
-            name=self.ft_topic.value,
+            name="~/ft_topic",
             message=ft_sensor_ok_message,
         )
         ft_sensor_error_message = (
@@ -157,7 +157,7 @@ class ADAWatchdog(Node):
         )
         self.ft_error_status = DiagnosticStatus(
             level=DiagnosticStatus.ERROR,
-            name=self.ft_topic.value,
+            name="~/ft_topic",
             message=ft_sensor_error_message,
         )
 
@@ -167,7 +167,7 @@ class ADAWatchdog(Node):
         # Subscribe to the force-torque sensor topic
         self.ft_sensor_subscription = self.create_subscription(
             WrenchStamped,
-            self.ft_topic.value,
+            "~/ft_topic",
             self.ft_sensor_callback,
             rclpy.qos.QoSPresetProfiles.SENSOR_DATA.value,
         )
@@ -182,16 +182,6 @@ class ADAWatchdog(Node):
         """
         Load parameters from the parameter server.
         """
-        self.ft_topic = self.declare_parameter(
-            "ft_topic",
-            "/wireless_ft/ftSensor1",
-            ParameterDescriptor(
-                name="ft_topic",
-                type=ParameterType.PARAMETER_STRING,
-                description="The name of topic that the force-torque sensor is publishing on",
-                read_only=True,
-            ),
-        )
         self.ft_timeout_sec = self.declare_parameter(
             "ft_timeout_sec",
             0.5,
@@ -199,16 +189,6 @@ class ADAWatchdog(Node):
                 name="ft_timeout_sec",
                 type=ParameterType.PARAMETER_DOUBLE,
                 description="The number of seconds within which the force-torque sensor must have: (a) published messages; and (b) had them be nonzero-variance",
-                read_only=True,
-            ),
-        )
-        self.watchdog_topic = self.declare_parameter(
-            "watchdog_topic",
-            "/ada_watchdog",
-            ParameterDescriptor(
-                name="watchdog_topic",
-                type=ParameterType.PARAMETER_STRING,
-                description="The name of the topic for the watchdog to publish on",
                 read_only=True,
             ),
         )

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -350,7 +350,9 @@ class CreateActionServers(Node):
         # Initialize the ActionServerBT object once
         tree_action_server = self._tree_classes[tree_class](**tree_kwargs)
         # Create the tree once
-        tree = tree_action_server.create_tree(server_name, action_type, self.get_logger(), self)
+        tree = tree_action_server.create_tree(
+            server_name, action_type, self.get_logger(), self
+        )
 
         async def execute_callback(goal_handle: ServerGoalHandle) -> Awaitable:
             """

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -76,7 +76,7 @@ class CreateActionServers(Node):
         super().__init__("create_action_servers")
 
         # Read the parameters that specify what action servers to create.
-        watchdog_topic, watchdog_timeout, action_server_params = self.read_params()
+        watchdog_timeout, action_server_params = self.read_params()
 
         # Subscribe to the watchdog topic
         self.watchdog_failed = (
@@ -85,7 +85,7 @@ class CreateActionServers(Node):
         self.last_watchdog_msg_time = None
         self.watchdog_sub = self.create_subscription(
             DiagnosticArray,
-            watchdog_topic.value,
+            "~/watchdog",
             self.watchdog_callback,
             1,
         )
@@ -106,17 +106,7 @@ class CreateActionServers(Node):
         -------
         action_server_params: A list of ActionServerParams objects.
         """
-        # Read the watchdog parameters
-        watchdog_topic = self.declare_parameter(
-            "watchdog_topic",
-            "/ada_watchdog",
-            ParameterDescriptor(
-                name="watchdog_topic",
-                type=ParameterType.PARAMETER_STRING,
-                description="The topic on which the watchdog publishes.",
-                read_only=True,
-            ),
-        )
+        # Read the watchdog timeout
         watchdog_timeout = self.declare_parameter(
             "watchdog_timeout",
             0.5,
@@ -220,7 +210,7 @@ class CreateActionServers(Node):
                 )
             )
 
-        return watchdog_topic, watchdog_timeout, action_server_params
+        return watchdog_timeout, action_server_params
 
     def watchdog_callback(self, msg: DiagnosticArray) -> None:
         """
@@ -360,7 +350,7 @@ class CreateActionServers(Node):
         # Initialize the ActionServerBT object once
         tree_action_server = self._tree_classes[tree_class](**tree_kwargs)
         # Create the tree once
-        tree = tree_action_server.create_tree(server_name, self.get_logger(), self)
+        tree = tree_action_server.create_tree(server_name, action_type, self.get_logger(), self)
 
         async def execute_callback(goal_handle: ServerGoalHandle) -> Awaitable:
             """

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -7,7 +7,7 @@ that wrap behavior trees.
 # Standard imports
 import threading
 import traceback
-from typing import Any, Awaitable, Callable, Dict, List, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 # Third-party imports
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
@@ -32,12 +32,15 @@ class ActionServerParams:
     A class to hold the parameters of an action server that wraps a behavior tree.
     """
 
+    # pylint: disable=too-many-arguments, too-few-public-methods, too-many-instance-attributes
+    # This is a data class
+
     def __init__(
         self,
         server_name: List[str],
         action_type: str,
         tree_class: str,
-        tree_kwargs: Dict[str, Any] = {},
+        tree_kwargs: Optional[Dict[str, Any]] = None,
         tick_rate: int = 30,
     ) -> None:
         """
@@ -47,6 +50,8 @@ class ActionServerParams:
         self.action_type = action_type
         self.tree_class = tree_class
         self.tree_kwargs = tree_kwargs
+        if tree_kwargs is None:
+            tree_kwargs = {}
         self.tick_rate = tick_rate
 
 
@@ -65,6 +70,9 @@ class CreateActionServers(Node):
     only execute one motion at once, all other action servers must reject
     incoming goal requests.
     """
+
+    # pylint: disable=too-many-instance-attributes
+    # Nine is fine if we are keeping watchdog functionality within the base Node
 
     def __init__(self) -> None:
         """
@@ -113,7 +121,10 @@ class CreateActionServers(Node):
             ParameterDescriptor(
                 name="watchdog_timeout",
                 type=ParameterType.PARAMETER_DOUBLE,
-                description="The maximum time (s) that the watchdog can go without publishing before the watchdog fails.",
+                description=(
+                    "The maximum time (s) that the watchdog can go without "
+                    "publishing before the watchdog fails."
+                ),
                 read_only=True,
             ),
         )
@@ -124,7 +135,10 @@ class CreateActionServers(Node):
             descriptor=ParameterDescriptor(
                 name="server_names",
                 type=ParameterType.PARAMETER_STRING_ARRAY,
-                description="List of action server names to create. All names must correspond to their own param namespace within this node.",
+                description=(
+                    "List of action server names to create. "
+                    "All names must correspond to their own param namespace within this node."
+                ),
                 read_only=True,
             ),
         )
@@ -137,50 +151,62 @@ class CreateActionServers(Node):
                 "",
                 [
                     (
-                        "%s.action_type" % server_name,
+                        f"{server_name}.action_type",
                         None,
                         ParameterDescriptor(
                             name="action_type",
                             type=ParameterType.PARAMETER_STRING,
-                            description="The type of action server to create. E.g., ada_feeding_msgs.action.MoveTo",
+                            description=(
+                                "The type of action server to create. "
+                                "E.g., ada_feeding_msgs.action.MoveTo"
+                            ),
                             read_only=True,
                         ),
                     ),
                     (
-                        "%s.tree_class" % server_name,
+                        f"{server_name}.tree_class",
                         None,
                         ParameterDescriptor(
                             name="tree_class",
                             type=ParameterType.PARAMETER_STRING,
-                            description="The class of the behavior tree to run, must subclass ActionServerBT. E.g., ada_feeding.behaviors.MoveTo",
+                            description=(
+                                "The class of the behavior tree to run, must "
+                                "subclass ActionServerBT. E.g., ada_feeding.behaviors.MoveTo"
+                            ),
                             read_only=True,
                         ),
                     ),
                     (
-                        "%s.tick_rate" % server_name,
+                        f"{server_name}.tick_rate",
                         30,
                         ParameterDescriptor(
                             name="tick_rate",
                             type=ParameterType.PARAMETER_INTEGER,
-                            description="The rate at which the behavior tree should be ticked, in Hz.",
+                            description=(
+                                "The rate at which the behavior tree should be "
+                                "ticked, in Hz."
+                            ),
                             read_only=True,
                         ),
                     ),
                 ],
             )
             tree_kws = self.declare_parameter(
-                "%s.tree_kws" % server_name,
+                f"{server_name}.tree_kws",
                 descriptor=ParameterDescriptor(
                     name="tree_kws",
                     type=ParameterType.PARAMETER_STRING_ARRAY,
-                    description="List of keywords for custom arguments to be passed to the behavior tree during initialization.",
+                    description=(
+                        "List of keywords for custom arguments to be passed "
+                        "to the behavior tree during initialization."
+                    ),
                     read_only=True,
                 ),
             )
             if tree_kws.value is not None:
                 tree_kwargs = {
                     kw: self.declare_parameter(
-                        "%s.tree_kwargs.%s" % (server_name, kw),
+                        f"{server_name}.tree_kwargs.{kw}",
                         descriptor=ParameterDescriptor(
                             name=kw,
                             description="Custom keyword argument for the behavior tree.",
@@ -195,8 +221,8 @@ class CreateActionServers(Node):
 
             if action_type.value is None or tree_class.value is None:
                 self.get_logger().warn(
-                    "Skipping action server %s because it has no action type or tree class"
-                    % server_name
+                    f"Skipping action server {server_name} "
+                    "because it has no action type or tree class"
                 )
                 continue
 
@@ -261,8 +287,7 @@ class CreateActionServers(Node):
         self._tree_classes = {}
         for params in action_server_params:
             self.get_logger().info(
-                "Creating action server %s with type %s"
-                % (params.server_name, params.action_type)
+                f"Creating action server {params.server_name} with type {params.action_type}"
             )
 
             # Import the action type
@@ -277,10 +302,10 @@ class CreateActionServers(Node):
             try:
                 assert issubclass(
                     self._tree_classes[params.tree_class], ActionServerBT
-                ), ("Tree %s must subclass ActionServerBT" % params.tree_class)
-            except Exception:
+                ), f"Tree {params.tree_class} must subclass ActionServerBT"
+            except AssertionError:
                 self.get_logger().warn(
-                    "%s\nSKIPPING THIS ACTION SERVER" % (traceback.format_exc())
+                    f"{traceback.format_exc()}\nSKIPPING THIS ACTION SERVER"
                 )
 
             # Create the action server.
@@ -333,6 +358,8 @@ class CreateActionServers(Node):
         self.get_logger().info("Received cancel request, accepting")
         return CancelResponse.ACCEPT
 
+    # pylint: disable=too-many-arguments
+    # This is appropriate
     def get_execute_callback(
         self,
         server_name: str,
@@ -362,13 +389,11 @@ class CreateActionServers(Node):
             periodic feedback.
             """
 
+            goal_uuid = "".join(format(x, "02x") for x in goal_handle.goal_id.uuid)
             self.get_logger().info(
-                "%s: Executing goal %s with request %s"
-                % (
-                    server_name,
-                    "".join(format(x, "02x") for x in goal_handle.goal_id.uuid),
-                    goal_handle.request,
-                )
+                f"{server_name}: "
+                f"Executing goal {goal_uuid} "
+                f"with request {goal_handle.request}"
             )
 
             # Setup the behavior tree class
@@ -408,7 +433,7 @@ class CreateActionServers(Node):
                     tree.tick()
                     feedback_msg = tree_action_server.get_feedback(tree)
                     goal_handle.publish_feedback(feedback_msg)
-                    self.get_logger().info("Publishing feedback %s" % feedback_msg)
+                    self.get_logger().info(f"Publishing feedback {feedback_msg}")
 
                     # Check the tree status
                     if tree.root.status == py_trees.common.Status.SUCCESS:
@@ -436,11 +461,13 @@ class CreateActionServers(Node):
                 result = self._action_types[action_type].Result()
 
             # Shutdown the tree
+            # pylint: disable=broad-exception-caught
+            # All exceptions need printing at shutdown
             try:
                 tree.shutdown()
             except Exception as exc:
                 self.get_logger().error(
-                    "Error shutting down tree: \n%s\n%s" % (traceback.format_exc(), exc)
+                    f"Error shutting down tree: \n{traceback.format_exc()}\n{exc}"
                 )
 
             # Unset the goal and return the result
@@ -462,6 +489,8 @@ def main(args: List = None) -> None:
     # Use a MultiThreadedExecutor to enable processing goals concurrently
     executor = MultiThreadedExecutor()
 
+    # pylint: disable=broad-exception-caught
+    # All exceptions need printing at shutdown
     try:
         rclpy.spin(create_action_servers, executor=executor)
     except Exception:

--- a/ada_feeding/scripts/dummy_ft_sensor.py
+++ b/ada_feeding/scripts/dummy_ft_sensor.py
@@ -11,8 +11,10 @@ Usage:
 - Run the node: `ros2 run ada_feeding dummy_ft_sensor`
 - Subscribe to the sensor data: `ros2 topic echo /wireless_ft/ftSensor1`
 - Turn the sensor off: `ros2 param set /dummy_ft_sensor is_on False`
-- Start publishing zero-variance data: `ros2 param set /dummy_ft_sensor std [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]`
-- Start publishing data where one dimension is zero-variance: `ros2 param set /dummy_ft_sensor std [0.0, 0.1, 0.1, 0.1, 0.1, 0.1]`
+- Start publishing zero-variance data: 
+    `ros2 param set /dummy_ft_sensor std [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]`
+- Start publishing data where one dimension is zero-variance:
+    `ros2 param set /dummy_ft_sensor std [0.0, 0.1, 0.1, 0.1, 0.1, 0.1]`
 """
 
 # Third-party imports


### PR DESCRIPTION
# Description

This PR does some linting / cleanup, replaces the topic-in-rosparam antipattern with topic remapping in the ROS launch file, and passes action_type to `create_tree` as every single tree pretty much requires it. It removes a redundant param in the YAML.

# Testing procedure

[TODO: test on my end, but this should not have changed any functionality, so all previous tests are valid]

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address (most) warnings/errors: `pylint --recursive=y .`

# Before Merging
- [ ] `Squash & Merge`
