### PR TITLE
Added termination logic to watchdog conditions

### DIFF
--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -427,3 +427,12 @@ class EStopCondition(WatchdogCondition):
         condition_2 = f"E-stop button has {'not ' if status_1 else ''}been unplugged"
 
         return [(status_1, name_1, condition_1), (status_2, name_2, condition_2)]
+
+    def terminate(self) -> None:
+        """
+        Terminate the EStop condition. This cleanly closes the pyaudio connection.
+        """
+        # Close the audio stream
+        self.stream.stop_stream()
+        self.stream.close()
+        self.audio.terminate()

--- a/ada_feeding/ada_feeding/watchdog/ft_sensor_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/ft_sensor_condition.py
@@ -191,3 +191,12 @@ class FTSensorCondition(WatchdogCondition):
             )
 
         return [(status_1, name_1, condition_1)]
+
+    def terminate(self) -> None:
+        """
+        Terminate the FT Sensor condition. In this case, no termination is
+        necessary, since the only state this watchdog condition maintains has
+        to do with ROS subscribers, which will be terminated when the watchdog
+        node terminates anyway.
+        """
+        return None

--- a/ada_feeding/ada_feeding/watchdog/watchdog_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/watchdog_condition.py
@@ -63,3 +63,11 @@ class WatchdogCondition(ABC):
             the watchdog should fail.
         """
         raise NotImplementedError("check_status not implemented")
+
+    @abstractmethod
+    def terminate(self) -> None:
+        """
+        Terminate the watchdog condition. This is called when the watchdog
+        terminates.
+        """
+        raise NotImplementedError("terminate not implemented")

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -66,7 +66,7 @@ class ADAWatchdog(Node):
 
         # Publish at the specified rate
         timer_period = 1.0 / self.publish_rate_hz.value  # seconds
-        self.timer = self.create_timer(timer_period, self.check_conditions)
+        self.timer = self.create_timer(timer_period, self.__check_conditions)
 
     def __load_parameters(self) -> None:
         """
@@ -147,7 +147,7 @@ class ADAWatchdog(Node):
             status=diagnostic_statuses,
         )
 
-    def check_conditions(self) -> None:
+    def __check_conditions(self) -> None:
         """
         Checks the watchdog conditions and publishes its output.
         """
@@ -183,6 +183,13 @@ class ADAWatchdog(Node):
             watchdog_output = self.__generate_diagnostic_array(diagnostic_statuses)
             self.watchdog_publisher.publish(watchdog_output)
 
+    def terminate(self) -> None:
+        """
+        Terminate the watchdog node.
+        """
+        for condition in self.conditions:
+            condition.terminate()
+
 
 def main(args=None):
     """
@@ -200,6 +207,7 @@ def main(args=None):
     # Destroy the node explicitly
     # (optional - otherwise it will be done automatically
     # when the garbage collector destroys the node object)
+    ada_watchdog.terminate()
     ada_watchdog.destroy_node()
     rclpy.shutdown()
 


### PR DESCRIPTION
# Description

In service of #69 .

Currently, watchdog conditions have no termination logic. This is fine for conditions like the `FTSensorCondition`, that only access sensors through ROS, because the subscriptions get terminated when `destro_node` is called. However, for conditions like the `EStopCondition` that use separate libraries, they need to implement separate logic to clean up the libraries they use.

As a specific example, if `pyaudio` is not properly closed, sometimes the connection to `portaudio` gets corrupted, and all future calls to pyaudio will return devices with only 0 channels until the computer restarts.

This PR adds a termination condition to all watchdog conditions, which is called if the watchdog node terminates.

# Testing procedure

- [x] Run the F/T sensor and plug in the e-stop. Run the watchdog `ros2 launch ada_feeding ada_feeding_launch.xml` Verify that the watchdog works as expected.
- [x] Terminate the watchdog. Verify that it terminates without exception.
- [x] Re-run the watchdog. Verify that the e-stop condition is still working as expected.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
