### PR TITLE
Added workspace walls to the planning scene

### DIFF
--- a/ada_feeding/config/ada_planning_scene.yaml
+++ b/ada_feeding/config/ada_planning_scene.yaml
@@ -6,28 +6,53 @@ ada_planning_scene:
       - wheelchair_collision
       - table
       - head
-    # For each object, specify the filename of the mesh, and the position and
-    # orientation relative to the robot's base frame.
+      - workspace_wall_front
+      - workspace_wall_left
+      - workspace_wall_top
+    # For each object, specify:
+    #   - Shape: EITHER `filepath` (for a mesh) OR `primitive_type` and
+    #     `primitive_dims`(for a primitive -- see shape_msgs/SolidPrimitive.msg)
+    #   - Pose: `position` and `quat_xyzw` (see geometry_msgs/Pose.msg)
+    #   - Frame ID: `frame_id` (the frame_id of the object that the pose is
+    #     relative to)
     wheelchair: # the wheelchair mesh
       filename: wheelchair.stl
       position: [0.02, -0.02, -0.05]
       quat_xyzw: [0.0, 0.0, 0.0, 1.0]
-      frame_id: root # the frame_id of the wheelchair meshthat the pose is relative to
+      frame_id: root # the frame_id that the pose is relative to
     # an expanded mesh around the wheelchair to account for a user sitting in it
     wheelchair_collision: 
       filename: wheelchair_collision.stl
       position: [0.02, -0.02, -0.05] # should match the wheelchair position
       quat_xyzw: [0.0, 0.0, 0.0, 1.0] # should match the wheelchair orientation
-      frame_id: root # the frame_id of the wheelchair meshthat the pose is relative to
+      frame_id: root # the frame_id that the pose is relative to
     table: # the table mesh
       filename: table.stl
       position: [0.08, -0.5, -0.45]
       quat_xyzw: [0.0, 0.0, 0.0, 1.0]
-      frame_id: root # the frame_id of the wheelchair meshthat the pose is relative to
+      frame_id: root # the frame_id that the pose is relative to
     head: # the head mesh
       filename: tom.stl
       # This is an initial guess of head position; it will be updated as the
       # robot perceives the face.
       position: [0.29, 0.35, 0.85]
       quat_xyzw: [-0.0616284, -0.0616284, -0.704416, 0.704416]
-      frame_id: root # the frame_id of the wheelchair meshthat the pose is relative to
+      frame_id: root # the frame_id that the pose is relative to
+    workspace_wall_front:
+      primitive_type: 1 # Box=1. See shape_msgs/SolidPrimitive.msg
+      primitive_dims: [1.59, 0.01, 0.8] # Box has 3 dims: [x, y, z]
+      position: [-0.05, -0.58, 0.65]
+      quat_xyzw: [0.0, 0.0, 0.0, 1.0]
+      frame_id: root # the frame_id that the pose is relative to
+    workspace_wall_left:
+      primitive_type: 1 # Box=1. See shape_msgs/SolidPrimitive.msg
+      primitive_dims: [0.01, 1.5, 1.60] # Box has 3 dims: [x, y, z]
+      position: [0.75, 0.17, 0.25]
+      quat_xyzw: [0.0, 0.0, 0.0, 1.0]
+      frame_id: root # the frame_id that the pose is relative to
+    workspace_wall_top:
+      primitive_type: 1 # Box=1. See shape_msgs/SolidPrimitive.msg
+      primitive_dims: [1.59, 1.5, 0.01] # Box has 3 dims: [x, y, z]
+      position: [-0.05, 0.17, 1.05]
+      quat_xyzw: [0.0, 0.0, 0.0, 1.0]
+      frame_id: root # the frame_id that the pose is relative to


### PR DESCRIPTION
# Description

Unfortunately, MoveIt's workspace bounds [only applies to mobile robots](https://github.com/ros-planning/moveit_msgs/blob/99e6898f589d3d6929c6da68e0c3f1057866aca8/msg/WorkspaceParameters.msg#L3), not manipulators. To address that, this PR adds walls as collision objects to the planning scene. Further, this PR generalizes `ada_planning_scene` to be able to add [SolidPrimitive](https://github.com/ros2/common_interfaces/blob/humble/shape_msgs/msg/SolidPrimitive.msg) box, sphere, cylinder, or cone collision objects.

# Testing procedure

Pull the code from [ada_ros2#17](https://github.com/personalrobotics/ada_ros2/pull/17).

- [x] Follow the instructions in the README to launch the code. Verify that the planning scene looks like below.
![Screenshot 2023-09-08 at 1 59 59 PM (2)](https://github.com/personalrobotics/ada_feeding/assets/8277986/12e62a9b-6f77-497e-92c3-2f0d2727ca4a)
- [x] Run the following actions and verify that they behave as expected and succeed:
    - [x] `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
    - [x] `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`
- [x] Add the following lines of code to the `ada_planning_scene.yaml`, rebuild your workspace, re-launch the files, and verify that you see the sphere, cone, and cylinder as in the below image.
- After line 11: 
``` 
      - sphere_test
      - cylinder_test
      - cone_test
```

- At the end of the file:

```
    sphere_test:
      primitive_type: 2 # Sphere=2. See shape_msgs/SolidPrimitive.msg
      primitive_dims: [0.1] # Sphere has 1 dim: [radius]
      position: [0.5, 0.0, 0.5]
      quat_xyzw: [0.0, 0.0, 0.0, 1.0]
      frame_id: root # the frame_id that the pose is relative to
    cylinder_test:
      primitive_type: 3 # Cylinder=3. See shape_msgs/SolidPrimitive.msg
      primitive_dims: [0.1, 0.2] # Cylinder has 2 dims: [radius, height]
      position: [0.5, 0.0, 0.5]
      quat_xyzw: [0.0, 0.0, 0.0, 1.0]
      frame_id: root # the frame_id that the pose is relative to
    cone_test:
      primitive_type: 4 # Cone=4. See shape_msgs/SolidPrimitive.msg
      primitive_dims: [0.1, 0.2] # Cone has 2 dims: [radius, height]
      position: [0.5, 0.0, 0.7]
      quat_xyzw: [0.0, 0.0, 0.0, 1.0]
      frame_id: root # the frame_id that the pose is relative to
```

![Screenshot 2023-09-08 at 2 06 48 PM (2)](https://github.com/personalrobotics/ada_feeding/assets/8277986/67bba7b5-7235-4d05-935b-4d48ab3d5a5b)


# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
