### PR TITLE
Implemented velocity scaling

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -93,6 +93,10 @@ class MoveTo(py_trees.behaviour.Behaviour):
         self.move_to_blackboard.register_key(
             key="allowed_planning_time", access=py_trees.common.Access.READ
         )
+        # Add the ability to set velocity scaling
+        self.move_to_blackboard.register_key(
+            key="max_velocity_scaling_factor", access=py_trees.common.Access.READ
+        )
         # Initialize the blackboard to read from the parent behavior tree
         self.tree_blackboard = self.attach_blackboard_client(
             name=name + " MoveTo", namespace=tree_name
@@ -152,6 +156,11 @@ class MoveTo(py_trees.behaviour.Behaviour):
             get_from_blackboard_with_default(
                 self.move_to_blackboard, "planner_id", "RRTstarkConfigDefault"
             )
+        )
+
+        # Set the max velocity
+        self.moveit2.max_velocity = get_from_blackboard_with_default(
+            self.move_to_blackboard, "max_velocity_scaling_factor", 0.1
         )
 
         # Set the allowed planning time

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
@@ -43,6 +43,7 @@ class MoveToConfigurationTree(MoveToTree):
         weight: float = 1.0,
         planner_id: str = "RRTstarkConfigDefault",
         allowed_planning_time: float = 0.5,
