### PR TITLE
Move Face Detection out of callbacks

### DIFF
--- a/ada_feeding_perception/ada_feeding_perception/face_detection.py
+++ b/ada_feeding_perception/ada_feeding_perception/face_detection.py
@@ -8,7 +8,7 @@ of the largest detected mouth with respect to camera_depth_optical_frame.
 # Standard Imports
 import collections
 import os
-from threading import Lock
+import threading
 from typing import Tuple
 
 # Third-party imports
@@ -37,6 +37,9 @@ class FaceDetectionNode(Node):
     """
     This node publishes a 3d PointStamped location
     of the largest detected face with respect to camera_depth_optical_frame.
+
+    TODO: Eventually this node should return all detected faces, and then
+    let the client decide which face to use.
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -64,9 +67,11 @@ class FaceDetectionNode(Node):
             landmark_model_base_url,
             model_dir,
             depth_buffer_size,
+            rate_hz,
         ) = self.read_params()
         face_model_name = face_model_name.value
         landmark_model_name = landmark_model_name.value
+        self.rate_hz = rate_hz.value
 
         # Download the checkpoints if they don't exist
         self.face_model_path = os.path.join(model_dir.value, face_model_name)
@@ -96,7 +101,7 @@ class FaceDetectionNode(Node):
 
         # Keeps track of whether face detection is on or not
         self.is_on = False
-        self.is_on_lock = Lock()
+        self.is_on_lock = threading.Lock()
 
         # Create the service
         self.srv = self.create_service(
@@ -121,21 +126,9 @@ class FaceDetectionNode(Node):
         self.landmark_detector = cv2.face.createFacemarkLBF()
         self.landmark_detector.loadModel(self.landmark_model_path)
 
-        # Approximate values of current camera intrinsics matrix
-        # (updated with subscription)
-        self.camera_matrix = [614, 0, 312, 0, 614, 223, 0, 0, 1]
-
-        # Keeps track of the detected mouth points
-        self.img_mouth_center = []
-        self.img_mouth_points = []
-        self.is_face_detected = False
-
-        # The header of the latest color image with a detected face/mouth
-        self.color_img_header = None
-
-        self.mouth_detection_lock = Lock()
-
         # Subscribe to the camera feed
+        self.latest_img_msg = None
+        self.latest_img_msg_lock = threading.Lock()
         image_topic = "~/image"
         self.img_subscription = self.create_subscription(
             get_img_msg_type(image_topic, self), image_topic, self.camera_callback, 1
@@ -143,6 +136,7 @@ class FaceDetectionNode(Node):
 
         depth_buffer_size = depth_buffer_size.value
         self.depth_buffer = collections.deque(maxlen=depth_buffer_size)
+        self.depth_buffer_lock = threading.Lock()
         aligned_depth_topic = "~/aligned_depth"
         # Subscribe to the depth image
         self.depth_subscription = self.create_subscription(
@@ -153,7 +147,10 @@ class FaceDetectionNode(Node):
         )
 
         # Subscribe to the camera info
-        self.camera_info_lock = Lock()
+        self.camera_info_lock = threading.Lock()
+        # Approximate values of current camera intrinsics matrix
+        # (updated with subscription)
+        self.camera_matrix = [614, 0, 312, 0, 614, 223, 0, 0, 1]
         self.camera_info_subscription = self.create_subscription(
             CameraInfo, "~/camera_info", self.camera_info_callback, 1
         )
@@ -239,11 +236,23 @@ class FaceDetectionNode(Node):
                 ),
                 (
                     "depth_buffer_size",
-                    None,
+                    30,
                     ParameterDescriptor(
                         name="depth_buffer_size",
                         type=ParameterType.PARAMETER_INTEGER,
                         description=("The desired length of the depth image buffer"),
+                        read_only=True,
+                    ),
+                ),
+                (
+                    "rate_hz",
+                    15,
+                    ParameterDescriptor(
+                        name="rate_hz",
+                        type=ParameterType.PARAMETER_DOUBLE,
+                        description=(
+                            "The rate at which to run the face detection node"
+                        ),
                         read_only=True,
                     ),
                 ),
@@ -275,11 +284,13 @@ class FaceDetectionNode(Node):
         """
         Callback function for the toggle_face_detection service. Safely toggles
         the face detection on or off depending on the request.
