### PR TITLE
Complete Linting Cleanup

### DIFF
--- a/ada_feeding/ada_feeding/action_server_bt.py
+++ b/ada_feeding/ada_feeding/action_server_bt.py
@@ -24,7 +24,7 @@ class ActionServerBT(ABC):
     def create_tree(
         self,
         name: str,
-        action_type: str,
+        action_type: type,
         logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
@@ -36,9 +36,7 @@ class ActionServerBT(ABC):
         Parameters
         ----------
         name: The name of the behavior tree.
-        action_type: full name of a Python class for the associated action,
-            can be converted to a type object with `import_from_string` in
-            helpers.py
+        action_type: the type for the action, as a class
         logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
@@ -79,13 +77,13 @@ class ActionServerBT(ABC):
         -------
         success: Whether the goal was successfully preempted.
         """
+        # pylint: disable=broad-exception-caught
+        # All exceptions need printing when stopping a tree
         try:
             tree.root.stop(py_trees.common.Status.INVALID)
             return True
         except Exception:
-            tree.root.logger.warn(
-                "Failed to preempt goal \n%s" % traceback.format_exc()
-            )
+            tree.root.logger.warn(f"Failed to preempt goal \n{traceback.format_exc()}")
             return False
 
     @abstractmethod

--- a/ada_feeding/ada_feeding/decorators/__init__.py
+++ b/ada_feeding/ada_feeding/decorators/__init__.py
@@ -1,6 +1,12 @@
 """
 This package contains custom py_tree decorators for the Ada Feeding project.
 """
+
+# pylint: disable=cyclic-import
+# We import all of the decorators here so that they can be imported as
+# ada_feeding.decorators.<decorators_name> instead of
+# ada_feeding.decorators.<decorators_file>.<decorators_name>
+
 # Parent class for all decorators that add constraints
 from .move_to_constraint import MoveToConstraint
 

--- a/ada_feeding/ada_feeding/decorators/move_to_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/move_to_constraint.py
@@ -40,8 +40,8 @@ class MoveToConstraint(py_trees.decorators.Decorator, ABC):
         # Check the child behavior type
         if not isinstance(child, (MoveTo, MoveToConstraint)):
             raise TypeError(
-                "%s [MoveToConstraint::__init__()] Child must be of type MoveTo or MoveToConstraint!"
-                % name
+                f"{name} [MoveToConstraint::__init__()] Child must be of "
+                "type MoveTo or MoveToConstraint!"
             )
 
         # Initiatilize the decorator
@@ -58,7 +58,7 @@ class MoveToConstraint(py_trees.decorators.Decorator, ABC):
         """
         Set the constraints before the child behavior starts executing.
         """
-        self.logger.info("%s [MoveToConstraint::initialise()]" % self.name)
+        self.logger.info(f"{self.name} [MoveToConstraint::initialise()]")
 
         # Set the constraint
         self.set_constraint()
@@ -84,8 +84,7 @@ class MoveToConstraint(py_trees.decorators.Decorator, ABC):
         Clear the constraints.
         """
         self.logger.info(
-            "%s [MoveToConstraint::terminate()][%s->%s]"
-            % (self.name, self.status, new_status)
+            f"{self.name} [MoveToConstraint::terminate()][{self.status}->{new_status}]"
         )
 
         # Clear the constraints

--- a/ada_feeding/ada_feeding/decorators/set_joint_goal_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_joint_goal_constraint.py
@@ -11,6 +11,10 @@ import py_trees
 from ada_feeding.decorators import MoveToConstraint
 from ada_feeding.helpers import get_from_blackboard_with_default
 
+# pylint: disable=duplicate-code
+# All the constraints have similar code when registering and setting blackboard
+# keys, since the parameters for constraints are similar. This is not a problem.
+
 
 class SetJointGoalConstraint(MoveToConstraint):
     """
@@ -53,7 +57,7 @@ class SetJointGoalConstraint(MoveToConstraint):
         """
         Sets the joint goal constraint.
         """
-        self.logger.info("%s [SetJointGoalConstraint::set_constraint()]" % self.name)
+        self.logger.info(f"{self.name} [SetJointGoalConstraint::set_constraint()]")
 
         # Get all parameters for planning, resorting to default values if unset.
         joint_positions = self.blackboard.joint_positions  # required

--- a/ada_feeding/ada_feeding/decorators/set_joint_path_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_joint_path_constraint.py
@@ -11,6 +11,10 @@ import py_trees
 from ada_feeding.decorators import MoveToConstraint
 from ada_feeding.helpers import get_from_blackboard_with_default
 
+# pylint: disable=duplicate-code
+# All the constraints have similar code when registering and setting blackboard
+# keys, since the parameters for constraints are similar. This is not a problem.
+
 
 class SetJointPathConstraint(MoveToConstraint):
     """
@@ -53,7 +57,7 @@ class SetJointPathConstraint(MoveToConstraint):
         """
         Sets the joint path constraint.
         """
-        self.logger.info("%s [SetJointPathConstraint::set_constraint()]" % self.name)
+        self.logger.info(f"{self.name} [SetJointPathConstraint::set_constraint()]")
 
         # Get all parameters for planning, resorting to default values if unset.
         joint_positions = self.blackboard.joint_positions  # required

--- a/ada_feeding/ada_feeding/decorators/set_orientation_goal_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_orientation_goal_constraint.py
@@ -11,6 +11,10 @@ import py_trees
 from ada_feeding.decorators import MoveToConstraint
 from ada_feeding.helpers import get_from_blackboard_with_default
 
+# pylint: disable=duplicate-code
+# All the constraints have similar code when registering and setting blackboard
+# keys, since the parameters for constraints are similar. This is not a problem.
+
 
 class SetOrientationGoalConstraint(MoveToConstraint):
     """
@@ -58,7 +62,7 @@ class SetOrientationGoalConstraint(MoveToConstraint):
         Sets the orientation goal constraint.
         """
         self.logger.info(
-            "%s [SetOrientationGoalConstraint::set_constraint()]" % self.name
+            f"{self.name} [SetOrientationGoalConstraint::set_constraint()]"
         )
 
         # Get all parameters for planning, resorting to default values if unset.

--- a/ada_feeding/ada_feeding/decorators/set_orientation_path_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_orientation_path_constraint.py
@@ -12,6 +12,10 @@ import py_trees
 from ada_feeding.decorators import MoveToConstraint
 from ada_feeding.helpers import get_from_blackboard_with_default
 
+# pylint: disable=duplicate-code
+# All the constraints have similar code when registering and setting blackboard
+# keys, since the parameters for constraints are similar. This is not a problem.
+
 
 class SetOrientationPathConstraint(MoveToConstraint):
     """
@@ -59,7 +63,7 @@ class SetOrientationPathConstraint(MoveToConstraint):
         Sets the orientation goal constraint.
         """
         self.logger.info(
-            "%s [SetOrientationPathConstraint::set_constraint()]" % self.name
+            f"{self.name} [SetOrientationPathConstraint::set_constraint()]"
         )
 
         # Get all parameters for planning, resorting to default values if unset.

--- a/ada_feeding/ada_feeding/decorators/set_position_goal_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_position_goal_constraint.py
@@ -11,6 +11,10 @@ import py_trees
 from ada_feeding.decorators import MoveToConstraint
 from ada_feeding.helpers import get_from_blackboard_with_default
 
+# pylint: disable=duplicate-code
+# All the constraints have similar code when registering and setting blackboard
+# keys, since the parameters for constraints are similar. This is not a problem.
+
 
 class SetPositionGoalConstraint(MoveToConstraint):
     """
@@ -52,7 +56,7 @@ class SetPositionGoalConstraint(MoveToConstraint):
         """
         Sets the position goal constraint.
         """
-        self.logger.info("%s [SetPositionGoalConstraint::set_constraint()]" % self.name)
+        self.logger.info(f"{self.name} [SetPositionGoalConstraint::set_constraint()]")
 
         # Get all parameters for planning, resorting to default values if unset.
         position = self.blackboard.position  # required

--- a/ada_feeding/ada_feeding/decorators/set_position_path_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_position_path_constraint.py
@@ -12,6 +12,10 @@ import py_trees
 from ada_feeding.decorators import MoveToConstraint
 from ada_feeding.helpers import get_from_blackboard_with_default
 
+# pylint: disable=duplicate-code
+# All the constraints have similar code when registering and setting blackboard
+# keys, since the parameters for constraints are similar. This is not a problem.
+
 
 class SetPositionPathConstraint(MoveToConstraint):
     """
@@ -53,7 +57,7 @@ class SetPositionPathConstraint(MoveToConstraint):
         """
         Sets the position path constraint.
         """
-        self.logger.info("%s [SetPositionPathConstraint::set_constraint()]" % self.name)
+        self.logger.info(f"{self.name} [SetPositionPathConstraint::set_constraint()]")
 
         # Get all parameters for planning, resorting to default values if unset.
         position = self.blackboard.position  # required

--- a/ada_feeding/ada_feeding/helpers.py
+++ b/ada_feeding/ada_feeding/helpers.py
@@ -54,16 +54,16 @@ def import_from_string(import_string: str) -> Any:
         import_package, import_module, import_class = import_string.split(".", 3)
     except Exception as exc:
         raise NameError(
-            'Invalid import string %s. Except "package.module.class" e.g., "ada_feeding_msgs.action.MoveTo"'
-            % import_string
+            f'Invalid import string {import_string}. Except "package.module.class" '
+            'e.g., "ada_feeding_msgs.action.MoveTo"'
         ) from exc
     try:
         return getattr(
             getattr(
-                __import__("%s.%s" % (import_package, import_module)),
+                __import__(f"{import_package}.{import_module}"),
                 import_module,
             ),
             import_class,
         )
     except Exception as exc:
-        raise ImportError("Error importing %s" % (import_string)) from exc
+        raise ImportError(f"Error importing {import_string}") from exc

--- a/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
+++ b/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
@@ -21,6 +21,11 @@ from ada_feeding.decorators import (
 )
 
 
+# pylint: disable=too-many-arguments, too-many-locals, too-many-statements
+# Unfortunately, all these arguments/locals/statements are necessary to add
+# pose path constraints to a behavior tree -- the point of putting them
+# into one function is to reduce the number of arguments/locals/statements
+# needed in other functions.
 def add_pose_path_constraints(
     child: py_trees.behaviour.Behaviour,
     name: str,

--- a/ada_feeding/ada_feeding/trees/__init__.py
+++ b/ada_feeding/ada_feeding/trees/__init__.py
@@ -3,6 +3,11 @@ This package contains custom behavior trees that are used in the Ada Feeding
 project. All of these trees implement the ActionServerBT interface, in order
 to be wrapped in a ROS action server. 
 """
+
+# pylint: disable=cyclic-import
+# We import all of the trees here so that they can be imported as
+# ada_feeding.trees.<tree_name> instead of ada_feeding.trees.<tree_file>.<tree_name>
+
 from .move_to_tree import MoveToTree
 from .move_to_configuration_tree import MoveToConfigurationTree
 from .move_to_configuration_with_pose_path_constraints_tree import (

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
@@ -19,11 +19,20 @@ from ada_feeding.behaviors import MoveTo
 from ada_feeding.decorators import SetJointGoalConstraint
 from ada_feeding.trees import MoveToTree
 
+# pylint: disable=duplicate-code
+# move_to_configuration_tree.py has similar code to move_to_pose.py when defining
+# blackboard variables that are necessary for all movements (e.g., planner_id).
+# This is not a problem.
+
 
 class MoveToConfigurationTree(MoveToTree):
     """
     A behavior tree that moves the robot to a specified configuration.
     """
+
+    # pylint: disable=too-many-instance-attributes, too-many-arguments
+    # Many arguments is fine for this class since it has to be able to configure all parameters
+    # of its constraints.
 
     def __init__(
         self,
@@ -46,7 +55,7 @@ class MoveToConfigurationTree(MoveToTree):
             planner.
         """
         # Initialize MoveToTree
-        super().__init__(action_type_class_str)
+        super().__init__()
 
         # Store the parameters
         self.joint_positions = joint_positions
@@ -56,6 +65,9 @@ class MoveToConfigurationTree(MoveToTree):
         self.planner_id = planner_id
         self.allowed_planning_time = allowed_planning_time
 
+    # pylint: disable=too-many-locals
+    # Unfortunately, many local variables are required here to isolate the keys
+    # of similar constraints in the blackboard.
     def create_move_to_tree(
         self,
         name: str,

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
@@ -11,12 +11,16 @@ from typing import List, Tuple, Optional, Union
 
 # Third-party imports
 import py_trees
-from py_trees.blackboard import Blackboard
 from rclpy.node import Node
 
 # Local imports
 from ada_feeding.idioms import add_pose_path_constraints
 from ada_feeding.trees import MoveToTree, MoveToConfigurationTree
+
+# pylint: disable=duplicate-code
+# move_to_configuration_with_pose_path_constraints_tree.py has similar code to
+# move_to_pose_with_pose_path_constraints_tree.py when calling `add_pose_path_constraints`.
+# This is not a problem.
 
 
 class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
@@ -24,6 +28,10 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
     A behavior tree that moves the robot to a specified configuration while
     honoring pose path constraints.
     """
+
+    # pylint: disable=too-many-instance-attributes, too-many-arguments
+    # Many arguments is fine for this class since it has to be able to configure all parameters
+    # of its constraints.
 
     def __init__(
         self,
@@ -124,7 +132,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
             )
-            .create_tree(name, self.action_type_class_str, logger, node)
+            .create_tree(name, self.action_type, logger, node)
             .root
         )
 

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -22,11 +22,20 @@ from ada_feeding.decorators import (
 )
 from ada_feeding.trees import MoveToTree
 
+# pylint: disable=duplicate-code
+# move_to_pose.py has similar code to move_to_configuration_tree.py when defining
+# blackboard variables that are necessary for all movements (e.g., planner_id).
+# This is not a problem.
+
 
 class MoveToPoseTree(MoveToTree):
     """
     A behavior tree that consists of a single behavior, MoveToPose.
     """
+
+    # pylint: disable=too-many-instance-attributes, too-many-arguments
+    # Many arguments is fine for this class since it has to be able to configure all parameters
+    # of its constraints.
 
     def __init__(
         self,
@@ -80,6 +89,9 @@ class MoveToPoseTree(MoveToTree):
         self.planner_id = planner_id
         self.allowed_planning_time = allowed_planning_time
 
+    # pylint: disable=too-many-locals, too-many-statements
+    # Unfortunately, many locals/statements are required here to isolate the keys
+    # of similar constraints in the blackboard.
     def create_move_to_tree(
         self,
         name: str,

--- a/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
@@ -17,12 +17,21 @@ from rclpy.node import Node
 from ada_feeding.idioms import add_pose_path_constraints
 from ada_feeding.trees import MoveToTree, MoveToPoseTree
 
+# pylint: disable=duplicate-code
+# move_to_pose_with_pose_path_constraints_tree.py has similar code to
+# move_to_configuration_with_pose_path_constraints_tree.py when calling `add_pose_path_constraints`.
+# This is not a problem.
+
 
 class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
     """
     A behavior tree that moves the robot to a specified end effector pose, while
     honoring pose path constraints.
     """
+
+    # pylint: disable=too-many-instance-attributes, too-many-arguments, too-many-locals
+    # Many arguments is fine for this class since it has to be able to configure all parameters
+    # of its constraints.
 
     def __init__(
         self,
@@ -149,7 +158,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
             )
-            .create_tree(name, self.action_type_class_str, logger, node)
+            .create_tree(name, self.action_type, logger, node)
             .root
         )
 

--- a/ada_feeding/scripts/ada_planning_scene.py
+++ b/ada_feeding/scripts/ada_planning_scene.py
@@ -34,6 +34,8 @@ class ADAPlanningScene(Node):
     In practice, this node is used to add the wheelchair, table, and user's face.
     """
 
+    # pylint: disable=duplicate-code
+    # The MoveIt2 object will have similar code in any file it is created.
     def __init__(self) -> None:
         """
         Initialize the planning scene.

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -155,7 +155,7 @@ class ADAWatchdog(Node):
             message=ft_sensor_ok_message,
         )
         ft_sensor_error_message = (
-            f"Over the last {self.ft_timeout_sec.value} sec, the force-torque sensor"
+            f"Over the last {self.ft_timeout_sec.value} sec, the force-torque sensor "
             "has either not published data or its data is zero-variance"
         )
         self.ft_error_status = DiagnosticStatus(

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -45,6 +45,14 @@ class ActionServerParams:
     ) -> None:
         """
         Initialize the ActionServerParams class.
+
+        Parameters
+        ----------
+        server_name: The name of the action server.
+        action_type: The type of the action as a str, e.g., ada_feeding_msgs.action.MoveTo.
+        tree_class: The class of the behavior tree, e.g., ada_feeding.trees.MoveToConfigurationTree.
+        tree_kwargs: The keyword arguments to pass to the behavior tree class.
+        tick_rate: The rate at which to tick the behavior tree.
         """
         self.server_name = server_name
         self.action_type = action_type
@@ -315,7 +323,7 @@ class CreateActionServers(Node):
                 params.server_name,
                 self.get_execute_callback(
                     params.server_name,
-                    params.action_type,
+                    self._action_types[params.action_type],
                     params.tree_class,
                     params.tree_kwargs,
                     params.tick_rate,
@@ -363,7 +371,7 @@ class CreateActionServers(Node):
     def get_execute_callback(
         self,
         server_name: str,
-        action_type: str,
+        action_type: type,
         tree_class: str,
         tree_kwargs: Dict,
         tick_rate: int,
@@ -373,6 +381,18 @@ class CreateActionServers(Node):
         server and returns a callback function that can be used for that server.
         This is necessary because the callback function must return a Result and
         Feedback consisitent with the action type.
+
+        Parameters
+        ----------
+        server_name: The name of the action server.
+        action_type: The type of the action, as a class.
+        tree_class: The class of the behavior tree, e.g., ada_feeding.trees.MoveToConfigurationTree.
+        tree_kwargs: The keyword arguments to pass to the behavior tree class.
+        tick_rate: The rate at which to tick the behavior tree.
+
+        Returns
+        -------
+        execute_callback: The callback function for the action server.
         """
         # Initialize the ActionServerBT object once
         tree_action_server = self._tree_classes[tree_class](**tree_kwargs)
@@ -458,7 +478,7 @@ class CreateActionServers(Node):
             # went wrong. Abort the goal.
             if result is None:
                 goal_handle.abort()
-                result = self._action_types[action_type].Result()
+                result = action_type.Result()
 
             # Shutdown the tree
             # pylint: disable=broad-exception-caught

--- a/ada_feeding_perception/README.md
+++ b/ada_feeding_perception/README.md
@@ -59,15 +59,17 @@ See `config/test_segment_from_point.yaml` for other sample images and points. No
 
 We have provided a ROS node that displays the live image stream from a topic, let's users click on it, and sends that point click to the SegmentFromPoint action server.
 
-Run this script with: `ros2 launch ada_feeding_perception test_segment_from_point_launch.xml`
+Run this script with: `ros2 launch ada_feeding_perception test_food_segmentation_launch.xml`
 
 Note that because we are rendering a live image stream in matplotlib, this script can be very resource intensive. As an example, on one non-GPU machine it **slowed SegmentAnything down by 10x** (since so many resources were going to rendering the video's live stream).
 
 #### Option C: Testing the ROS Action Server on Saved Images
 
+Option C is now **DEPRECATED** because SegmentFromPoint requires aligned depth images, and we don't have aligned depth images for any of the offline images. The below instructions are kept only for legacy purposes.
+
 To facilitate the testing of a large number of stored images, we have provided a script that reads in a list of images and points and sends then to the SegmentFromPoint action server one-at-a-time, saving the results.
 
-To run this script, change the `mode` parameter in `config/test_segment_from_point.yaml` to `offline`. Then run `ros2 launch ada_feeding_perception test_segment_from_point_launch.xml`.
+To run this script, change the `mode` parameter in `config/test_segment_from_point.yaml` to `offline`. Then run `ros2 launch ada_feeding_perception test_food_segmentation_launch.xml`.
 
 This script should save the output images in `<path/to/your/workspace>/install/ada_feeding_perception/share/ada_feeding_perception/test_img/output`.
 

--- a/ada_feeding_perception/ada_feeding_perception/helpers.py
+++ b/ada_feeding_perception/ada_feeding_perception/helpers.py
@@ -12,6 +12,7 @@ from urllib.request import urlretrieve
 import cv2
 from cv_bridge import CvBridge
 import numpy as np
+import numpy.typing as npt
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import CompressedImage, Image
@@ -20,7 +21,7 @@ from skimage.morphology import flood_fill
 
 def ros_msg_to_cv2_image(
     msg: Union[Image, CompressedImage], bridge: Optional[CvBridge] = None
-) -> np.ndarray:
+) -> npt.NDArray:
     """
     Convert a ROS Image or CompressedImage message to a cv2 image. By default,
     this will maintain the depth of the image (e.g., 16-bit depth for depth
@@ -48,7 +49,7 @@ def ros_msg_to_cv2_image(
 
 
 def cv2_image_to_ros_msg(
-    image: np.ndarray, compress: bool, bridge: Optional[CvBridge] = None
+    image: npt.NDArray, compress: bool, bridge: Optional[CvBridge] = None
 ) -> Union[Image, CompressedImage]:
     """
     Convert a cv2 image to a ROS Image or CompressedImage message. Note that this
@@ -111,8 +112,8 @@ def get_img_msg_type(topic: str, node: Node) -> type:
         if endpoint.topic_type == "sensor_msgs/msg/Image":
             return Image
     raise ValueError(
-        "No publisher found with img type for topic %s. Publishers: %s"
-        % (final_topic, [str(endpoint) for endpoint in topic_endpoints])
+        f"No publisher found with img type for topic {final_topic}. "
+        "Publishers: {[str(endpoint) for endpoint in topic_endpoints]}"
     )
 
 
@@ -147,6 +148,9 @@ class BoundingBox:
     A class representing a bounding box on an image
     """
 
+    # pylint: disable=too-few-public-methods
+    # This is a data class
+
     def __init__(self, xmin: int, ymin: int, xmax: int, ymax: int):
         """
         Parameters
@@ -162,7 +166,7 @@ class BoundingBox:
         self.ymax = ymax
 
 
-def bbox_from_mask(mask: np.ndarray[bool]) -> BoundingBox:
+def bbox_from_mask(mask: npt.NDArray[bool]) -> BoundingBox:
     """
     Takes in a binary mask and returns the smallest axis-aligned bounding box
     that contains all the True pixels in the mask.
@@ -185,8 +189,11 @@ def bbox_from_mask(mask: np.ndarray[bool]) -> BoundingBox:
 
 
 def crop_image_mask_and_point(
-    image: np.ndarray, mask: np.ndarray[bool], point: Tuple[int, int], bbox: BoundingBox
-) -> Tuple[np.ndarray, np.ndarray[bool], Tuple[int, int]]:
+    image: npt.NDArray,
+    mask: npt.NDArray[bool],
+    point: Tuple[int, int],
+    bbox: BoundingBox,
+) -> Tuple[npt.NDArray, npt.NDArray[bool], Tuple[int, int]]:
     """
     Crop the image and mask to the bounding box.
 
@@ -213,8 +220,8 @@ def crop_image_mask_and_point(
 
 
 def overlay_mask_on_image(
-    image: np.ndarray,
-    mask: np.ndarray[bool],
+    image: npt.NDArray,
+    mask: npt.NDArray[bool],
     alpha: float = 0.5,
     color: Tuple[int, int, int] = (0, 255, 0),
 ):
@@ -242,8 +249,8 @@ def overlay_mask_on_image(
 
 
 def get_connected_component(
-    mask: np.ndarray[bool], point: Tuple[int, int]
-) -> np.ndarray[bool]:
+    mask: npt.NDArray[bool], point: Tuple[int, int]
+) -> npt.NDArray[bool]:
     """
     Takes in a binary mask and returns a new mask that has only the connected
     component that contains the given point.
@@ -268,16 +275,14 @@ def get_connected_component(
     """
     # Check that the point and mask satisfy the constraints
     if len(mask.shape) != 2:
-        raise ValueError(
-            "Mask must be a 2D array, it instead has shape {}".format(mask.shape)
-        )
+        raise ValueError(f"Mask must be a 2D array, it instead has shape {mask.shape}")
     if (
         point[1] < 0
         or point[1] >= mask.shape[0]
         or point[0] < 0
         or point[0] >= mask.shape[1]
     ):
-        raise IndexError("Point %s is not in mask of shape %s" % (point, mask.shape))
+        raise IndexError(f"Point {point} is not in mask of shape {mask.shape}")
     # Convert mask to uint8
     mask_uint = mask.astype(np.uint8)
     # Flood fill the mask with 3. Swap x and y because flood_fill expects

--- a/ada_feeding_perception/ada_feeding_perception/helpers.py
+++ b/ada_feeding_perception/ada_feeding_perception/helpers.py
@@ -166,7 +166,7 @@ class BoundingBox:
         self.ymax = ymax
 
 
-def bbox_from_mask(mask: npt.NDArray[bool]) -> BoundingBox:
+def bbox_from_mask(mask: npt.NDArray[np.bool_]) -> BoundingBox:
     """
     Takes in a binary mask and returns the smallest axis-aligned bounding box
     that contains all the True pixels in the mask.
@@ -190,10 +190,10 @@ def bbox_from_mask(mask: npt.NDArray[bool]) -> BoundingBox:
 
 def crop_image_mask_and_point(
     image: npt.NDArray,
-    mask: npt.NDArray[bool],
+    mask: npt.NDArray[np.bool_],
     point: Tuple[int, int],
     bbox: BoundingBox,
-) -> Tuple[npt.NDArray, npt.NDArray[bool], Tuple[int, int]]:
+) -> Tuple[npt.NDArray, npt.NDArray[np.bool_], Tuple[int, int]]:
     """
     Crop the image and mask to the bounding box.
 
@@ -221,7 +221,7 @@ def crop_image_mask_and_point(
 
 def overlay_mask_on_image(
     image: npt.NDArray,
-    mask: npt.NDArray[bool],
+    mask: npt.NDArray[np.bool_],
     alpha: float = 0.5,
     color: Tuple[int, int, int] = (0, 255, 0),
 ):
@@ -249,8 +249,8 @@ def overlay_mask_on_image(
 
 
 def get_connected_component(
-    mask: npt.NDArray[bool], point: Tuple[int, int]
-) -> npt.NDArray[bool]:
+    mask: npt.NDArray[np.bool_], point: Tuple[int, int]
+) -> npt.NDArray[np.bool_]:
     """
     Takes in a binary mask and returns a new mask that has only the connected
     component that contains the given point.

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -393,7 +393,7 @@ class SegmentFromPointNode(Node):
         self,
         item_id: str,
         score: float,
-        mask: npt.NDArray[bool],
+        mask: npt.NDArray[np.bool_],
         image: npt.NDArray,
         depth_img: npt.NDArray,
         seed_point: Tuple[int, int],

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -84,7 +84,7 @@ class SegmentFromPointNode(Node):
         # Subscribe to the camera info topic, to get the camera intrinsics
         self.camera_info_subscriber = self.create_subscription(
             CameraInfo,
-            "/camera_info",
+            "~/camera_info",
             self.camera_info_callback,
             1,
         )
@@ -96,7 +96,7 @@ class SegmentFromPointNode(Node):
 
         # Subscribe to the aligned depth image topic, to store the latest depth image
         # NOTE: We assume this is in the same frame as the RGB image
-        aligned_depth_topic = "/aligned_depth"
+        aligned_depth_topic = "~/aligned_depth"
         self.depth_image_subscriber = self.create_subscription(
             get_img_msg_type(aligned_depth_topic, self),
             aligned_depth_topic,
@@ -107,7 +107,7 @@ class SegmentFromPointNode(Node):
         self.latest_depth_img_msg_lock = threading.Lock()
 
         # Subscribe to the RGB image topic, to store the latest image
-        image_topic = "/image"
+        image_topic = "~/image"
         self.image_subscriber = self.create_subscription(
             get_img_msg_type(image_topic, self),
             image_topic,

--- a/ada_feeding_perception/ada_feeding_perception/test_sam.py
+++ b/ada_feeding_perception/ada_feeding_perception/test_sam.py
@@ -39,27 +39,29 @@ args = parser.parse_args()
 image_path = args.input_image
 input_point = np.array(json.loads(args.input_point))
 
-# Model parameters
-device = "cuda" if torch.cuda.is_available() else "cpu"
-model_type = "vit_b"
-model_name = "sam_vit_b_01ec64.pth"
-checkpoint_base_url = "https://dl.fbaipublicfiles.com/segment_anything/"
+# Constant model parameters
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+MODEL_TYPE = "vit_b"
+MODEL_NAME = "sam_vit_b_01ec64.pth"
+CHECKPOINT_BASE_URL = "https://dl.fbaipublicfiles.com/segment_anything/"
+
+# Download the model
 model_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../", "model"))
-sam_checkpoint = os.path.join(model_dir, model_name)
+sam_checkpoint = os.path.join(model_dir, MODEL_NAME)
 # if the model can't be found download it
 if not os.path.isfile(sam_checkpoint):
     print("SAM model checkpoint not found. Downloading...")
-    download_checkpoint(model_name, model_dir, checkpoint_base_url)
-    print("Download complete! Model saved at {}".format(sam_checkpoint))
+    download_checkpoint(MODEL_NAME, model_dir, CHECKPOINT_BASE_URL)
+    print(f"Download complete! Model saved at {sam_checkpoint}")
 
 # Read the image
 image = cv2.imread(image_path)
 image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-print("Image shape: {}".format(image.shape))
+print(f"Image shape: {image.shape}")
 
 # Load the model
-sam = sam_model_registry[model_type](checkpoint=sam_checkpoint)
-sam.to(device=device)
+sam = sam_model_registry[MODEL_TYPE](checkpoint=sam_checkpoint)
+sam.to(device=DEVICE)
 predictor = SamPredictor(sam)
 predictor.set_image(image)
 
@@ -101,10 +103,10 @@ def show_points(coords, labels, ax, marker_size=128):
         )
 
 
-number_output = 3
+NUMBER_OUTPUT = 3
 # After getting the masks
 for i, (score, mask) in enumerate(scored_masks_sorted):
-    if i >= number_output:
+    if i >= NUMBER_OUTPUT:
         break
     # Clean the mask to only contain the connected component containing
     # the seed point
@@ -141,12 +143,12 @@ for i, (score, mask) in enumerate(scored_masks_sorted):
     # Show the cropped image
     axes[0].imshow(cropped_image)
     axes[0].axis("off")
-    axes[0].set_title("Cropped Image {}".format(i))
+    axes[0].set_title(f"Cropped Image {i}")
 
     # Show the overlaid image
     axes[1].imshow(overlaid_image)
     axes[1].axis("off")
-    axes[1].set_title("Cropped Image {} with Mask, Conf {:.3f}".format(i, score))
+    axes[1].set_title(f"Cropped Image {i} with Mask, Conf {score:.3f}")
 
     plt.tight_layout()
     plt.show()

--- a/ada_feeding_perception/ada_feeding_perception/test_segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/test_segment_from_point.py
@@ -39,6 +39,11 @@ class TestSegmentFromPoint(Node):
         images and points and saves the resultant masks.
     """
 
+    # pylint: disable=too-many-instance-attributes
+    # Although we have many more instance attributes (28) than recommended (7),
+    # this class contains a lot of functionalities including online and offline
+    # testing, which justifies the large number of attributes.
+
     def __init__(self) -> None:
         """
         Initializes the TestSegmentFromPoint node. This function reads the
@@ -132,7 +137,10 @@ class TestSegmentFromPoint(Node):
                     ParameterDescriptor(
                         name="mode",
                         type=ParameterType.PARAMETER_STRING,
-                        description="What mode to run the node in. Options are 'online' and 'offline'",
+                        description=(
+                            "What mode to run the node in. "
+                            "Options are 'online' and 'offline'"
+                        ),
                         read_only=True,
                     ),
                 ),
@@ -177,7 +185,10 @@ class TestSegmentFromPoint(Node):
                         ParameterDescriptor(
                             name="base_dir",
                             type=ParameterType.PARAMETER_STRING,
-                            description="The base directory that all paths in offline mode are relative to.",
+                            description=(
+                                "The base directory that all paths "
+                                "in offline mode are relative to."
+                            ),
                             read_only=True,
                         ),
                     ),
@@ -197,7 +208,10 @@ class TestSegmentFromPoint(Node):
                         ParameterDescriptor(
                             name="sleep_time",
                             type=ParameterType.PARAMETER_DOUBLE,
-                            description="How long (secs) to sleep after publishing an image before sending a goal to the action server.",
+                            description=(
+                                "How long (secs) to sleep after publishing an image "
+                                "before sending a goal to the action server."
+                            ),
                             read_only=True,
                         ),
                     ),
@@ -318,9 +332,7 @@ class TestSegmentFromPoint(Node):
         self.get_logger().info(f"Clicked at {x}, {y}")
         with self.latest_img_msg_lock:
             latest_img_msg = self.latest_img_msg
-            self.get_logger().info(
-                "Latest image header: {}".format(self.latest_img_msg.header)
-            )
+            self.get_logger().info(f"Latest image header: {self.latest_img_msg.header}")
 
         # Call the action server if we aren't waiting for the result of another call
         with self.waiting_for_goal_lock:
@@ -378,14 +390,14 @@ class TestSegmentFromPoint(Node):
         future: the future that contains the result from the action server.
         """
         result = future.result().result
-        self.get_logger().info("Result: {}".format(result))
+        self.get_logger().info(f"Result: {result}")
 
         # Get the image that matches the result header
-        self.get_logger().info("Result header: {}".format(result.header))
+        self.get_logger().info(f"Result header: {result.header}")
         segmented_image_msg = None
         with self.stored_image_msgs_lock:
             for image_msg in self.stored_image_msgs:
-                self.get_logger().info("Image header: {}".format(image_msg.header))
+                self.get_logger().info(f"Image header: {image_msg.header}")
                 if image_msg.header.stamp == result.header.stamp:
                     segmented_image_msg = image_msg
                     break
@@ -471,10 +483,12 @@ class TestSegmentFromPoint(Node):
 
             # Render the confidence of the mask
             if render_confidence:
-                y_offset = 24  # An estimate of how tall the text will be, since the coordinates are for the *bottom*-left corner
+                # y_offset is an estimate of how tall the text will be, since
+                # the coordinates are for the *bottom*-left corner
+                y_offset = 24
                 cv2.putText(
                     overlaid,
-                    "Conf: {:.3f}".format(mask_raw.confidence),
+                    f"Conf: {mask_raw.confidence:.3f}",
                     (x, y + y_offset),
                     cv2.FONT_HERSHEY_SIMPLEX,
                     1,
@@ -496,15 +510,12 @@ class TestSegmentFromPoint(Node):
         point_xs = self.point_xs.value
         point_ys = self.point_ys.value
 
-        n_images = min((len(images), len(point_xs), len(point_ys)))
-
         # For every image, call the action server
-        for i in range(n_images):
+        for i in range(min((len(images), len(point_xs), len(point_ys)))):
             # Load the image and publish it
             image_path = os.path.join(self.base_dir.value, images[i])
-            image_filename = os.path.splitext(os.path.split(image_path)[-1])[0]
             image = cv2.imread(image_path)
-            self.get_logger().info("Loaded image {}".format(image_path))
+            self.get_logger().info(f"Loaded image {image_path}")
             image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
             image_msg = self.bridge.cv2_to_imgmsg(image, encoding="bgr8")
             self.image_pub.publish(image_msg)
@@ -512,39 +523,34 @@ class TestSegmentFromPoint(Node):
             # before we send the goal
             time.sleep(self.sleep_time.value)
 
-            # Get the point
-            point_x = point_xs[i]
-            point_y = point_ys[i]
-
             # Create the goal message
             goal_msg = SegmentFromPoint.Goal()
             goal_msg.seed_point.header.stamp = self.get_clock().now().to_msg()
-            goal_msg.seed_point.point.x = float(point_x)
-            goal_msg.seed_point.point.y = float(point_y)
+            goal_msg.seed_point.point.x = float(point_xs[i])
+            goal_msg.seed_point.point.y = float(point_ys[i])
 
             # Call the action server
             self.get_logger().info("Waiting for action server")
             self._action_client.wait_for_server()
-            self.get_logger().info(
-                "Calling action server with goal: {}".format(goal_msg)
-            )
+            self.get_logger().info(f"Calling action server with goal: {goal_msg}")
             result = self._action_client.send_goal(goal_msg)
 
             # Process the result
-            image_with_point = self.overlay_point_on_image(point_x, point_y, image)
             overlaid_images = self.get_overlaid_images(
-                image_with_point, result.result, render_confidence=True
+                self.overlay_point_on_image(point_xs[i], point_ys[i], image),
+                result.result,
+                render_confidence=True,
             )
 
             # Save them
+            image_filename = os.path.splitext(os.path.split(image_path)[-1])[0]
             for j, overlaid_image in enumerate(overlaid_images):
                 save_path = os.path.join(
                     self.base_dir.value,
                     self.save_dir.value,
                     f"image_{i}_{image_filename}_mask_{j}.png",
                 )
-                overlaid_image = cv2.cvtColor(overlaid_image, cv2.COLOR_RGB2BGR)
-                cv2.imwrite(save_path, overlaid_image)
+                cv2.imwrite(save_path, cv2.cvtColor(overlaid_image, cv2.COLOR_RGB2BGR))
 
         self.get_logger().info("Done!")
 

--- a/ada_feeding_perception/ada_feeding_perception/test_segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/test_segment_from_point.py
@@ -109,13 +109,13 @@ class TestSegmentFromPoint(Node):
             self.latest_img_msg = None
             self.create_subscription(
                 Image,
-                self.image_topic.value,
+                "~/image",
                 self.image_callback,
                 1,
             )
         else:  # Configure offline mode
             # Create a publisher to publish the images to
-            self.image_pub = self.create_publisher(Image, self.image_topic.value, 1)
+            self.image_pub = self.create_publisher(Image, "~/image", 1)
 
             # Make the directory to save the segmented images in
             os.makedirs(
@@ -128,7 +128,7 @@ class TestSegmentFromPoint(Node):
         each parameter for more information.
         """
         # Get the required parameters, mode and action_server_name
-        self.mode, self.action_server_name, self.image_topic = self.declare_parameters(
+        self.mode, self.action_server_name = self.declare_parameters(
             "",
             [
                 (
@@ -151,16 +151,6 @@ class TestSegmentFromPoint(Node):
                         name="action_server_name",
                         type=ParameterType.PARAMETER_STRING,
                         description="The name of the action server to connect to.",
-                        read_only=True,
-                    ),
-                ),
-                (
-                    "image_topic",
-                    None,
-                    ParameterDescriptor(
-                        name="image_topic",
-                        type=ParameterType.PARAMETER_STRING,
-                        description="The topic to subscribe/publish to for images.",
                         read_only=True,
                     ),
                 ),
@@ -247,7 +237,7 @@ class TestSegmentFromPoint(Node):
                     ),
                 ],
             )
-        else:
+        elif self.mode.value != "online":
             raise ValueError(
                 "Invalid mode parameter. Must be either 'online' or 'offline'"
             )

--- a/ada_feeding_perception/config/test_segment_from_point.yaml
+++ b/ada_feeding_perception/config/test_segment_from_point.yaml
@@ -12,10 +12,6 @@ test_segment_from_point:
     # The name of the action server to call
     action_server_name: /SegmentFromPoint
     
-    # The name of the image topic to subscribe to (online) or publish to (offline)
-    # This must be the same image topic the action server is reading from.
-    image_topic: /camera/color/image_raw
-    
     # Note that all directories are relative to the `base_dir` parameter, passed
     # in by the launchfile.
     offline: # Params for offline mode

--- a/ada_feeding_perception/launch/ada_feeding_perception_launch.xml
+++ b/ada_feeding_perception/launch/ada_feeding_perception_launch.xml
@@ -2,9 +2,9 @@
   <node pkg="ada_feeding_perception" exec="segment_from_point" name="segment_from_point">
     <param from="$(find-pkg-share ada_feeding_perception)/config/segment_from_point.yaml"/>
     <param name="model_dir" value="$(find-pkg-share ada_feeding_perception)/model/"/>
-    <remap from="/image" to="/camera/color/image_raw/compressed"/>
-    <remap from="/camera_info" to="/camera/color/camera_info"/>
-    <remap from="/aligned_depth" to="/camera/aligned_depth_to_color/image_raw"/>
+    <remap from="~/image" to="/camera/color/image_raw/compressed"/>
+    <remap from="~/camera_info" to="/camera/color/camera_info"/>
+    <remap from="~/aligned_depth" to="/camera/aligned_depth_to_color/image_raw"/>
   </node>
 
 </launch>

--- a/ada_feeding_perception/launch/test_food_segmentation_launch.xml
+++ b/ada_feeding_perception/launch/test_food_segmentation_launch.xml
@@ -2,6 +2,9 @@
   <node pkg="ada_feeding_perception" exec="test_segment_from_point" name="test_segment_from_point">
     <param from="$(find-pkg-share ada_feeding_perception)/config/test_segment_from_point.yaml"/>
     <param name="base_dir" value="$(find-pkg-share ada_feeding_perception)"/>
+
+    <!-- The image topic must be the same topic that the SegmentFromPoint action server is listening to -->
+    <remap from="~/image" to="/camera/color/image_raw/compressed"/>
   </node>
 
 </launch>


### PR DESCRIPTION
# Description

This PR does a complete linting cleanup on the `ada_feeding` repo (including `ada_feeding_perception` and `ada_feeding`). Specifically, it includes the following changes:
1. Adds a `.pylintrc` and modifies the pull request template with more specific instructions on running pylint with that file. (**Note**: Because Github only looks in `main` for pull request templates, this was in a [commit to `main`](https://github.com/personalrobotics/ada_feeding/commit/48a0ecac815cadca9515bc62e202e6033c115f4a) that is not in this PR.)
2. Addresses **every single `pylint` warning or error** (based on `.pylintrc`) in this repository, except for the two `fixme` warnings (to indicate a comment with the word "TODO" in it).

# Testing procedure

Because these changes touch every part of the code, it is crucial to re-test every part of the code. Therefore, we run the following tests:

- [x] Test the Planning Scene: Run `ros2 launch ada_moveit demo.launch.py sim:=mock` and `ros2 launch ada_feeding ada_feeding_launch.xml` and verify that the planning scene that shows up in RVIZ matches the screenshots from #39 .
- [x] Test **every single tree** in `ada_feeding` (I did this with MoveIt in `sim:=mock`):
    - [x]  **MoveToDummyTree**: `ros2 action send_goal /AcquireFood ada_feeding_msgs/action/AcquireFood "{header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, detected_food: {roi: {x_offset: 0, y_offset: 0, height: 0, width: 0, do_rectify: false}, mask: {header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, format: '', data: []}, item_id: '', confidence: 0.0}}" --feedback`
    - [x]  **MoveToConfigurationTree**: `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
    - [x]  **MoveToConfigurationWithPosePathConstraintsTree**: (Note: run the action server for`/MoveToRestingPosition` before this) `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveTo "{}" --feedback`
    - [x]  **MoveToPoseTree**: (Note: run the action server for`/MoveToRestingPosition` before this) `ros2 action send_goal /TestMoveToPose ada_feeding_msgs/action/MoveTo "{}" --feedback`
    - [x]  **MoveToPoseWithPosePathConstraintsTree**: (Note: run the action server for`/MoveToRestingPosition` before this) `ros2 action send_goal /TestMoveToPoseWithPosePathConstraints ada_feeding_msgs/action/MoveTo "{}" --feedback`
- [x] Test the watchdog in isolation (and the dummy FT sensor): follow instructions in the [README](https://github.com/personalrobotics/ada_feeding/tree/amaln/cleanup/ada_feeding).
- [x] Test SegmentFromPoint. See Options in the [README](https://github.com/personalrobotics/ada_feeding/tree/amaln/cleanup/ada_feeding_perception).
    - [x] Option A
    - [x] Option B
    - [ ] [EDIT: I deprecated this because it is non-trivial to make it work with the depth images that SegmentFromPoint now requires] Option C
    - [x] Option D

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