+        max_velocity_scaling_factor: float = 0.1,
         keys_to_not_write_to_blackboard: Set[str] = set(),
     ):
         """
@@ -56,6 +57,8 @@ class MoveToConfigurationTree(MoveToTree):
         planner_id: The planner ID to use for the MoveIt2 motion planning.
         allowed_planning_time: The allowed planning time for the MoveIt2 motion
             planner.
+        max_velocity_scaling_factor: The maximum velocity scaling factor for the
+            MoveIt2 motion planner.
         keys_to_not_write_to_blackboard: A set of keys that should not be written
             Note that the keys need to be exact e.g., "move_to.cartesian,"
             "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
@@ -71,6 +74,7 @@ class MoveToConfigurationTree(MoveToTree):
         self.weight = weight
         self.planner_id = planner_id
         self.allowed_planning_time = allowed_planning_time
+        self.max_velocity_scaling_factor = max_velocity_scaling_factor
         self.keys_to_not_write_to_blackboard = keys_to_not_write_to_blackboard
 
     # pylint: disable=too-many-locals
@@ -137,6 +141,12 @@ class MoveToConfigurationTree(MoveToTree):
         self.blackboard.register_key(
             key=allowed_planning_time_key, access=py_trees.common.Access.WRITE
         )
+        max_velocity_scaling_factor_key = Blackboard.separator.join(
+            [move_to_namespace_prefix, "max_velocity_scaling_factor"]
+        )
+        self.blackboard.register_key(
+            key=max_velocity_scaling_factor_key, access=py_trees.common.Access.WRITE
+        )
 
         # Write the inputs to MoveToConfiguration to blackboard
         set_to_blackboard(
@@ -167,6 +177,12 @@ class MoveToConfigurationTree(MoveToTree):
             self.blackboard,
             allowed_planning_time_key,
             self.allowed_planning_time,
+            self.keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            self.blackboard,
+            max_velocity_scaling_factor_key,
+            self.max_velocity_scaling_factor,
             self.keys_to_not_write_to_blackboard,
         )
 

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -38,6 +38,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         weight_joint: float = 1.0,
         planner_id: str = "RRTstarkConfigDefault",
         allowed_planning_time: float = 0.5,
+        max_velocity_scaling_factor: float = 0.1,
         # Optional parameters for the FT thresholds
         re_tare: bool = True,
         toggle_watchdog_listener: bool = True,
@@ -62,6 +63,8 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         planner_id: The planner ID to use for MoveIt2 motion planning.
         allowed_planning_time: The allowed planning time for the MoveIt2 motion
             planner.
+        max_velocity_scaling_factor: The maximum velocity scaling factor for the
+            MoveIt2 motion planner.
         re_tare: Whether to re-tare the force-torque sensor.
         toggle_watchdog_listener: Whether to toggle the watchdog listener on and off.
             In practice, if the watchdog listener is on, you should toggle it.
@@ -92,6 +95,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         self.weight_joint = weight_joint
         self.planner_id = planner_id
         self.allowed_planning_time = allowed_planning_time
+        self.max_velocity_scaling_factor = max_velocity_scaling_factor
 
         # Store the parameters for the FT threshold
         self.re_tare = re_tare
@@ -137,6 +141,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                 weight=self.weight_joint,
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
+                max_velocity_scaling_factor=self.max_velocity_scaling_factor,
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
             )
             .create_tree(name, self.action_type, tree_root_name, logger, node)

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
@@ -43,6 +43,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         weight_joint_goal: float = 1.0,
         planner_id: str = "RRTstarkConfigDefault",
         allowed_planning_time: float = 0.5,
+        max_velocity_scaling_factor: float = 0.1,
         # Optional parameters for the pose path constraint
         position_path: Tuple[float, float, float] = None,
         quat_xyzw_path: Tuple[float, float, float, float] = None,
@@ -66,6 +67,8 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         planner_id: The planner ID to use for MoveIt2 motion planning.
         allowed_planning_time: The allowed planning time for the MoveIt2 motion
             planner.
+        max_velocity_scaling_factor: The maximum velocity scaling factor for the
+            MoveIt2 motion planner.
         position_path: the position for the path constraint.
         quat_xyzw_path: the orientation for the path constraint.
         frame_id: the frame id of the target pose, for the pose path constraint.
@@ -96,6 +99,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         self.weight_joint_goal = weight_joint_goal
         self.planner_id = planner_id
         self.allowed_planning_time = allowed_planning_time
+        self.max_velocity_scaling_factor = max_velocity_scaling_factor
 
         # Store the parameters for the pose path constraint
         self.position_path = position_path
@@ -143,6 +147,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
                 weight=self.weight_joint_goal,
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
+                max_velocity_scaling_factor=self.max_velocity_scaling_factor,
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
             )
             .create_tree(name, self.action_type, tree_root_name, logger, node)

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -54,6 +54,8 @@ class MoveToMouthTree(MoveToTree):
         planner_id: str = "RRTstarkConfigDefault",
         allowed_planning_time_to_staging_configuration: float = 0.5,
         allowed_planning_time_to_mouth: float = 0.5,
+        max_velocity_scaling_factor_to_staging_configuration: float = 0.1,
+        max_velocity_scaling_factor_to_mouth: float = 0.1,
         head_object_id: str = "head",
         wheelchair_collision_object_id: str = "wheelchair_collision",
         force_threshold: float = 4.0,
@@ -79,6 +81,11 @@ class MoveToMouthTree(MoveToTree):
             time for the MoveIt2 motion planner to move to the staging config.
         allowed_planning_time_to_mouth: The allowed planning time for the MoveIt2
             motion planner to move to the user's mouth.
+        max_velocity_scaling_factor_to_staging_configuration: The maximum
+            velocity scaling factor for the MoveIt2 motion planner to move to
+            the staging config.
+        max_velocity_scaling_factor_to_mouth: The maximum velocity scaling
+            factor for the MoveIt2 motion planner to move to the user's mouth.
         head_object_id: The ID of the head collision object in the MoveIt2
             planning scene.
         wheelchair_collision_object_id: The ID of the wheelchair collision object
@@ -92,6 +99,10 @@ class MoveToMouthTree(MoveToTree):
         allowed_face_distance: The maximum distance (m) between a face and the
             **camera's optical frame** for the robot to move towards the face.
         """
+
+        # pylint: disable=too-many-locals
+        # These are all necessary due to all the behaviors MoveToMouth contains
+
         # Initialize MoveToTree
         super().__init__()
 
@@ -107,6 +118,10 @@ class MoveToMouthTree(MoveToTree):
             allowed_planning_time_to_staging_configuration
         )
         self.allowed_planning_time_to_mouth = allowed_planning_time_to_mouth
+        self.max_velocity_scaling_factor_to_staging_configuration = (
+            max_velocity_scaling_factor_to_staging_configuration
+        )
+        self.max_velocity_scaling_factor_to_mouth = max_velocity_scaling_factor_to_mouth
         self.head_object_id = head_object_id
         self.wheelchair_collision_object_id = wheelchair_collision_object_id
         self.force_threshold = force_threshold