+
         TODO: We technically only need to read one message from CameraInfo,
         since the intrinsics don't change. If `rclpy` adds a `wait_for_message`
         function, this subscription/callback should be replaced with that.
         """
-        self.camera_matrix = msg.k
+        with self.camera_info_lock:
+            self.camera_matrix = msg.k
 
     def depth_callback(self, msg: CompressedImage):
         """
@@ -287,58 +298,120 @@ class FaceDetectionNode(Node):
         function publishes the 3d location of the mouth on the /face_detection
         topic in the camera_depth_optical_frame
         """
-        # pylint: disable=too-many-locals
-        # The number of local variables is needed to implement locking behavior
-
         # Collect a buffer of depth images (depth_buffer is a collections.deque
         # of max length depth_buffer_size)
-        self.depth_buffer.append(msg)
+        with self.depth_buffer_lock:
+            self.depth_buffer.append(msg)
 
-        with self.is_on_lock:
-            is_on = self.is_on
+    def camera_callback(self, msg: CompressedImage):
+        """
+        Callback function for the camera feed. If face detection is on, this
+        function will detect faces in the image and store the location of the
+        center of the mouth of the largest detected face.
+        """
+        with self.latest_img_msg_lock:
+            self.latest_img_msg = msg
 
-        with self.mouth_detection_lock:
-            is_face_detected = self.is_face_detected
-            img_mouth_center = self.img_mouth_center
-            img_mouth_points = self.img_mouth_points
-            color_img_header = self.color_img_header
+    def run(self) -> None:
+        """
+        Run face detection at the specified rate. Specifically, this function
+        gets the latest RGB image message, gets the depth image message closest
+        to it in time, runs face detection on the RGB image, and then determines
+        the depth of the detected face.
+        """
 
-        with self.camera_info_lock:
-            camera_matrix = self.camera_matrix
+        # pylint: disable=too-many-locals
+        # TODO: Split the RGB part of face detection and the depth part of face
+        # detection into separate functions.
 
-        # Check if face detection is on
-        if is_on:
+        rate = self.create_rate(self.rate_hz)
+        while rclpy.ok():
+            # Loop at the specified rate
+            rate.sleep()
+
+            # Check if face detection is on
+            with self.is_on_lock:
+                is_on = self.is_on
+            if not is_on:
+                continue
+
+            # Create the FaceDetection message
             face_detection_msg = FaceDetection()
+
+            # Get the latest RGB image message
+            with self.latest_img_msg_lock:
+                rgb_msg = self.latest_img_msg
+
+            # Decode the image
+            image_rgb = cv2.imdecode(
+                np.frombuffer(rgb_msg.data, np.uint8), cv2.IMREAD_COLOR
+            )
+            image_gray = cv2.cvtColor(image_rgb, cv2.COLOR_BGR2GRAY)
+
+            # Detect faces using the haarcascade classifier on the grayscale image
+            faces = self.detector.detectMultiScale(image_gray)
+            is_face_detected = len(faces) > 0
+
             if is_face_detected:
-                # Retrieve the 2d location of the mouth center
-                u = int(img_mouth_center[0])
-                v = int(img_mouth_center[1])
+                # Detect landmarks (a 3d list) on image
+                # Relevant dimensions are 1: faces and 3: individual landmarks 0-68
+                _, landmarks = self.landmark_detector.fit(image_gray, faces)
+
+                # Add face markers to the image and find largest face
+                largest_face = [0, 0]  # [area (px^2), index]
+                for i, face in enumerate(faces):
+                    (x, y, w, h) = face
+                    # Annotate the image with the face. See below for the landmark indices:
+                    # https://pyimagesearch.com/2017/04/03/facial-landmarks-dlib-opencv-python/
+                    cv2.rectangle(image_rgb, (x, y), (x + w, y + h), (255, 255, 255), 2)
+                    for j in range(48, 68):
+                        x, y = landmarks[i][0][j]
+                        cv2.circle(image_rgb, (int(x), int(y)), 1, (0, 255, 0), 5)
+
+                    # Update the largest face
+                    if w * h > largest_face[0]:
+                        largest_face = [w * h, i]
+
+                # Annotate the image with a red rectangle around largest face
+                (x, y, w, h) = faces[largest_face[1]]
+                cv2.rectangle(image_rgb, (x, y), (x + w, y + h), (255, 0, 0), 2)
+
+                # Find stomion (mouth center) in image
+                img_mouth_center = landmarks[largest_face[1]][0][66]
+                u, v = int(round(img_mouth_center[0])), int(round(img_mouth_center[1]))
+                img_mouth_points = landmarks[largest_face[1]][0][48:68]
 
                 # Find depth image closest in time to saved color image
-                difference_array = np.zeros((len(self.depth_buffer),), dtype=np.float32)
-                for i, depth_img in enumerate(self.depth_buffer):
-                    depth_time = depth_img.header.stamp.sec + (
-                        depth_img.header.stamp.nanosec / (10**9)
-                    )
-                    img_time = color_img_header.stamp.sec + (
-                        color_img_header.stamp.nanosec / (10**9)
-                    )
-                    difference_array[i] = abs(depth_time - img_time)
-                closest_depth = self.bridge.imgmsg_to_cv2(
-                    self.depth_buffer[difference_array.argmin()],
+                time_diffs = []
+                with self.depth_buffer_lock:
+                    for i, depth_msg in enumerate(self.depth_buffer):
+                        depth_time = depth_msg.header.stamp.sec + (
+                            depth_msg.header.stamp.nanosec / (10**9)
+                        )
+                        img_time = rgb_msg.header.stamp.sec + (
+                            rgb_msg.header.stamp.nanosec / (10**9)
+                        )
+                        time_diffs.append(abs(depth_time - img_time))
+                    closest_depth_msg = self.depth_buffer[np.argmin(time_diffs)]
+                image_depth = self.bridge.imgmsg_to_cv2(
+                    closest_depth_msg,
                     desired_encoding="passthrough",
                 )
 
                 # Retrieve the depth value averaged over all mouth coordinates
                 depth_sum = 0
                 for point in img_mouth_points:
-                    depth_sum += closest_depth[int(point[1])][int(point[0])]
+                    depth_sum += image_depth[int(point[1])][int(point[0])]
                 depth = depth_sum / float(len(img_mouth_points))
+
+                # Get the camera matrix
+                with self.camera_info_lock:
+                    camera_matrix = self.camera_matrix
 
                 # Create target 3d point, with mm measurements converted to m
                 # Equations and explanation can be found at https://youtu.be/qByYk6JggQU
                 mouth_location = PointStamped()
-                mouth_location.header = color_img_header
+                mouth_location.header = rgb_msg.header
                 mouth_location.point.x = (
                     float(depth) * (float(u) - camera_matrix[2])
                 ) / (1000.0 * camera_matrix[0])
@@ -353,75 +426,8 @@ class FaceDetectionNode(Node):
             face_detection_msg.is_face_detected = is_face_detected
             self.publisher_results.publish(face_detection_msg)
 
-    def camera_callback(self, msg: CompressedImage):
-        """
-        Callback function for the camera feed. If face detection is on, this
-        function will detect faces in the image and store the location of the
-        center of the mouth of the largest detected face.
-        TODO: Eventually this node should return all detected faces, and then
-        let the client decide which face to use.
-        """
-        # pylint: disable=too-many-locals
-        # Two variables over the limit is fine, needed to find both faces and mouths
-        with self.is_on_lock:
-            is_on = self.is_on
-
-        if is_on:
-            image_rgb = cv2.imdecode(
-                np.frombuffer(msg.data, np.uint8), cv2.IMREAD_COLOR
-            )
-            is_face_detected = False
-
-            # Convert image to Grayscale
-            image_gray = cv2.cvtColor(image_rgb, cv2.COLOR_BGR2GRAY)
-
-            # Detect faces using the haarcascade classifier on the grayscale image
-            faces = self.detector.detectMultiScale(image_gray)
-
-            # Check if a face has been detected
-            if len(faces) > 0:
-                is_face_detected = True
-
-            if is_face_detected:
-                # Detect landmarks (a 3d list) on image
-                # Relevant dimensions are 1: faces and 3: individual landmarks 0-68
-                _, landmarks = self.landmark_detector.fit(image_gray, faces)
-
-                # Add face markers to the image and find largest face
-                largest_face = [0, 0]  # [area (px^2), index]
-                for i, face in enumerate(faces):
-                    # Draw a white rectangle around each face
-                    (x, y, w, h) = face
-                    cv2.rectangle(image_rgb, (x, y), (x + w, y + h), (255, 255, 255), 2)
-
-                    largest_face = [max(largest_face[0], w * h), i]
-                    # Display mouth landmarks (48-67, as explained in the below link)
-                    # https://pyimagesearch.com/2017/04/03/facial-landmarks-dlib-opencv-python/
-                    for j in range(48, 68):
-                        x, y = landmarks[i][0][j]
-                        cv2.circle(image_rgb, (int(x), int(y)), 1, (0, 255, 0), 5)
-
-                # Draw a red rectangle around largest face
-                (x, y, w, h) = faces[largest_face[1]]
-                cv2.rectangle(image_rgb, (x, y), (x + w, y + h), (255, 0, 0), 2)
-
-                # Find stomion (mouth center) in image
-                img_mouth_center = landmarks[largest_face[1]][0][66]
-                img_mouth_points = landmarks[largest_face[1]][0][48:68]
-
-                color_img_header = msg.header
-
-            annotated_msg = cv2_image_to_ros_msg(image_rgb, compress=False)
-
-            with self.mouth_detection_lock:
-                self.is_face_detected = is_face_detected
-                # The below variables are only accessed if is_face_detected is True
-                if is_face_detected:
-                    self.img_mouth_center = img_mouth_center
-                    self.img_mouth_points = img_mouth_points
-                    self.color_img_header = color_img_header
-
             # Publish annotated image with face and mouth landmarks
+            annotated_msg = cv2_image_to_ros_msg(image_rgb, compress=False)
             self.publisher_image.publish(annotated_msg)
 
 
@@ -434,9 +440,27 @@ def main(args=None):
     face_detection = FaceDetectionNode()
     executor = MultiThreadedExecutor()
 
-    rclpy.spin(face_detection, executor)
+    # Spin in the background since detecting faces will block
+    # the main thread
+    spin_thread = threading.Thread(
+        target=rclpy.spin,
+        args=(face_detection,),
+        kwargs={"executor": executor},
+        daemon=True,
+    )
+    spin_thread.start()
 
+    # Run face detection
+    try:
+        face_detection.run()
+    except KeyboardInterrupt:
+        pass
+
+    # Terminate this node
+    face_detection.destroy_node()
     rclpy.shutdown()
+    # Join the spin thread (so it is spinning in the main thread)
+    spin_thread.join()
 
 
 if __name__ == "__main__":

--- a/ada_feeding_perception/ada_feeding_perception/face_detection.py
+++ b/ada_feeding_perception/ada_feeding_perception/face_detection.py
@@ -9,12 +9,12 @@ of the largest detected mouth with respect to camera_depth_optical_frame.
 import collections
 import os
 import threading
-from typing import Tuple
+from typing import Tuple, Union
 
 # Third-party imports
 import cv2
 from cv_bridge import CvBridge
-from geometry_msgs.msg import PointStamped
+from geometry_msgs.msg import Point
 import numpy as np
 import rclpy
 from rclpy.node import Node
@@ -292,7 +292,7 @@ class FaceDetectionNode(Node):
         with self.camera_info_lock:
             self.camera_matrix = msg.k
 
-    def depth_callback(self, msg: CompressedImage):
+    def depth_callback(self, msg: Image):
         """
         Callback function for depth images. If face_detection is on, this
         function publishes the 3d location of the mouth on the /face_detection
