### PR TITLE
Have `EStopCondition` set system mic volume

### DIFF
--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -45,8 +45,9 @@ class EStopCondition(WatchdogCondition):
         "try the following:\n"
         "  1. Close all applications (e.g., System Settings) that may be accessing "
         "audio devices.\n"
-        "  2. If that still doesn't address it, run `pulseaudio -k && sudo alsa "
-        "force-reload`.\n"
+        "  2. If that still doesn't address it, run `sudo alsa force-reload`.\n"
+        "     Wait a few (~5) secs after running this command to restart the node,\n"
+        "     and note that you may have to run this command multiple times.\n"
         "Note that until this is addressed, the e-stop button will not be working."
     )
 
@@ -356,9 +357,9 @@ class EStopCondition(WatchdogCondition):
                     control_output = subprocess.check_output(
                         ["amixer", "sset", control_name, f"{control_percentage}%"]
                     )
-                    if f"[{control_percentage}]%".encode() not in control_output:
+                    if f"[{control_percentage}%]".encode() not in control_output:
                         self._node.get_logger().error(
-                            f"Microphone f{control_name} volume did not correctly set to "
+                            f"Microphone {control_name} volume did not correctly set to "
                             f"{control_percentage}%:\n{control_output}"
                         )
                 except subprocess.CalledProcessError as exc:

--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -287,6 +287,10 @@ class EStopCondition(WatchdogCondition):
         Set the system volume using `amixer`. This is necessary because the
         e-stop button is a microphone, so the system's microphone volume will
         impact the amplitude of readings for the e-stop button.
