### PR TITLE
Fix MoveTo bug if service is not available

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -216,7 +216,13 @@ class MoveTo(py_trees.behaviour.Behaviour):
                     )
                     return py_trees.common.Status.FAILURE
                 # Initiate an asynchronous planning call
-                self.planning_future = self.moveit2.plan_async(cartesian=self.cartesian)
+                planning_future = self.moveit2.plan_async(cartesian=self.cartesian)
+                if planning_future is None:
+                    self.logger.error(
+                        f"{self.name} [MoveTo::update()] Failed to initiate planning!"
+                    )
+                    return py_trees.common.Status.FAILURE
+                self.planning_future = planning_future
                 return py_trees.common.Status.RUNNING
 
             # Check if planning is complete


### PR DESCRIPTION
# Description

Currently, if a service is not available, [`pymoveit2` returns None instead of a future](https://github.com/personalrobotics/pymoveit2/blob/ccf1f1823218d972d8b2032897e021a0ff2b2454/pymoveit2/moveit2.py#L1461). However, for the `MoveTo` behavior, that is indistinguishable from the case where the plan has not yet been called, so it will call the plan again. However, because [`pymoveit2` already cleared the constraints](https://github.com/personalrobotics/pymoveit2/blob/ccf1f1823218d972d8b2032897e021a0ff2b2454/pymoveit2/moveit2.py#L568), the resulting plan will fail.

This PR addresses that my making `MoveTo` fail if `plan_async` returns None.

# Testing procedure

- [x] Launch the code as documented in the README. Run an action. Ensure it succeeds.
- [x] Modify pymoveit2 to make it always return the service is not available. Run the action. Ensure it fails right after it says the service is not available.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
