### PR TITLE
Put all callbacks in the same Reentrant Callback Group

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -15,7 +15,6 @@ from moveit_msgs.msg import MoveItErrorCodes
 import py_trees
 from pymoveit2 import MoveIt2, MoveIt2State
 from pymoveit2.robots import kinova
-from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
 from rclpy.qos import QoSPresetProfiles
 from sensor_msgs.msg import JointState
@@ -121,14 +120,12 @@ class MoveTo(py_trees.behaviour.Behaviour):
         # Create MoveIt 2 interface for moving the Jaco arm. This must be done
         # in __init__ and not setup since the MoveIt2 interface must be
         # initialized before the ROS2 node starts spinning.
-        callback_group = ReentrantCallbackGroup()
         self.moveit2 = MoveIt2(
             node=self.node,
             joint_names=kinova.joint_names(),
             base_link_name=kinova.base_link_name(),
             end_effector_name="forkTip",
             group_name=kinova.MOVE_GROUP_ARM,
-            callback_group=callback_group,
         )
 
         # Subscribe to the joint state and track the distance to goal while the

--- a/ada_feeding/ada_feeding/behaviors/toggle_collision_object.py
+++ b/ada_feeding/ada_feeding/behaviors/toggle_collision_object.py
@@ -12,7 +12,6 @@ MoveIt's planning scene.
 import py_trees
 from pymoveit2 import MoveIt2
 from pymoveit2.robots import kinova
-from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
 
 # Local imports
@@ -56,14 +55,12 @@ class ToggleCollisionObject(py_trees.behaviour.Behaviour):
         # Create MoveIt 2 interface for moving the Jaco arm. This must be done
         # in __init__ and not setup since the MoveIt2 interface must be
         # initialized before the ROS2 node starts spinning.
-        callback_group = ReentrantCallbackGroup()
         self.moveit2 = MoveIt2(
             node=self.node,
             joint_names=kinova.joint_names(),
             base_link_name=kinova.base_link_name(),
             end_effector_name="forkTip",
             group_name=kinova.MOVE_GROUP_ARM,
-            callback_group=callback_group,
         )
 
     def update(self) -> py_trees.common.Status:

--- a/ada_feeding/scripts/ada_watchdog.py
+++ b/ada_feeding/scripts/ada_watchdog.py
@@ -45,6 +45,8 @@ class ADAWatchdog(Node):
         """
         super().__init__("ada_watchdog")
 
+        self._default_callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
+
         # Load parameters
         self.__load_parameters()
 

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -89,6 +89,8 @@ class CreateActionServers(Node):
         """
         super().__init__("create_action_servers")
 
+        self._default_callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
+
         # Read the parameters that specify what action servers to create.
         action_server_params = self.read_params()
 

--- a/ada_feeding/scripts/dummy_ft_sensor.py
+++ b/ada_feeding/scripts/dummy_ft_sensor.py
@@ -55,6 +55,8 @@ class DummyForceTorqueSensor(Node):
         """
         super().__init__("dummy_ft_sensor")
 
+        self._default_callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
+
         # Get the mean and standard deviaion of the distribution
         self.mean = self.declare_parameter(
             "mean",

--- a/ada_feeding_perception/ada_feeding_perception/face_detection.py
+++ b/ada_feeding_perception/ada_feeding_perception/face_detection.py
@@ -52,6 +52,8 @@ class FaceDetectionNode(Node):
         """
         super().__init__("face_detection")
 
+        self._default_callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
+
         # Read the parameters
         # NOTE: These parameters are only read once. Any changes after the node
         # is initialized will not be reflected.

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -58,6 +58,8 @@ class SegmentFromPointNode(Node):
 
         super().__init__("segment_from_point")
 
+        self._default_callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
+
         # Check if cuda is available
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/ada_feeding_perception/launch/ada_feeding_perception.launch.py
+++ b/ada_feeding_perception/launch/ada_feeding_perception.launch.py
@@ -11,7 +11,6 @@ from launch_ros.parameter_descriptions import ParameterValue
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
-from launch.launch_context import LaunchContext
 from launch.substitutions import LaunchConfiguration, PythonExpression
 
 


### PR DESCRIPTION
# Description

In service of #62 .

As far as I can tell, our code is not at risk of any race conditions or deadlocks that would require mutually exclusive callbacks. (e.g., [calling a synchronous service from a callback is an example of a situation that may cause deadlock](https://docs.ros.org/en/humble/How-To-Guides/Using-callback-groups.html#avoiding-deadlocks).) However, our code does require callbacks to be received simultaneously, e.g., we should still receive watchdog messages while deciding whether or not to accept a goal.

Therefore, for every node in `ada_feeding` and `ada_feeding_perception`, this PR puts all the callbacks into the same ReentrantCallbackGroup, so they can be executed in parallel.

Paired with [ada_ros2#19](https://github.com/personalrobotics/ada_ros2/pull/19).

# Testing procedure

- [x] Launch the code as documented in the README. Run all actions. Ensure they behave as expected.
- [x] Launch the web app. Test SegmentAnything. Ensure it behaves as expected.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
