### PR TITLE
Revamp Callback Groups

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/move_to.py
+++ b/ada_feeding/ada_feeding/behaviors/move_to.py
@@ -15,6 +15,7 @@ from moveit_msgs.msg import MoveItErrorCodes
 import py_trees
 from pymoveit2 import MoveIt2, MoveIt2State
 from pymoveit2.robots import kinova
+from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
 from rclpy.qos import QoSPresetProfiles
 from sensor_msgs.msg import JointState
@@ -120,12 +121,16 @@ class MoveTo(py_trees.behaviour.Behaviour):
         # Create MoveIt 2 interface for moving the Jaco arm. This must be done
         # in __init__ and not setup since the MoveIt2 interface must be
         # initialized before the ROS2 node starts spinning.
+        # Using ReentrantCallbackGroup to align with the examples from pymoveit2.
+        # TODO: Assess whether ReentrantCallbackGroup is necessary for MoveIt2.
+        callback_group = ReentrantCallbackGroup()
         self.moveit2 = MoveIt2(
             node=self.node,
             joint_names=kinova.joint_names(),
             base_link_name=kinova.base_link_name(),
             end_effector_name="forkTip",
             group_name=kinova.MOVE_GROUP_ARM,
+            callback_group=callback_group,
         )
 
         # Subscribe to the joint state and track the distance to goal while the

--- a/ada_feeding/ada_feeding/behaviors/toggle_collision_object.py
+++ b/ada_feeding/ada_feeding/behaviors/toggle_collision_object.py
@@ -12,6 +12,7 @@ MoveIt's planning scene.
 import py_trees
 from pymoveit2 import MoveIt2
 from pymoveit2.robots import kinova
+from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
 
 # Local imports
@@ -55,12 +56,16 @@ class ToggleCollisionObject(py_trees.behaviour.Behaviour):
         # Create MoveIt 2 interface for moving the Jaco arm. This must be done
         # in __init__ and not setup since the MoveIt2 interface must be
         # initialized before the ROS2 node starts spinning.
+        # Using ReentrantCallbackGroup to align with the examples from pymoveit2.
+        # TODO: Assess whether ReentrantCallbackGroup is necessary for MoveIt2.
+        callback_group = ReentrantCallbackGroup()
         self.moveit2 = MoveIt2(
             node=self.node,
             joint_names=kinova.joint_names(),
             base_link_name=kinova.base_link_name(),
             end_effector_name="forkTip",
             group_name=kinova.MOVE_GROUP_ARM,
+            callback_group=callback_group,
         )
 
     def update(self) -> py_trees.common.Status:

--- a/ada_feeding/ada_feeding/watchdog/ft_sensor_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/ft_sensor_condition.py
@@ -67,11 +67,15 @@ class FTSensorCondition(WatchdogCondition):
 
         # Subscribe to the FT sensor topic
         self.ft_sensor_topic = self._node.resolve_topic_name("~/ft_topic")
+        self.ft_sensor_callback_group = (
+            rclpy.callback_groups.MutuallyExclusiveCallbackGroup()
+        )
         self.ft_sensor_subscription = self._node.create_subscription(
             WrenchStamped,
             self.ft_sensor_topic,
             self.__ft_sensor_callback,
             rclpy.qos.QoSPresetProfiles.SENSOR_DATA.value,
+            callback_group=self.ft_sensor_callback_group,
         )
 
     def __ft_sensor_callback(self, msg: WrenchStamped) -> None:

--- a/ada_feeding/scripts/ada_planning_scene.py
+++ b/ada_feeding/scripts/ada_planning_scene.py
@@ -55,6 +55,8 @@ class ADAPlanningScene(Node):
         self.load_parameters()
 
         # Initialize the MoveIt2 interface