@@ -303,7 +303,7 @@ class FaceDetectionNode(Node):
         with self.depth_buffer_lock:
             self.depth_buffer.append(msg)
 
-    def camera_callback(self, msg: CompressedImage):
+    def camera_callback(self, msg: Union[CompressedImage, Image]):
         """
         Callback function for the camera feed. If face detection is on, this
         function will detect faces in the image and store the location of the
@@ -312,6 +312,163 @@ class FaceDetectionNode(Node):
         with self.latest_img_msg_lock:
             self.latest_img_msg = msg
 
+    def detect_largest_face(
+        self, img_msg: Union[CompressedImage, Image], publish_annotated_img: bool = True
+    ) -> Tuple[bool, Tuple[int, int], np.ndarray]:
+        """
+        Detect the largest face in an RGB image.
+
+        Parameters
+        ----------
+        img_msg: The RGB image to detect faces in.
+        publish_annotated_img: Whether to publish an annotated image with the
+            detected faces and mouth points.
+
+        Returns
+        -------
+        is_face_detected: Whether a face was detected in the image.
+        mouth_center: The (u,v) coordinates of the somion of the largest face
+            detected in the image.
+        mouth_points: A list of (u,v) coordinates of the facial landmarks of the mouth.
+        """
+
+        # pylint: disable=too-many-locals
+        # This function is not too complex, but it does have a lot of local variables.
+
+        # Decode the image
+        image_rgb = cv2.imdecode(
+            np.frombuffer(img_msg.data, np.uint8), cv2.IMREAD_COLOR
+        )
+        image_gray = cv2.cvtColor(image_rgb, cv2.COLOR_BGR2GRAY)
+
+        # Detect faces using the haarcascade classifier on the grayscale image
+        # NOTE: This detector will launch multiple threads to detect faces in
+        # parallel.
+        faces = self.detector.detectMultiScale(image_gray)
+        is_face_detected = len(faces) > 0
+        img_mouth_center = (0, 0)
+        img_mouth_points = []
+
+        if is_face_detected:
+            # Detect landmarks (a 3d list) on image
+            # Relevant dimensions are 1: faces and 3: individual landmarks 0-68
+            _, landmarks = self.landmark_detector.fit(image_gray, faces)
+
+            # Add face markers to the image and find largest face
+            largest_face = [0, 0]  # [area (px^2), index]
+            for i, face in enumerate(faces):
+                (x, y, w, h) = face
+
+                # Update the largest face
+                if w * h > largest_face[0]:
+                    largest_face = [w * h, i]
+
+                # Annotate the image with the face. See below for the landmark indices:
+                # https://pyimagesearch.com/2017/04/03/facial-landmarks-dlib-opencv-python/
+                if publish_annotated_img:
+                    cv2.rectangle(image_rgb, (x, y), (x + w, y + h), (255, 255, 255), 2)
+                    for j in range(48, 68):
+                        landmark_x, landmark_y = landmarks[i][0][j]
+                        cv2.circle(
+                            image_rgb,
+                            (int(landmark_x), int(landmark_y)),
+                            1,
+                            (0, 255, 0),
+                            5,
+                        )
+
+            # Annotate the image with a red rectangle around largest face
+            (x, y, w, h) = faces[largest_face[1]]
+            cv2.rectangle(image_rgb, (x, y), (x + w, y + h), (0, 0, 255), 2)
+
+            # Find stomion (mouth center) in image
+            img_mouth_center = landmarks[largest_face[1]][0][66]
+            img_mouth_points = landmarks[largest_face[1]][0][48:68]
+
+        # Publish annotated image
+        if publish_annotated_img:
+            annotated_msg = cv2_image_to_ros_msg(image_rgb, compress=False)
+            self.publisher_image.publish(annotated_msg)
+
+        return is_face_detected, img_mouth_center, img_mouth_points
+
+    def get_mouth_depth(
+        self, rgb_msg: Union[CompressedImage, Image], face_points: np.ndarray
+    ) -> float:
+        """
+        Get the depth of the mouth of the largest detected face in the image.
+
+        Parameters
+        ----------
+        rgb_msg: The RGB image that the face was detected in.
+        face_points: A list of (u,v) coordinates of the facial landmarks whose depth
+            should be averaged to get the predicted depth of the mouth.
+
+        Returns
+        -------
+        depth_mm: The depth of the mouth in mm.
+        """
+        # Find depth image closest in time to RGB image that face was in
+        with self.depth_buffer_lock:
+            min_time_diff = float("inf")
+            closest_depth_msg = None
+            for depth_msg in self.depth_buffer:
+                depth_time = depth_msg.header.stamp.sec + (
+                    depth_msg.header.stamp.nanosec / (10**9)
+                )
+                img_time = rgb_msg.header.stamp.sec + (
+                    rgb_msg.header.stamp.nanosec / (10**9)
+                )
+                time_diff = abs(depth_time - img_time)
+                if time_diff < min_time_diff:
+                    min_time_diff = time_diff
+                    closest_depth_msg = depth_msg
+        image_depth = self.bridge.imgmsg_to_cv2(
+            closest_depth_msg,
+            desired_encoding="passthrough",
+        )
+
+        # Retrieve the depth value averaged over all mouth coordinates
+        depth_sum = 0
+        for point in face_points:
+            depth_sum += image_depth[int(point[1])][int(point[0])]
+        depth_mm = depth_sum / float(len(face_points))
+
+        return depth_mm
+
+    def get_stomion_point(self, u: int, v: int, depth_mm: float) -> Point:
+        """
+        Get the 3d location of the mouth. This function assumes the color
+        and depth images have the same frame, and returns the point in
+        that frame.
+
+        Parameters
+        ----------
+        u: The u coordinate of the mouth in the RGB image.
+        v: The v coordinate of the mouth in the RGB image.
+        depth_mm: The depth of the mouth in mm.
+
+        Returns
+        -------
+        mouth_point: The 3d location of the mouth in the camera frame.
+        """
+        # Get the camera matrix
+        with self.camera_info_lock:
+            camera_matrix = self.camera_matrix
+
+        # Compute the point. See https://www.youtube.com/watch?v=qByYk6JggQU&t=443s
+        # for the derivation of the formulae.
+        mouth_point = Point()
+        mouth_point.x = (float(depth_mm) * (float(u) - camera_matrix[2])) / (
+            1000.0 * camera_matrix[0]
+        )
+        mouth_point.y = (float(depth_mm) * (float(v) - camera_matrix[5])) / (
+            1000.0 * camera_matrix[4]
+        )
+        mouth_point.z = float(depth_mm) / 1000.0
+
+        return mouth_point
+
     def run(self) -> None:
         """
         Run face detection at the specified rate. Specifically, this function
