### PR TITLE
Remove re-taring + adjust wait for service

### DIFF
--- a/ada_feeding/ada_feeding/idioms/retry_call_ros_service.py
+++ b/ada_feeding/ada_feeding/idioms/retry_call_ros_service.py
@@ -25,7 +25,7 @@ def retry_call_ros_service(
     key_response: Optional[str] = None,
     response_checks: Optional[List[py_trees.common.ComparisonExpression]] = None,
     max_retries: int = 3,
-    wait_for_server_timeout_sec: float = 3.0,
+    wait_for_server_timeout_sec: float = 0.0,
     logger: Optional[logging.Logger] = None,
 ) -> py_trees.behaviour.Behaviour:
     """

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -227,6 +227,7 @@ class MoveToMouthTree(MoveToTree):
         )
         pre_moveto_config_behavior = pre_moveto_config(
             name=pre_moveto_config_name,
+            toggle_watchdog_listener=False,
             f_mag=self.force_threshold,
             t_mag=self.torque_threshold,
             logger=logger,

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -21,6 +21,7 @@ ada_feeding_action_servers:
       tree_class: ada_feeding.trees.MoveToConfigurationWithFTThresholdsTree # required
       tree_kws: # optional
         - joint_positions
+        - toggle_watchdog_listener
         - f_mag
         - max_velocity_scaling_factor
       tree_kwargs: # optional
@@ -31,6 +32,7 @@ ada_feeding_action_servers:
           - -2.30031 # j2n6s200_joint_4
           - -2.34026 # j2n6s200_joint_5
           -  2.95450 # j2n6s200_joint_6
+        toggle_watchdog_listener: false # optional, default: true
         f_mag: 4.0 # N
         max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30
@@ -53,6 +55,7 @@ ada_feeding_action_servers:
       tree_class: ada_feeding.trees.MoveToConfigurationWithFTThresholdsTree # required
       tree_kws: # optional
         - joint_positions
+        - toggle_watchdog_listener
         - f_mag
         - max_velocity_scaling_factor
       tree_kwargs: # optional
@@ -63,6 +66,7 @@ ada_feeding_action_servers:
           - -4.76501 # j2n6s200_joint_4
           -  5.99991 # j2n6s200_joint_5
           -  4.99555 # j2n6s200_joint_6
+        toggle_watchdog_listener: false # optional, default: true
         f_mag: 4.0 # N
         max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30
@@ -111,6 +115,7 @@ ada_feeding_action_servers:
       tree_class: ada_feeding.trees.MoveToConfigurationWithFTThresholdsTree # required
       tree_kws: # optional
         - joint_positions
+        - toggle_watchdog_listener
         - f_mag
         - max_velocity_scaling_factor
       tree_kwargs: # optional
@@ -121,6 +126,7 @@ ada_feeding_action_servers:
           - -4.00012 # j2n6s200_joint_4
           -  0.22831 # j2n6s200_joint_5
           -  3.87886 # j2n6s200_joint_6
+        toggle_watchdog_listener: false # optional, default: true
         f_mag: 4.0 # N
         max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
       tick_rate: 10 # Hz, optional, default: 30

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -340,10 +340,11 @@ class CreateActionServers(Node):
         """
         # Initialize the ActionServerBT object once
         tree_action_server = self._tree_classes[tree_class](**tree_kwargs)
-        # Create the tree once
+        # Create and setup the tree once
         tree = tree_action_server.create_tree(
             server_name, action_type, server_name, self.get_logger(), self
         )
+        tree.setup(node=self)  # TODO: consider adding a timeout here
         self._trees.append(tree)
 
         async def execute_callback(goal_handle: ServerGoalHandle) -> Awaitable:
@@ -360,9 +361,6 @@ class CreateActionServers(Node):
                 f"Executing goal {goal_uuid} "
                 f"with request {goal_handle.request}"
             )
-
-            # Setup the behavior tree class
-            tree.setup(node=self)  # TODO: consider adding a timeout here
 
             # pylint: disable=broad-exception-caught
             # All exceptions need printing at shutdown

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -469,12 +469,10 @@ def main(args: List = None) -> None:
     try:
         rclpy.spin(create_action_servers, executor=executor)
     except Exception:
-        create_action_servers.shutdown()
         traceback.print_exc()
 
     # Destroy the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
+    create_action_servers.shutdown()
     create_action_servers.destroy_node()
     rclpy.shutdown()
 


### PR DESCRIPTION
# Description

This PR makes 3 changes:
1. As of this commit in `forque_sensor_hardware`, it no longer stops publishing F/T data while re-taring. It's performance does drop from 100Hz to 10Hz while retaring, but that is not enough to trip the F/T sensor. As a result, we no longer need to toggle the watchdog listener on/off when re-taring (since the watchdog waits for the F/T sensor to stop publishing for 0.5 sec before tripping.
2. Currently, `create_action_servers.py` calls a tree's `setup` method every time the action is executed, and then calls its `shutdown` method at the end. This is against the spirit of py_trees: `setup` should be called once (e.g., to set up any middleware connections), and `shutdown` should be called once at the end to counteract anything that `setup` did. This PR makes that change.
3. Additionally, it doesn't make much sense to wait for a service in the `setup` method of a behavior, because that is only called once. For most of the trees execution, it just performs `update`, which fails if the service is not ready (but doesn't wait on it to be ready). Therefore, this PR changes the default time to wait on services to 0.0.

# Testing procedure

1. Follow the [instructions in the README](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/ada_feeding/README.md#usage) to launch the code.
2. Run a few actions and verify that they succeed as expected:
    - [x] `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
    - [x] `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