+        # Using ReentrantCallbackGroup to align with the examples from pymoveit2.
+        # TODO: Assess whether ReentrantCallbackGroup is necessary for MoveIt2.
         callback_group = ReentrantCallbackGroup()
         self.moveit2 = MoveIt2(
             node=self,

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -89,8 +89,6 @@ class CreateActionServers(Node):
         """
         super().__init__("create_action_servers")
 
-        self._default_callback_group = rclpy.callback_groups.ReentrantCallbackGroup()
-
         # Read the parameters that specify what action servers to create.
         action_server_params = self.read_params()
 

--- a/ada_feeding_perception/ada_feeding_perception/republisher.py
+++ b/ada_feeding_perception/ada_feeding_perception/republisher.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, List, Tuple
 # Third-party imports
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 import rclpy
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
@@ -79,6 +80,7 @@ class Republisher(Node):
                 topic=self.from_topics[i],
                 callback=callback,
                 qos_profile=1,  # TODO: we should get and mirror the QOS profile of the from_topic
+                callback_group=MutuallyExclusiveCallbackGroup(),
             )
             self.subs.append(subscriber)
 
@@ -183,7 +185,7 @@ def main(args=None):
     republisher = Republisher()
 
     # Use a MultiThreadedExecutor to enable processing goals concurrently
-    executor = MultiThreadedExecutor()
+    executor = MultiThreadedExecutor(num_threads=len(republisher.subs))
 
     rclpy.spin(republisher, executor=executor)
 


### PR DESCRIPTION
# Description

**Recommended Reading**: ROS2 tutorial on [Executors](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Executors.html), ROS2 tutorial on [Callback Groups](https://docs.ros.org/en/humble/How-To-Guides/Using-callback-groups.html).

In service of #62 . Paired with [ada_ros2#20](https://github.com/personalrobotics/ada_ros2/pull/20).

Before PR #90 , all callbacks were in the same mutually exclusive callback group, which means only one could be running at a time. This sometimes resulted in watchdog messages being dropped on `lovelace` while a service call was active (Issue #63 ). PR #90 changed this to put all callbacks into a Reentrant Callback Group. However, this had the following issues:

1. **Too much CPU load**. This is documented in the ROS2 tutorials: ["the executor overhead in terms of CPU and memory usage is considerable."](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Executors.html#outlook). In practice, on both `t0b1` and `lovelace`, due to the high CPU load the controller (which is running on the same computer) sometimes resulted in very jerky movements.
2. **Missed messages**. Strangely enough, having everything in one ReentrantCallbackGroup still resulted in the watchdog messages sometimes being missed. However, I think this time it is due to a different reason -- some callback in the callback group fires very frequently, and therefore uses up all the threads, so there is no longer a thread available for the watchdog. This is documented in the ROS2 tutorials: ["Higher priority callbacks may be blocked by lower priority callbacks."](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Executors.html#outlook)
3. **Callback queue filling up.** If a callback takes quite long (e.g., face detection prior to #91 ), then the callback queue in RMW would fill up, which I'd imagine negatively impacts CPU load. ["if the processing time of some callbacks is longer, messages and events will be queued on the lower layers of the stack"](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Executors.html#outlook)
4. **Callbacks being called in parallel with themselves.** Callbacks in a reentrant group can be called in parallel with themselves, which is not always desirable behavior. For example, we may not want to run two instances of face detection on two separate images -- we only care about the newest one.

This PR addresses the above issues by revamping callback groups in the following way:

1. Use ReentrantGroups sparingly. If a MultiThreadedExecutor has even one ReentrantCallbackGroup in it, it is possible that that callback group eats up all the threads, and none are left for any other callback group. Instead, opting for multiple MutuallyExclusiveCallbackGroups is better, because we can anticipate how many threads the Executor needs, and ensure that one is always available for each callback group.
    1. The only reason to use a ReentrnatCallbackGroup is if the callback **should** be called in parallel with itself. If it **can** be called in parallel with itself but doesn't get a benefit from it, instead opt for it to have its own MutuallyExclusiveCallbackGroup. If it **should** be called in parallel with **other** callbacks (a common case), put the callbacks in separate MutuallyExclusiveCallbackGroups.
2. Time-critical callbacks that should not be blocked by anything (e.g., watchdog messages) should be in their own callback group (typically their own MutuallyExclusiveCallbackGroup).
3. For all other callbacks, the main question is whether to put them into a separate MutuallyExclusiveCallbackGroup, or a MutuallyExclusiveCallbackGroup that is shared with other callbacks. For that decision, determine whether the callbacks **should be** called in parallel with each other or not. 
    1. For instance, in [forque_sensor_hardware](https://github.com/personalrobotics/forque_sensor_hardware/blob/main/src/main.cpp), the re-taring service and the timer to read from the FT sensor should be called in parallel with each other, so that FT readings continue to be read even while the service is active. Therefore, those callbacks should be put into separate mutually exclusive callback groups. 
    2. On the other hand, in many of the MoveTo trees (e.g., MoveToMouth), the subscriptions and service calls are only ever called sequentially relative to each other. Hence, they can and should be placed into the same MutuallyExclusiveCallbackGroup.

# Testing procedure

- [x] On both `t0b1` and `lovelace`, run all actions, at least twice each, and ensure that there is no wierdness in having callbacks get called.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