@@ -319,11 +476,6 @@ class FaceDetectionNode(Node):
         to it in time, runs face detection on the RGB image, and then determines
         the depth of the detected face.
         """
-
-        # pylint: disable=too-many-locals
-        # TODO: Split the RGB part of face detection and the depth part of face
-        # detection into separate functions.
-
         rate = self.create_rate(self.rate_hz)
         while rclpy.ok():
             # Loop at the specified rate
@@ -342,93 +494,26 @@ class FaceDetectionNode(Node):
             with self.latest_img_msg_lock:
                 rgb_msg = self.latest_img_msg
 
-            # Decode the image
-            image_rgb = cv2.imdecode(
-                np.frombuffer(rgb_msg.data, np.uint8), cv2.IMREAD_COLOR
-            )
-            image_gray = cv2.cvtColor(image_rgb, cv2.COLOR_BGR2GRAY)
-
-            # Detect faces using the haarcascade classifier on the grayscale image
-            faces = self.detector.detectMultiScale(image_gray)
-            is_face_detected = len(faces) > 0
+            # Detect the largest face in the RGB image
+            (
+                is_face_detected,
+                img_mouth_center,
+                img_mouth_points,
+            ) = self.detect_largest_face(rgb_msg)
 
             if is_face_detected:
-                # Detect landmarks (a 3d list) on image
-                # Relevant dimensions are 1: faces and 3: individual landmarks 0-68
-                _, landmarks = self.landmark_detector.fit(image_gray, faces)
+                # Get the depth of the mouth
+                depth_mm = self.get_mouth_depth(rgb_msg, img_mouth_points)
 
-                # Add face markers to the image and find largest face
-                largest_face = [0, 0]  # [area (px^2), index]
-                for i, face in enumerate(faces):
-                    (x, y, w, h) = face
-                    # Annotate the image with the face. See below for the landmark indices:
-                    # https://pyimagesearch.com/2017/04/03/facial-landmarks-dlib-opencv-python/
-                    cv2.rectangle(image_rgb, (x, y), (x + w, y + h), (255, 255, 255), 2)
-                    for j in range(48, 68):
-                        x, y = landmarks[i][0][j]
-                        cv2.circle(image_rgb, (int(x), int(y)), 1, (0, 255, 0), 5)
-
-                    # Update the largest face
-                    if w * h > largest_face[0]:
-                        largest_face = [w * h, i]
-
-                # Annotate the image with a red rectangle around largest face
-                (x, y, w, h) = faces[largest_face[1]]
-                cv2.rectangle(image_rgb, (x, y), (x + w, y + h), (255, 0, 0), 2)
-
-                # Find stomion (mouth center) in image
-                img_mouth_center = landmarks[largest_face[1]][0][66]
-                u, v = int(round(img_mouth_center[0])), int(round(img_mouth_center[1]))
-                img_mouth_points = landmarks[largest_face[1]][0][48:68]
-
-                # Find depth image closest in time to saved color image
-                time_diffs = []
-                with self.depth_buffer_lock:
-                    for i, depth_msg in enumerate(self.depth_buffer):
-                        depth_time = depth_msg.header.stamp.sec + (
-                            depth_msg.header.stamp.nanosec / (10**9)
-                        )
-                        img_time = rgb_msg.header.stamp.sec + (
-                            rgb_msg.header.stamp.nanosec / (10**9)
-                        )
-                        time_diffs.append(abs(depth_time - img_time))
-                    closest_depth_msg = self.depth_buffer[np.argmin(time_diffs)]
-                image_depth = self.bridge.imgmsg_to_cv2(
-                    closest_depth_msg,
-                    desired_encoding="passthrough",
+                # Get the 3d location of the mouth
+                face_detection_msg.detected_mouth_center.header = rgb_msg.header
+                face_detection_msg.detected_mouth_center.point = self.get_stomion_point(
+                    img_mouth_center[0], img_mouth_center[1], depth_mm
                 )
-
-                # Retrieve the depth value averaged over all mouth coordinates
-                depth_sum = 0
-                for point in img_mouth_points:
-                    depth_sum += image_depth[int(point[1])][int(point[0])]
-                depth = depth_sum / float(len(img_mouth_points))
-
-                # Get the camera matrix
-                with self.camera_info_lock:
-                    camera_matrix = self.camera_matrix
-
-                # Create target 3d point, with mm measurements converted to m
-                # Equations and explanation can be found at https://youtu.be/qByYk6JggQU
-                mouth_location = PointStamped()
-                mouth_location.header = rgb_msg.header
-                mouth_location.point.x = (
-                    float(depth) * (float(u) - camera_matrix[2])
-                ) / (1000.0 * camera_matrix[0])
-                mouth_location.point.y = (
-                    float(depth) * (float(v) - camera_matrix[5])
-                ) / (1000.0 * camera_matrix[4])
-                mouth_location.point.z = float(depth) / 1000.0
-
-                face_detection_msg.detected_mouth_center = mouth_location
 
             # Publish 3d point
             face_detection_msg.is_face_detected = is_face_detected
             self.publisher_results.publish(face_detection_msg)
-
-            # Publish annotated image with face and mouth landmarks
-            annotated_msg = cv2_image_to_ros_msg(image_rgb, compress=False)
-            self.publisher_image.publish(annotated_msg)
 
 
 def main(args=None):

--- a/ada_feeding_perception/ada_feeding_perception/republisher.py
+++ b/ada_feeding_perception/ada_feeding_perception/republisher.py
@@ -39,13 +39,13 @@ class Republisher(Node):
         # Load the parameters
         (
             self.from_topics,
-            self.topic_type_strs,
-            self.republished_namespace,
+            topic_type_strs,
+            republished_namespace,
         ) = self.load_parameters()
 
         # Import the topic types
         self.topic_types = []
-        for topic_type_str in self.topic_type_strs:
+        for topic_type_str in topic_type_strs:
             self.topic_types.append(import_from_string(topic_type_str))
 
         # For each topic, create a callback, publisher, and subscriber
@@ -62,7 +62,7 @@ class Republisher(Node):
             to_topic = "/".join(
                 [
                     "",
-                    self.republished_namespace.lstrip("/"),
+                    republished_namespace.lstrip("/"),
                     self.from_topics[i].lstrip("/"),
                 ]
             )

--- a/ada_feeding_perception/ada_feeding_perception/republisher.py
+++ b/ada_feeding_perception/ada_feeding_perception/republisher.py
@@ -34,6 +34,8 @@ class Republisher(Node):
         """
         super().__init__("republisher")
 