@@ -227,6 +242,9 @@ class MoveToMouthTree(MoveToTree):
                 tolerance_joint_goal=self.staging_configuration_tolerance,
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time_to_staging_configuration,
+                max_velocity_scaling_factor=(
+                    self.max_velocity_scaling_factor_to_staging_configuration
+                ),
                 quat_xyzw_path=self.orientation_constraint_quaternion,
                 tolerance_orientation_path=self.orientation_constraint_tolerances,
                 parameterization_orientation_path=1,  # Rotation vector
@@ -371,6 +389,7 @@ class MoveToMouthTree(MoveToTree):
                 cartesian=False,
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time_to_mouth,
+                max_velocity_scaling_factor=self.max_velocity_scaling_factor_to_mouth,
                 quat_xyzw_path=self.orientation_constraint_quaternion,
                 tolerance_orientation_path=self.orientation_constraint_tolerances,
                 parameterization_orientation_path=1,  # Rotation vector

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -58,6 +58,7 @@ class MoveToPoseTree(MoveToTree):
         cartesian: bool = False,
         planner_id: str = "RRTstarkConfigDefault",
         allowed_planning_time: float = 0.5,
+        max_velocity_scaling_factor: float = 0.1,
         keys_to_not_write_to_blackboard: Set[str] = set(),
     ):
         """
@@ -79,6 +80,8 @@ class MoveToPoseTree(MoveToTree):
         cartesian: whether to use cartesian path planning.
         planner_id: the planner to use for path planning.
         allowed_planning_time: the allowed planning time for path planning.
+        max_velocity_scaling_factor: the maximum velocity scaling factor for path
+            planning.
         keys_to_not_write_to_blackboard: the keys to not write to the blackboard.
             Note that the keys need to be exact e.g., "move_to.cartesian,"
             "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
@@ -100,6 +103,7 @@ class MoveToPoseTree(MoveToTree):
         self.cartesian = cartesian
         self.planner_id = planner_id
         self.allowed_planning_time = allowed_planning_time
+        self.max_velocity_scaling_factor = max_velocity_scaling_factor
         self.keys_to_not_write_to_blackboard = keys_to_not_write_to_blackboard
 
     # pylint: disable=too-many-locals, too-many-statements
@@ -232,6 +236,12 @@ class MoveToPoseTree(MoveToTree):
         self.blackboard.register_key(
             key=allowed_planning_time_key, access=py_trees.common.Access.WRITE
         )
+        max_velocity_scaling_factor_key = Blackboard.separator.join(
+            [move_to_namespace_prefix, "max_velocity_scaling_factor"]
+        )
+        self.blackboard.register_key(
+            key=max_velocity_scaling_factor_key, access=py_trees.common.Access.WRITE
+        )
 
         # Write the inputs to MoveToPose to blackboard
         if self.position is not None:
@@ -318,6 +328,12 @@ class MoveToPoseTree(MoveToTree):
             self.blackboard,
             allowed_planning_time_key,
             self.allowed_planning_time,
+            self.keys_to_not_write_to_blackboard,
+        )
+        set_to_blackboard(
+            self.blackboard,
+            max_velocity_scaling_factor_key,
+            self.max_velocity_scaling_factor,
             self.keys_to_not_write_to_blackboard,
         )
 

--- a/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
@@ -50,6 +50,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         cartesian: bool = False,
         planner_id: str = "RRTstarkConfigDefault",
         allowed_planning_time: float = 0.5,
+        max_velocity_scaling_factor: float = 0.1,
         # Optional parameters for the pose path constraint
         position_path: Tuple[float, float, float] = None,
         quat_xyzw_path: Tuple[float, float, float, float] = None,
@@ -81,7 +82,9 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         cartesian: whether to use cartesian path planning.
         planner_id: the planner ID to use for MoveIt2 motion planning.
         allowed_planning_time: the allowed planning time for the MoveIt2 motion
-            planner..
+            planner.
+        max_velocity_scaling_factor: the maximum velocity scaling factor for
+            MoveIt2 motion planning.
         position_path: the target position relative to frame_id for path constraints.
         quat_xyzw_path: the target orientation relative to frame_id for path constraints.
         frame_id_path: the frame id of the target pose for path constraints. If None,
@@ -115,6 +118,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         self.cartesian = cartesian
         self.planner_id = planner_id
         self.allowed_planning_time = allowed_planning_time
+        self.max_velocity_scaling_factor = max_velocity_scaling_factor
 
         # Store the parameters for the pose path constraint
         self.position_path = position_path
@@ -169,6 +173,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
                 cartesian=self.cartesian,
                 planner_id=self.planner_id,
                 allowed_planning_time=self.allowed_planning_time,
+                max_velocity_scaling_factor=self.max_velocity_scaling_factor,
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
             )
             .create_tree(name, self.action_type, tree_root_name, logger, node)

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -22,6 +22,7 @@ ada_feeding_action_servers:
       tree_kws: # optional
         - joint_positions
         - f_mag
+        - max_velocity_scaling_factor
       tree_kwargs: # optional
         joint_positions: # required
           - -2.11666 # j2n6s200_joint_1
@@ -31,6 +32,7 @@ ada_feeding_action_servers:
           - -2.34026 # j2n6s200_joint_5
           -  2.95450 # j2n6s200_joint_6
         f_mag: 4.0 # N
+        max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the AcquireFood action
@@ -52,6 +54,7 @@ ada_feeding_action_servers:
       tree_kws: # optional
         - joint_positions
         - f_mag
+        - max_velocity_scaling_factor
       tree_kwargs: # optional
         joint_positions: # required
           - -1.94672 # j2n6s200_joint_1
@@ -61,6 +64,7 @@ ada_feeding_action_servers:
           -  5.99991 # j2n6s200_joint_5
           -  4.99555 # j2n6s200_joint_6
         f_mag: 4.0 # N
+        max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the MoveToMouth action
@@ -75,6 +79,8 @@ ada_feeding_action_servers:
         - orientation_constraint_quaternion
         - orientation_constraint_tolerances
         - allowed_planning_time_to_staging_configuration
+        - max_velocity_scaling_factor_to_staging_configuration
+        - max_velocity_scaling_factor_to_mouth
       tree_kwargs: # optional
         staging_configuration:
           -  2.74709 # j2n6s200_joint_1
@@ -93,6 +99,8 @@ ada_feeding_action_servers:
           - 3.14159 # y, rad
           - 0.5 # z, rad
         allowed_planning_time_to_staging_configuration: 1.0 # secs
+        max_velocity_scaling_factor_to_staging_configuration: 0.65 # optional in (0.0, 1.0], default: 0.1
+        max_velocity_scaling_factor_to_mouth: 0.4 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the MoveToStowLocation action
@@ -104,6 +112,7 @@ ada_feeding_action_servers:
       tree_kws: # optional
         - joint_positions
         - f_mag
+        - max_velocity_scaling_factor
       tree_kwargs: # optional
         joint_positions: # required
           - -1.52101 # j2n6s200_joint_1
@@ -113,6 +122,7 @@ ada_feeding_action_servers:
           -  0.22831 # j2n6s200_joint_5
           -  3.87886 # j2n6s200_joint_6
         f_mag: 4.0 # N
+        max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the TestMoveToPose action. Moves to the staging location
@@ -122,6 +132,7 @@ ada_feeding_action_servers:
       tree_kws: # optional
         - position
         - quat_xyzw
+        - max_velocity_scaling_factor
       tree_kwargs: # optional
         position:
           -  0.27971 # x
@@ -132,6 +143,7 @@ ada_feeding_action_servers:
           -  0.70159 # y
           -  0.71255 # z
           - -0.00636 # w
+        max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30
 
     # Parameters for the TestMoveToPoseWithPosePathConstraints action. Moves to the staging location
@@ -145,6 +157,7 @@ ada_feeding_action_servers:
         - tolerance_orientation_path
         - parameterization_orientation_path
         - weight_orientation_path
+        - max_velocity_scaling_factor
       tree_kwargs: # optional
         position_goal:
           - -0.00070 # x
@@ -166,4 +179,5 @@ ada_feeding_action_servers:
           - 0.5 # z, rad
         parameterization_orientation_path: 1 # 0: Euler, 1: Rotation Vector
         weight_orientation_path: 1.0
+        max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30


### PR DESCRIPTION
# Description

This PR allows the MoveTo trees to specify the desired velocity scale at which the robot should move.

# Testing procedure

Configure the robot to run `MoveToMouth` as documented in #42 .

- [x] Run `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback` Verify that is moves slower than before, and at a velocity that doesn't seem scary (feel free to play with the scaling in the YAML file).
- [x] Run `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveTo "{}" --feedback`. Verify that the movement to the staging location is faster than the movement to thei user's mouth.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
