### PR TITLE
Hotfix: Change planner_id to a property

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -152,10 +152,8 @@ class MoveTo(py_trees.behaviour.Behaviour):
         self.logger.info(f"{self.name} [MoveTo::initialise()]")
 
         # Set the planner_id
-        self.moveit2.set_planner_id(
-            get_from_blackboard_with_default(
-                self.move_to_blackboard, "planner_id", "RRTstarkConfigDefault"
-            )
+        self.moveit2.planner_id = get_from_blackboard_with_default(
+            self.move_to_blackboard, "planner_id", "RRTstarkConfigDefault"
         )
 
         # Set the max velocity


### PR DESCRIPTION
# Description

- In [this commit](https://github.com/AndrejOrsula/pymoveit2/commit/ad568eafa5ddb02ceb180ad3c6598f74d3448861), I replaced `MoveIt2`'s `set_planner_id` function with a property instead, which is more in-line with how other similar parameters are handled.
- I then percolated that change up to branches that build on top of `amaln/set_planner_id`. (Note: the newest top branch in our fork of pymoveit2 is [`amaln/cartesian_avoid_collision`](https://github.com/personalrobotics/pymoveit2/tree/amaln/cartesian_avoid_collision).
- This PR gets the MoveTo behavior in line with these changes.

# Testing procedure

- [x] Run the ada_feeding code as described in the [README](https://github.com/personalrobotics/ada_feeding/tree/ros2-devel/ada_feeding#usage).
- [x] Run any one action (e.g., `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`) and verify it succeeds.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