+        self._default_callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
+
         # Load the parameters
         (
             self.from_topics,

--- a/ada_feeding_perception/config/face_detection.yaml
+++ b/ada_feeding_perception/config/face_detection.yaml
@@ -10,4 +10,6 @@ face_detection:
     # The URL to download the facial landmark detection model checkpoint from if it is not already downloaded
     landmark_model_base_url: "https://raw.githubusercontent.com/kurnianggoro/GSOC2017/master/data/"
     # The desired length of the depth image buffer
-    depth_buffer_size: 10
+    depth_buffer_size: 30
+    # The rate at which to detect and publish detected faces
+    rate_hz: 15

--- a/ada_feeding_perception/config/face_detection.yaml
+++ b/ada_feeding_perception/config/face_detection.yaml
@@ -12,4 +12,4 @@ face_detection:
     # The desired length of the depth image buffer
     depth_buffer_size: 30
     # The rate at which to detect and publish detected faces
-    rate_hz: 15
+    rate_hz: 3


### PR DESCRIPTION
# Description

Currently, the work of face detection happens in callback functions. Since the work of face detection is slower than the publishing rate, this creates a backlog of threads waiting to call that callback function. This PR addresses it, by moving the core work of face detection out of callbacks into its own thread.

# Testing procedure

Setup:
1. `ros2 launch ada_feeding_perception ada_Feeding_perception.launch.py`
2. `ros2 service call /toggle_face_detection std_srvs/srv/SetBool "{data: true}" `

Tests:
- [x] Launch `rviz2` and display `face_detection_img`. Move your face in and out of the camera field of view and ensure it is properly annotated. 
- [x] `ros2 topic echo /face_detection` Ensure the returned coordinates make sense from the camera color optical frame.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
