### PR TITLE
Added MoveFromMouth Actions

### DIFF
--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -197,21 +197,23 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         children.append(move_to_configuration_root)
 
         # Create the behavior to disallow collisions with certain objects
-        disallow_collision_children = []
-        if len(self.collision_object_ids) > 0:
-            for collision_object_id in self.collision_object_ids:
-                disallow_collision_prefix = (
-                    f"disallow_collision_with_{collision_object_id}"
-                )
-                disallow_collision = ToggleCollisionObject(
-                    name=Blackboard.separator.join([name, disallow_collision_prefix]),
-                    node=node,
-                    collision_object_id=collision_object_id,
-                    allow=False,
-                )
-                disallow_collision.logger = logger
-                children.append(disallow_collision)
-                disallow_collision_children.append(disallow_collision)
+        def gen_disallow_collision_children():
+            disallow_collision_children = []
+            if len(self.collision_object_ids) > 0:
+                for collision_object_id in self.collision_object_ids:
+                    disallow_collision_prefix = (
+                        f"disallow_collision_with_{collision_object_id}"
+                    )
+                    disallow_collision = ToggleCollisionObject(
+                        name=Blackboard.separator.join([name, disallow_collision_prefix]),
+                        node=node,
+                        collision_object_id=collision_object_id,
+                        allow=False,
+                    )
+                    disallow_collision.logger = logger
+                    disallow_collision_children.append(disallow_collision)
+            return disallow_collision_children
+        children.extend(gen_disallow_collision_children())
 
         # Combine them in a sequence with memory
         main_behavior = py_trees.composites.Sequence(
@@ -236,7 +238,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                         py_trees.composites.Sequence(
                             name=name,
                             memory=True,
-                            children=disallow_collision_children,
+                            children=gen_disallow_collision_children(),
                         ),
                     ),
                 ],

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -205,7 +205,9 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                         f"disallow_collision_with_{collision_object_id}"
                     )
                     disallow_collision = ToggleCollisionObject(
-                        name=Blackboard.separator.join([name, disallow_collision_prefix]),
+                        name=Blackboard.separator.join(
+                            [name, disallow_collision_prefix]
+                        ),
                         node=node,
                         collision_object_id=collision_object_id,
                         allow=False,
@@ -213,6 +215,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                     disallow_collision.logger = logger
                     disallow_collision_children.append(disallow_collision)
             return disallow_collision_children
+
         children.extend(gen_disallow_collision_children())
 
         # Combine them in a sequence with memory
@@ -226,6 +229,8 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         # If any part of the main behavior fails, we need to clean it up by still
         # allowing the collision.
         if len(self.collision_object_ids) > 0:
+            # pylint: disable=duplicate-code
+            # The cleanup across trees will look similar.
             root = py_trees.composites.Selector(
                 name=name,
                 memory=True,

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -34,11 +34,12 @@ from ada_feeding.trees import (
     MoveToPoseWithPosePathConstraintsTree,
 )
 
+
 def get_toggle_face_detection_behavior(
-        tree_name: str,
-        behavior_name_prefix: str,
-        request_data: bool,
-        logger: logging.Logger,
+    tree_name: str,
+    behavior_name_prefix: str,
+    request_data: bool,
+    logger: logging.Logger,
 ) -> py_trees.behaviour.Behaviour:
     """
     Creates a behaviour that toggles face detection.
@@ -54,12 +55,8 @@ def get_toggle_face_detection_behavior(
     -------
     behavior: The behaviour that toggles face detection.
     """
-    behavior_name = Blackboard.separator.join(
-        [tree_name, behavior_name_prefix]
-    )
-    key_response = Blackboard.separator.join(
-        [behavior_name, "response"]
-    )
+    behavior_name = Blackboard.separator.join([tree_name, behavior_name_prefix])
+    key_response = Blackboard.separator.join([behavior_name, "response"])
     toggle_face_detection_behavior = retry_call_ros_service(
         name=behavior_name,
         service_type=SetBool,
@@ -78,13 +75,14 @@ def get_toggle_face_detection_behavior(
     )
     return toggle_face_detection_behavior
 
+
 def get_toggle_collision_object_behavior(
-        tree_name: str,
-        behavior_name_prefix: str,
-        node: Node,
-        collision_object_id: str,
-        allow: bool,
-        logger: logging.Logger,
+    tree_name: str,
+    behavior_name_prefix: str,
+    node: Node,
+    collision_object_id: str,
+    allow: bool,
+    logger: logging.Logger,
 ) -> py_trees.behaviour.Behaviour:
     """
     Creates a behaviour that toggles a collision object.
@@ -102,16 +100,20 @@ def get_toggle_collision_object_behavior(
     -------
     behavior: The behaviour that toggles the collision object.
     """
+
+    # pylint: disable=too-many-arguments
+    # This is acceptable, as these are the parameters necessary to create
+    # the behaviour.
+
     toggle_collision_object = ToggleCollisionObject(
-        name=Blackboard.separator.join(
-            [tree_name, behavior_name_prefix]
-        ),
+        name=Blackboard.separator.join([tree_name, behavior_name_prefix]),
         node=node,
         collision_object_id=collision_object_id,
         allow=allow,
     )
     toggle_collision_object.logger = logger
     return toggle_collision_object
+
 
 class MoveToMouthTree(MoveToTree):
     """
@@ -407,7 +409,7 @@ class MoveToMouthTree(MoveToTree):
         # to the user so the wheelchair collision object must be allowed.
         allow_wheelchair_collision = get_toggle_collision_object_behavior(
             name,
-            disallow_wheelchair_collision_prefix,
+            allow_wheelchair_collision_prefix,
             node,
             self.wheelchair_collision_object_id,
             True,
@@ -508,6 +510,8 @@ class MoveToMouthTree(MoveToTree):
             False,
             logger,
         )
+        # pylint: disable=duplicate-code
+        # The cleanup across trees will look similar.
         root = py_trees.composites.Selector(
             name=name,
             memory=True,

--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -107,8 +107,8 @@ class EStopCondition(WatchdogCondition):
                 type=ParameterType.PARAMETER_DOUBLE,
                 description=(
                     "The number of audio samples to take at a time from the microphone "
-                    "(where the e-stop button is plugged in). If you get overflow errors, "
-                    "try increasing this value."
+                    "(where the e-stop button is plugged in). If you get overflow "
+                    "errors, try increasing this value."
                 ),
                 read_only=True,
             ),
@@ -419,7 +419,10 @@ class EStopCondition(WatchdogCondition):
         name_1 = "E-Stop Button Not Clicked"
         with self.num_clicks_lock:
             status_1 = self.num_clicks < 2
-        condition_1 = f"E-stop button has {'not ' if status_1 else ''}been clicked since the startup click"
+        condition_1 = (
+            f"E-stop button has {'not ' if status_1 else ''}been clicked since "
+            "the startup click"
+        )
 
         name_2 = "E-Stop Button Plugged in"
         with self.is_mic_unplugged_lock:

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -45,7 +45,7 @@ ada_feeding_action_servers:
         dummy_motion_time: 10.0 # secs
       tick_rate: 10 # Hz, optional, default: 30
 
-   # Parameters for the MoveToRestingPosition action
+    # Parameters for the MoveToRestingPosition action
     MoveToRestingPosition: # required
       action_type: ada_feeding_msgs.action.MoveTo # required
       tree_class: ada_feeding.trees.MoveToConfigurationWithFTThresholdsTree # required
@@ -93,6 +93,48 @@ ada_feeding_action_servers:
           - 3.14159 # y, rad
           - 0.5 # z, rad
         allowed_planning_time_to_staging_configuration: 1.0 # secs
+      tick_rate: 10 # Hz, optional, default: 30
+
+    # Parameters for the MoveFromMouthToAbovePlate action
+    MoveFromMouthToAbovePlate: # required
+      action_type: ada_feeding_msgs.action.MoveTo # required
+      tree_class: ada_feeding.trees.MoveToConfigurationWithFTThresholdsTree # required
+      tree_kws: # optional
+        - joint_positions
+        - f_mag
+        - collision_object_ids
+      tree_kwargs: # optional
+        joint_positions: # required
+          - -2.11666 # j2n6s200_joint_1
+          -  3.34967 # j2n6s200_joint_2
+          -  2.04129 # j2n6s200_joint_3
+          - -2.30031 # j2n6s200_joint_4
+          - -2.34026 # j2n6s200_joint_5
+          -  2.95450 # j2n6s200_joint_6
+        f_mag: 4.0 # N
+        collision_object_ids: # list of objects to allow collisions with during the motion
+          - wheelchair_collision
+      tick_rate: 10 # Hz, optional, default: 30
+
+    # Parameters for the MoveFromMouthToRestingPosition action
+    MoveFromMouthToRestingPosition: # required
+      action_type: ada_feeding_msgs.action.MoveTo # required
+      tree_class: ada_feeding.trees.MoveToConfigurationWithFTThresholdsTree # required
+      tree_kws: # optional
+        - joint_positions
+        - f_mag
+        - collision_object_ids
+      tree_kwargs: # optional
+        joint_positions: # required
+          - -1.94672 # j2n6s200_joint_1
+          -  2.51268 # j2n6s200_joint_2
+          -  0.35653 # j2n6s200_joint_3
+          - -4.76501 # j2n6s200_joint_4
+          -  5.99991 # j2n6s200_joint_5
+          -  4.99555 # j2n6s200_joint_6
+        f_mag: 4.0 # N
+        collision_object_ids: # list of objects to allow collisions with during the motion
+          - wheelchair_collision
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the MoveToStowLocation action

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -10,6 +10,8 @@ ada_feeding_action_servers:
       - MoveAbovePlate
       - AcquireFood
       - MoveToMouth
+      - MoveFromMouthToAbovePlate
+      - MoveFromMouthToRestingPosition
       - MoveToRestingPosition
       - MoveToStowLocation
       - TestMoveToPose

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -26,7 +26,6 @@ from std_msgs.msg import Header
 from ada_feeding.watchdog import (
     EStopCondition,
     FTSensorCondition,
-    WatchdogCondition,
 )
 
 

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -453,6 +453,9 @@ def main(args: List = None) -> None:
     rclpy.init(args=args)
 
     create_action_servers = CreateActionServers()
+    create_action_servers._default_callback_group = (
+        rclpy.callback_groups.ReentrantCallbackGroup()
+    )
 
     # Use a MultiThreadedExecutor to enable processing goals concurrently
     executor = MultiThreadedExecutor()

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -453,6 +453,9 @@ def main(args: List = None) -> None:
     rclpy.init(args=args)
 
     create_action_servers = CreateActionServers()
+    # pylint: disable=protected-access
+    # There is an issue to address this, see
+    # https://github.com/personalrobotics/ada_feeding/issues/62
     create_action_servers._default_callback_group = (
         rclpy.callback_groups.ReentrantCallbackGroup()
     )

--- a/ada_feeding/scripts/dummy_ft_sensor.py
+++ b/ada_feeding/scripts/dummy_ft_sensor.py
@@ -107,7 +107,7 @@ class DummyForceTorqueSensor(Node):
 
         self.get_logger().info("Initialized!")
 
-    def set_bias_callback(self, _: SetBool.Request, response: SetBool.Response):
+    def set_bias_callback(self, request: SetBool.Request, response: SetBool.Response):
         """
         Callback for the set_bias service. In order to mimic the actual service,
         this returns immediately, but then stops publishing data for 0.75 sec


### PR DESCRIPTION
# Description

In service of #53 . At the end of transfer, the robot is colliding with the wheelchair collision mesh. Therefore, the actions that take the robot from that position to above the plate or the resting position need to toggle that mesh off.

These actions for now execute the entire motion with the mesh toggled off. However, in the future we should consider only executing an initial part of the motion (e.g., move back to the staging location) with the mesh off, then re-enable it, and then complete the rest of the motion, for increased safety.

# Testing procedure

Pull the code from [ada_ros2#12](https://github.com/personalrobotics/ada_ros2/pull/12).

- [x] On the real robot, call MoveToMouth as documented in #42 . 
- [x] Run `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback` and verify that it fails.
- [x] Run `ros2 action send_goal /MoveFromMouthToAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback` and verify that it succeeds.
- [x] Run `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback` and verify that it fails.
- [x] Run `ros2 action send_goal /MoveFromMouthToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback` and verify that it succeeds.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
