### PR TITLE
Update `ada_feeding` to account for the fact that the robot base can rotate

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -400,12 +400,13 @@ class DistanceToGoal:
         # Only store messages that have all of the robot's joints. This is
         # because sometimes nodes other than the robot will be publishing to
         # the joint state publisher.
+        if self.joint_names is None:
+            return
         contains_all_robot_joints = True
-        if self.joint_names is not None:
-            for joint_name in self.joint_names:
-                if joint_name not in msg.name:
-                    contains_all_robot_joints = False
-                    break
+        for joint_name in self.joint_names:
+            if joint_name not in msg.name:
+                contains_all_robot_joints = False
+                break
         if contains_all_robot_joints:
             self.curr_joint_state = msg
 

--- a/ada_feeding/config/ada_planning_scene.yaml
+++ b/ada_feeding/config/ada_planning_scene.yaml
@@ -12,18 +12,22 @@ ada_planning_scene:
       filename: wheelchair.stl
       position: [0.02, -0.02, -0.05]
       quat_xyzw: [0.0, 0.0, 0.0, 1.0]
+      frame_id: root # the frame_id of the wheelchair meshthat the pose is relative to
     # an expanded mesh around the wheelchair to account for a user sitting in it
     wheelchair_collision: 
       filename: wheelchair_collision.stl
       position: [0.02, -0.02, -0.05] # should match the wheelchair position
       quat_xyzw: [0.0, 0.0, 0.0, 1.0] # should match the wheelchair orientation
+      frame_id: root # the frame_id of the wheelchair meshthat the pose is relative to
     table: # the table mesh
       filename: table.stl
       position: [0.08, -0.5, -0.45]
       quat_xyzw: [0.0, 0.0, 0.0, 1.0]
+      frame_id: root # the frame_id of the wheelchair meshthat the pose is relative to
     head: # the head mesh
       filename: tom.stl
       # This is an initial guess of head position; it will be updated as the
       # robot perceives the face.
       position: [0.29, 0.35, 0.85]
       quat_xyzw: [-0.0616284, -0.0616284, -0.704416, 0.704416]
+      frame_id: root # the frame_id of the wheelchair meshthat the pose is relative to

--- a/ada_feeding/scripts/ada_planning_scene.py
+++ b/ada_feeding/scripts/ada_planning_scene.py
@@ -23,7 +23,7 @@ from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
 CollisionMeshParams = namedtuple(
-    "CollisionMeshParams", ["filepath", "position", "quat_xyzw"]
+    "CollisionMeshParams", ["filepath", "position", "quat_xyzw", "frame_id"]
 )
 
 
@@ -136,12 +136,22 @@ class ADAPlanningScene(Node):
                     read_only=True,
                 ),
             )
+            frame_id = self.declare_parameter(
+                f"{object_id}.frame_id",
+                descriptor=ParameterDescriptor(
+                    name="frame_id",
+                    type=ParameterType.PARAMETER_STRING,
+                    description=("The frame ID that the pose is in."),
+                    read_only=True,
+                ),
+            )
 
             # Add the object to the list of objects
             self.objects[object_id] = CollisionMeshParams(
                 filepath=path.join(assets_dir.value, filename.value),
                 position=position.value,
                 quat_xyzw=quat_xyzw.value,
+                frame_id=frame_id.value,
             )
 
     def wait_for_moveit(self) -> None:
@@ -171,6 +181,7 @@ class ADAPlanningScene(Node):
                 filepath=params.filepath,
                 position=params.position,
                 quat_xyzw=params.quat_xyzw,
+                frame_id=params.frame_id,
             )
 
 


### PR DESCRIPTION
# Description

This PR has multiple changes to get `ada_feeding` integrated with the new IMU rotation code from [ada_ros2#16](https://github.com/personalrobotics/ada_ros2/pull/16).

1. There are multiple publishers to `/joint_state`: the robot state publisher, and the IMU node. However, the `MoveTo` behavior only cares about the robot state publisher when it is tracking the robot's configuration and determining how far along the robot is on the trajectory. Therefore, it should ignore `/joint_state` messages not from the robot state publisher, which is what this PR does.
2. The planning scene was earlier populated in the robot's base frame, but since that can rotate, it should instead by populated in the `root` frame.

# Testing procedure

1. Pull [ada_ros2#16](https://github.com/personalrobotics/ada_ros2/pull/16) and re-build your workspace.
3. Run the ada feeding code as documented in [the README](https://github.com/personalrobotics/ada_feeding/tree/ros2-devel/ada_feeding#usage).
4. Run an action, e.g., `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`
    - [x] Verify that it succeeds.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