+
+        TODO: Although not crucial, we should consider storing the original
+        system volume, and then restoring it when thos watchdog condition is
+        terminated.
         """
         # Get the amixer_configuration
         toggle_control_name = self.amixer_configuration[

--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -6,9 +6,6 @@ ada_watchdog:
     ############################################################################
     # The rate at which to publish the watchdog message
     publish_rate_hz: 60.0
-    # Whether or not to use the estop button. This should only be set false in
-    # sim, because we currently have no way of simulating the estop button.
-    use_estop: true
 
     ############################################################################
     # Parameters for the FTSensorCondition of the watchdog

--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -31,6 +31,8 @@ ada_watchdog:
     # The device ID of the microphone (e-stop button). This should usually
     # be 0, the system default
     device: 0
+    # How often (in Hz) to retry opening the microphone if it fails.
+    stream_open_retry_hz: 1.0
     # How long to wait before checking the microphone readings. This is because
     # there is initial noise when we first listen to the microphone.
     initial_wait_secs: 2.0

--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -41,3 +41,59 @@ ada_watchdog:
     #   jack/microphone MICROPHONE unplug
     # Include the first two words in this parameter, exclude the third.
     acpi_event_name: "jack/microphone MICROPHONE"
+    # If there is a falling edge that passes this 16-bit int, it is considered a button
+    # click.
+    min_threshold: -10000
+    # If there is a rising edge that passes this 16-bit int, it is considered a button
+    # click.
+    max_threshold: 10000
+    # If there are multiple button clicks within this time range, it is considered a
+    # single click.
+    time_per_click_sec: 0.5
+    
+    # The below parameters are used to set the system microphone volume. It is
+    # important for system microphone volume to be consistent, because the e-stop
+    # button's signal amplitude is based on that. Since each device has different
+    # controls, we specify device-specific configurations.
+    # 
+    # Instructions to get the amixer parameters are here:
+    #     1. `amixer_mic_toggle_control_name`:
+    #         - Mute the microphone in the system settings.
+    #         - Run `amixer` in a terminal.
+    #         - Unmute the microphone in the system settings.
+    #         - Run `amixer` in a terminal.
+    #         - See which control switched from [off] to [on]. That is the control
+    #           name you want. (Note: saving amixer output to file and running `diff`
+    #           make this process easier.)
+    #     2. `amixer_mic_control_names`:
+    #         - Unmute the microphone in the system settings, and set its volume to be
+    #           low but not 0%.
+    #         - Run `amixer` in a terminal.
+    #         - In system settings, set the microphone volume to be 100%.
+    #         - Run `amixer` in a terminal.
+    #         - See which controls changed. Those are the control names you want.
+    #     3. `amixer_mic_control_percentages`:
+    #         - Open Audacity and System Settings side-by-side. Start recording in
+    #           Audacity. Press the e-stop button and notice the curve. You want the
+    #           low/high points of the curve to reach +/-1.0, but not exceed it (evidenced
+    #           by a horizontal line at 1.0 in Audacity). Tune the microphone volume in
+    #           System Settings until you get this.
+    #         - Run `amixer` in a terminal. Check the percentages for the controls you found
+    #           in the previous step. Those are the percentages you want.
+    amixer_configuration_name: lovelace
+    t0b1:
+      amixer_mic_toggle_control_name: "'Capture',0"
+      amixer_mic_control_names:
+        - "'Capture',0"
+        - "'Front Mic Boost',0"
+      amixer_mic_control_percentages:
+        - 37
+        - 0
+    lovelace:
+      amixer_mic_toggle_control_name: "'Capture',0"
+      amixer_mic_control_names:
+        - "'Capture',0"
+        - "'Internal Mic Boost',0"
+      amixer_mic_control_percentages:
+        - 40
+        - 0

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <arg name="run_web_bridge" default="true" description="Whether to run the web bridge nodes" />
+  <arg name="use_estop" default="true" description="Whether to use the e-stop. Should only be set false in sim, since we don't have a way of simulating the e-stop button." />
 
   <group if="$(var run_web_bridge)">
     <!-- The ROSBridge Node -->
@@ -11,6 +12,7 @@
   <!-- Launch the watchdog -->
   <node pkg="ada_feeding" exec="ada_watchdog.py" name="ada_watchdog">
     <param from="$(find-pkg-share ada_feeding)/config/ada_watchdog.yaml"/>
+    <param name="use_estop" value="$(var use_estop)"/>
     <remap from="~/ft_topic" to="/wireless_ft/ftSensor1" />
   </node>
 

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -26,7 +26,6 @@ from std_msgs.msg import Header
 from ada_feeding.watchdog import (
     EStopCondition,
     FTSensorCondition,
-    WatchdogCondition,
 )
 
 

--- a/ada_feeding/scripts/dummy_ft_sensor.py
+++ b/ada_feeding/scripts/dummy_ft_sensor.py
@@ -107,7 +107,7 @@ class DummyForceTorqueSensor(Node):
 
         self.get_logger().info("Initialized!")
 
-    def set_bias_callback(self, _: SetBool.Request, response: SetBool.Response):
+    def set_bias_callback(self, request: SetBool.Request, response: SetBool.Response):
         """
         Callback for the set_bias service. In order to mimic the actual service,
         this returns immediately, but then stops publishing data for 0.75 sec


### PR DESCRIPTION
# Description

In service of #66 . Since the e-stop button is read through the system's microphone stream, the system's microphone volume impacts the amplitude of the readings. This, in turn, impacts detection of a single e-stop button click.

This PR makes the following changes:

1. It has the `EStopCondition` always set the system volume to the same level, using user-specified parameters, so e-stop behavior is consistent regardless of what the system volume starts out as.
2. It adds instructions on getting and tuning these parameters to the config file.

# Testing procedure

On `lovelace`, do the following:

- [x] Mute the microphone and set the volume to 0. You can do that either in `System Settings > Sound`, or using `amixer sset [control_name] toggle` and `amixer sset [control_name] 0%` for `[control_name]` in `["'Capture',0", "'Internal Mic Boost',0"]`.
- [x] Run `amixer` to check the system microphone volume before the code is run.
- [x] Run `ros2 launch ada_feeding ada_feeding_launch.xml`
- [x] Run `amixer` and verify that the volume is toggled on and set to the percentages specified in the yaml file.
- [x] Thoroughly test the e-stop with a variety of different clicks. Verify that a click is picked up as only a single click, a soft-click is also picked up, a hold-and-click is picked up as two clicks, etc. You will likely have to kill and re-launch the e-stop several times to test this.

Note that if you test the e-stop button on a computer with a dedicated mic port (TS or TRS), you should just plug the e-stop in directly. If you test on a computer with a headset port (TRRS), you need to use the adapters.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
