### PR TITLE
Added Global MoveIt2 Object

### DIFF
--- a/ada_feeding/ada_feeding/decorators/__init__.py
+++ b/ada_feeding/ada_feeding/decorators/__init__.py
@@ -10,6 +10,9 @@ This package contains custom py_tree decorators for the Ada Feeding project.
 # Parent class for all decorators that add constraints
 from .move_to_constraint import MoveToConstraint
 
+# Clear constraints
+from .clear_constraints import ClearConstraints
+
 # Goal constraints
 from .set_joint_goal_constraint import SetJointGoalConstraint
 from .set_position_goal_constraint import SetPositionGoalConstraint

--- a/ada_feeding/ada_feeding/decorators/clear_constraints.py
+++ b/ada_feeding/ada_feeding/decorators/clear_constraints.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the ClearConstraints decorator, which clears all constraints
+on the MoveIt2 object.
+"""
+# Third-party imports
+import py_trees
+from rclpy.node import Node
+
+# Local imports
+from ada_feeding.decorators import MoveToConstraint
+from ada_feeding.helpers import get_moveit2_object
+
+# pylint: disable=duplicate-code
+# All the constraints have similar code when registering and setting blackboard
+# keys, since the parameters for constraints are similar. This is not a problem.
+
+
+class ClearConstraints(MoveToConstraint):
+    """
+    ClearConstraints clears all constraints on the MoveIt2 object. This
+    Should be at the top of a branch of constraints and the MoveTo behavior,
+    in case any previous behavior left lingering constraints (e.g., due to
+    an error).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        child: py_trees.behaviour.Behaviour,
+        node: Node,
+    ):
+        """
+        Initialize the MoveToConstraint decorator.
+
+        Parameters
+        ----------
+        name: The name of the behavior.
+        child: The child behavior.
+        """
+        # Initiatilize the decorator
+        super().__init__(name=name, child=child)
+
+        # Define inputs from the blackboard
+        self.blackboard = self.attach_blackboard_client(
+            name=name + " ClearConstraints", namespace=name
+        )
+
+        # Get the MoveIt2 object.
+        self.moveit2, self.moveit2_lock = get_moveit2_object(
+            self.blackboard,
+            node,
+        )
+
+    def set_constraint(self) -> None:
+        """
+        Sets the joint goal constraint.
+        """
+        self.logger.info(f"{self.name} [ClearConstraints::set_constraint()]")
+
+        # Set the constraint
+        with self.moveit2_lock:
+            self.moveit2.clear_goal_constraints()
+            self.moveit2.clear_path_constraints()

--- a/ada_feeding/ada_feeding/decorators/move_to_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/move_to_constraint.py
@@ -12,10 +12,8 @@ from abc import ABC, abstractmethod
 
 # Third-party imports
 import py_trees
-from pymoveit2 import MoveIt2
 
 # Local imports
-from ada_feeding.behaviors import MoveTo
 
 
 class MoveToConstraint(py_trees.decorators.Decorator, ABC):
@@ -23,36 +21,6 @@ class MoveToConstraint(py_trees.decorators.Decorator, ABC):
     An abstract decorator to add constraints to any behavior that moves
     the robot using MoveIt2.
     """
-
-    def __init__(
-        self,
-        name: str,
-        child: py_trees.behaviour.Behaviour,
-    ):
-        """
-        Initialize the MoveToConstraint decorator.
-
-        Parameters
-        ----------
-        name: The name of the behavior.
-        child: The child behavior.
-        """
-        # Check the child behavior type
-        if not isinstance(child, (MoveTo, MoveToConstraint)):
-            raise TypeError(
-                f"{name} [MoveToConstraint::__init__()] Child must be of "
-                "type MoveTo or MoveToConstraint!"
-            )
-
-        # Initiatilize the decorator
-        super().__init__(name=name, child=child)
-
-    @property
-    def moveit2(self) -> MoveIt2:
-        """
-        Get the MoveIt2 interface.
-        """
-        return self.decorated.moveit2
 
     def initialise(self) -> None:
         """
@@ -78,15 +46,3 @@ class MoveToConstraint(py_trees.decorators.Decorator, ABC):
         Just pass through the child's status
         """
         return self.decorated.status
-
-    def terminate(self, new_status: py_trees.common.Status) -> None:
-        """
-        Clear the constraints.
-        """
-        self.logger.info(
-            f"{self.name} [MoveToConstraint::terminate()][{self.status}->{new_status}]"
-        )
-
-        # Clear the constraints
-        self.moveit2.clear_goal_constraints()
-        self.moveit2.clear_path_constraints()

--- a/ada_feeding/ada_feeding/decorators/set_joint_goal_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_joint_goal_constraint.py
@@ -6,10 +6,11 @@ behavior that moves the robot using MoveIt2.
 """
 # Third-party imports
 import py_trees
+from rclpy.node import Node
 
 # Local imports
 from ada_feeding.decorators import MoveToConstraint
-from ada_feeding.helpers import get_from_blackboard_with_default
+from ada_feeding.helpers import get_from_blackboard_with_default, get_moveit2_object
 
 # pylint: disable=duplicate-code
 # All the constraints have similar code when registering and setting blackboard
@@ -26,6 +27,7 @@ class SetJointGoalConstraint(MoveToConstraint):
         self,
         name: str,
         child: py_trees.behaviour.Behaviour,
+        node: Node,
     ):
         """
         Initialize the MoveToConstraint decorator.
@@ -53,6 +55,12 @@ class SetJointGoalConstraint(MoveToConstraint):
         )
         self.blackboard.register_key(key="weight", access=py_trees.common.Access.READ)
 
+        # Get the MoveIt2 object.
+        self.moveit2, self.moveit2_lock = get_moveit2_object(
+            self.blackboard,
+            node,
+        )
+
     def set_constraint(self) -> None:
         """
         Sets the joint goal constraint.
@@ -70,9 +78,10 @@ class SetJointGoalConstraint(MoveToConstraint):
         weight = get_from_blackboard_with_default(self.blackboard, "weight", 1.0)
 
         # Set the constraint
-        self.moveit2.set_joint_goal(
-            joint_positions=joint_positions,
-            joint_names=joint_names,
-            tolerance=tolerance,
-            weight=weight,
-        )
+        with self.moveit2_lock:
+            self.moveit2.set_joint_goal(
+                joint_positions=joint_positions,
+                joint_names=joint_names,
+                tolerance=tolerance,
+                weight=weight,
+            )

--- a/ada_feeding/ada_feeding/decorators/set_joint_path_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_joint_path_constraint.py
@@ -6,10 +6,11 @@ to keep specified joints within a specified tolerance of a specified position.
 """
 # Third-party imports
 import py_trees
+from rclpy.node import Node
 
 # Local imports
 from ada_feeding.decorators import MoveToConstraint
-from ada_feeding.helpers import get_from_blackboard_with_default
+from ada_feeding.helpers import get_from_blackboard_with_default, get_moveit2_object
 
 # pylint: disable=duplicate-code
 # All the constraints have similar code when registering and setting blackboard
@@ -26,6 +27,7 @@ class SetJointPathConstraint(MoveToConstraint):
         self,
         name: str,
         child: py_trees.behaviour.Behaviour,
+        node: Node,
     ):
         """
         Initialize the MoveToConstraint decorator.
@@ -53,6 +55,12 @@ class SetJointPathConstraint(MoveToConstraint):
         )
         self.blackboard.register_key(key="weight", access=py_trees.common.Access.READ)
 
+        # Get the MoveIt2 object.
+        self.moveit2, self.moveit2_lock = get_moveit2_object(
+            self.blackboard,
+            node,
+        )
+
     def set_constraint(self) -> None:
         """
         Sets the joint path constraint.
@@ -70,9 +78,10 @@ class SetJointPathConstraint(MoveToConstraint):
         weight = get_from_blackboard_with_default(self.blackboard, "weight", 1.0)
 
         # Set the constraint
-        self.moveit2.set_path_joint_constraint(
-            joint_positions=joint_positions,
-            joint_names=joint_names,
-            tolerance=tolerance,
-            weight=weight,
-        )
+        with self.moveit2_lock:
+            self.moveit2.set_path_joint_constraint(
+                joint_positions=joint_positions,
+                joint_names=joint_names,
+                tolerance=tolerance,
+                weight=weight,
+            )

--- a/ada_feeding/ada_feeding/decorators/set_orientation_goal_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_orientation_goal_constraint.py
@@ -6,10 +6,11 @@ orientation goal to any behavior that moves the robot using MoveIt2.
 """
 # Third-party imports
 import py_trees
+from rclpy.node import Node
 
 # Local imports
 from ada_feeding.decorators import MoveToConstraint
-from ada_feeding.helpers import get_from_blackboard_with_default
+from ada_feeding.helpers import get_from_blackboard_with_default, get_moveit2_object
 
 # pylint: disable=duplicate-code
 # All the constraints have similar code when registering and setting blackboard
@@ -26,6 +27,7 @@ class SetOrientationGoalConstraint(MoveToConstraint):
         self,
         name: str,
         child: py_trees.behaviour.Behaviour,
+        node: Node,
     ):
         """
         Initialize the MoveToConstraint decorator.
@@ -57,6 +59,12 @@ class SetOrientationGoalConstraint(MoveToConstraint):
             key="parameterization", access=py_trees.common.Access.READ
         )
 
+        # Get the MoveIt2 object.
+        self.moveit2, self.moveit2_lock = get_moveit2_object(
+            self.blackboard,
+            node,
+        )
+
     def set_constraint(self) -> None:
         """
         Sets the orientation goal constraint.
@@ -80,11 +88,12 @@ class SetOrientationGoalConstraint(MoveToConstraint):
         )
 
         # Set the constraint
-        self.moveit2.set_orientation_goal(
-            quat_xyzw=quat_xyzw,
-            frame_id=frame_id,
-            target_link=target_link,
-            tolerance=tolerance,
-            weight=weight,
-            parameterization=parameterization,
-        )
+        with self.moveit2_lock:
+            self.moveit2.set_orientation_goal(
+                quat_xyzw=quat_xyzw,
+                frame_id=frame_id,
+                target_link=target_link,
+                tolerance=tolerance,
+                weight=weight,
+                parameterization=parameterization,
+            )

--- a/ada_feeding/ada_feeding/decorators/set_orientation_path_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_orientation_path_constraint.py
@@ -7,10 +7,11 @@ specified orientation.
 """
 # Third-party imports
 import py_trees
+from rclpy.node import Node
 
 # Local imports
 from ada_feeding.decorators import MoveToConstraint
-from ada_feeding.helpers import get_from_blackboard_with_default
+from ada_feeding.helpers import get_from_blackboard_with_default, get_moveit2_object
 
 # pylint: disable=duplicate-code
 # All the constraints have similar code when registering and setting blackboard
@@ -27,6 +28,7 @@ class SetOrientationPathConstraint(MoveToConstraint):
         self,
         name: str,
         child: py_trees.behaviour.Behaviour,
+        node: Node,
     ):
         """
         Initialize the MoveToConstraint decorator.
@@ -58,6 +60,12 @@ class SetOrientationPathConstraint(MoveToConstraint):
             key="parameterization", access=py_trees.common.Access.READ
         )
 
+        # Get the MoveIt2 object.
+        self.moveit2, self.moveit2_lock = get_moveit2_object(
+            self.blackboard,
+            node,
+        )
+
     def set_constraint(self) -> None:
         """
         Sets the orientation goal constraint.
@@ -81,11 +89,12 @@ class SetOrientationPathConstraint(MoveToConstraint):
         )
 
         # Set the constraint
-        self.moveit2.set_path_orientation_constraint(
-            quat_xyzw=quat_xyzw,
-            frame_id=frame_id,
-            target_link=target_link,
-            tolerance=tolerance,
-            weight=weight,
-            parameterization=parameterization,
-        )
+        with self.moveit2_lock:
+            self.moveit2.set_path_orientation_constraint(
+                quat_xyzw=quat_xyzw,
+                frame_id=frame_id,
+                target_link=target_link,
+                tolerance=tolerance,
+                weight=weight,
+                parameterization=parameterization,
+            )

--- a/ada_feeding/ada_feeding/decorators/set_position_goal_constraint.py
+++ b/ada_feeding/ada_feeding/decorators/set_position_goal_constraint.py
@@ -6,10 +6,11 @@ behavior that moves the robot using MoveIt2.
 """
 # Third-party imports
 import py_trees
+from rclpy.node import Node
 
 # Local imports
 from ada_feeding.decorators import MoveToConstraint
-from ada_feeding.helpers import get_from_blackboard_with_default
+from ada_feeding.helpers import get_from_blackboard_with_default, get_moveit2_object
 
 # pylint: disable=duplicate-code
 # All the constraints have similar code when registering and setting blackboard
@@ -26,6 +27,7 @@ class SetPositionGoalConstraint(MoveToConstraint):
         self,
         name: str,
         child: py_trees.behaviour.Behaviour,
+        node: Node,
     ):
         """
         Initialize the MoveToConstraint decorator.
@@ -52,6 +54,12 @@ class SetPositionGoalConstraint(MoveToConstraint):
         )
         self.blackboard.register_key(key="weight", access=py_trees.common.Access.READ)
 
+        # Get the MoveIt2 object.
+        self.moveit2, self.moveit2_lock = get_moveit2_object(
+            self.blackboard,
+            node,
+        )
+
     def set_constraint(self) -> None:
         """
         Sets the position goal constraint.
@@ -70,10 +78,11 @@ class SetPositionGoalConstraint(MoveToConstraint):
         weight = get_from_blackboard_with_default(self.blackboard, "weight", 1.0)
 
         # Set the constraint
-        self.moveit2.set_position_goal(
-            position=position,
-            frame_id=frame_id,
-            target_link=target_link,
-            tolerance=tolerance,
-            weight=weight,
-        )
+        with self.moveit2_lock:
+            self.moveit2.set_position_goal(
+                position=position,
+                frame_id=frame_id,
+                target_link=target_link,
+                tolerance=tolerance,
+                weight=weight,
+            )

--- a/ada_feeding/ada_feeding/helpers.py
+++ b/ada_feeding/ada_feeding/helpers.py
@@ -4,10 +4,16 @@ Ada Feeding project.
 """
 
 # Standard imports
-from typing import Any, Set
+from threading import Lock
+from typing import Any, Optional, Set, Tuple
 
 # Third-party imports
 import py_trees
+from py_trees.common import Access
+from pymoveit2 import MoveIt2
+from pymoveit2.robots import kinova
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.node import Node
 
 # These prefixes are used to separate namespaces from each other.
 # For example, if we have a behavior `foo` that has a position goal constraint,
@@ -19,6 +25,7 @@ import py_trees
 # Note that this norm can only be used if each MoveTo behavior has maximally
 # one constraint of each type. When creating a behavior with multiple constraints
 # of the same time, you'll have to create custom namespaces.
+CLEAR_CONSTRAINTS_NAMESPACE_PREFIX = "clear_constraints"
 POSITION_GOAL_CONSTRAINT_NAMESPACE_PREFIX = "position_goal_constraint"
 ORIENTATION_GOAL_CONSTRAINT_NAMESPACE_PREFIX = "orientation_goal_constraint"
 JOINT_GOAL_CONSTRAINT_NAMESPACE_PREFIX = "joint_goal_constraint"
@@ -26,6 +33,79 @@ POSITION_PATH_CONSTRAINT_NAMESPACE_PREFIX = "position_path_constraint"
 ORIENTATION_PATH_CONSTRAINT_NAMESPACE_PREFIX = "orientation_path_constraint"
 JOINT_PATH_CONSTRAINT_NAMESPACE_PREFIX = "joint_path_constraint"
 MOVE_TO_NAMESPACE_PREFIX = "move_to"
+
+
+def get_moveit2_object(
+    blackboard: py_trees.blackboard.Client,
+    node: Optional[Node] = None,
+) -> Tuple[MoveIt2, Lock]:
+    """
+    Gets the MoveIt2 object and its corresponding lock from the blackboard.
+    If they do not exist on the blackboard, they are created.
+
+    Parameters
+    ----------
+    blackboard: The blackboard client. Any blackboard client can be used, as
+        this function: (a) uses absolute paths; and (b) registers the keys if
+        they are not already registered.
+    node: The ROS2 node that the MoveIt2 object should be associated with, if
+        we need to create it from scratch. If None, this function will not create
+        the MoveIt2 object if it doesn't exist, and will instead raise a KeyError.
+
+    Returns
+    -------
+    moveit2: The MoveIt2 object.
+    lock: The lock for the MoveIt2 object.
+
+    Raises
+    -------
+    KeyError: if the MoveIt2 object does not exist and node is None.
+    """
+    # These Blackboard keys are used to store the single, global MoveIt2 object
+    # and its corresponding lock. Note that it is important that these keys start with
+    # a "/" because to indicate it is an absolute path, so all behaviors can access
+    # the same object.
+    moveit2_blackboard_key = "/moveit2"
+    moveit2_lock_blackboard_key = "/moveit2_lock"
+
+    # First, register the MoveIt2 object and its corresponding lock for READ access
+    if not blackboard.is_registered(moveit2_blackboard_key, Access.READ):
+        blackboard.register_key(moveit2_blackboard_key, Access.READ)
+    if not blackboard.is_registered(moveit2_lock_blackboard_key, Access.READ):
+        blackboard.register_key(moveit2_lock_blackboard_key, Access.READ)
+
+    # Second, check if the MoveIt2 object and its corresponding lock exist on the
+    # blackboard. If they do not, register the blackboard for WRITE access to those
+    # keys and create them.
+    try:
+        moveit2 = blackboard.get(moveit2_blackboard_key)
+        lock = blackboard.get(moveit2_lock_blackboard_key)
+    except KeyError as exc:
+        # If no node is passed in, raise an error.
+        if node is None:
+            raise KeyError("MoveIt2 object does not exist on the blackboard") from exc
+
+        # If a node is passed in, create a new MoveIt2 object and lock.
+        node.get_logger().info(
+            "MoveIt2 object and lock do not exist on the blackboard. Creating them now."
+        )
+        blackboard.register_key(moveit2_blackboard_key, Access.WRITE)
+        blackboard.register_key(moveit2_lock_blackboard_key, Access.WRITE)
+        # TODO: Assess whether ReentrantCallbackGroup is necessary for MoveIt2.
+        callback_group = ReentrantCallbackGroup()
+        moveit2 = MoveIt2(
+            node=node,
+            joint_names=kinova.joint_names(),
+            base_link_name=kinova.base_link_name(),
+            end_effector_name="forkTip",
+            group_name=kinova.MOVE_GROUP_ARM,
+            callback_group=callback_group,
+        )
+        lock = Lock()
+        blackboard.set(moveit2_blackboard_key, moveit2)
+        blackboard.set(moveit2_lock_blackboard_key, lock)
+
+    return moveit2, lock
 
 
 def get_from_blackboard_with_default(

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -51,6 +51,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         t_y: float = 0.0,
         t_z: float = 0.0,
         keys_to_not_write_to_blackboard: Set[str] = set(),
+        clear_constraints: bool = True,
     ):
         """
         Initializes tree-specific parameters.
@@ -80,6 +81,9 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
             Note that the keys need to be exact e.g., "move_to.cartesian,"
             "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
             etc.
+        clear_constraints: Whether or not to put a ClearConstraints decorator at the top
+            of this branch. If you will be adding additional Constraints on top of this
+            tree, this should be False. Else (e.g., if this is a standalone tree), True.
         """
 
         # pylint: disable=too-many-locals
@@ -110,6 +114,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         self.t_z = t_z
 
         self.keys_to_not_write_to_blackboard = keys_to_not_write_to_blackboard
+        self.clear_constraints = clear_constraints
 
     def create_move_to_tree(
         self,
@@ -143,6 +148,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                 allowed_planning_time=self.allowed_planning_time,
                 max_velocity_scaling_factor=self.max_velocity_scaling_factor,
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
+                clear_constraints=self.clear_constraints,
             )
             .create_tree(name, self.action_type, tree_root_name, logger, node)
             .root

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
@@ -55,6 +55,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         weight_position_path: float = 1.0,
         weight_orientation_path: float = 1.0,
         keys_to_not_write_to_blackboard: Set[str] = set(),
+        clear_constraints: bool = True,
     ):
         """
         Initializes tree-specific parameters.
@@ -88,6 +89,9 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
             Note that the keys need to be exact e.g., "move_to.cartesian,"
             "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
             etc.
+        clear_constraints: Whether or not to put a ClearConstraints decorator at the top
+            of this branch. If you will be adding additional Constraints on top of this
+            tree, this should be False. Else (e.g., if this is a standalone tree), True.
         """
         # Initialize MoveToTree
         super().__init__()
@@ -113,6 +117,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         self.weight_orientation_path = weight_orientation_path
 
         self.keys_to_not_write_to_blackboard = keys_to_not_write_to_blackboard
+        self.clear_constraints = clear_constraints
 
     def create_move_to_tree(
         self,
@@ -149,6 +154,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
                 allowed_planning_time=self.allowed_planning_time,
                 max_velocity_scaling_factor=self.max_velocity_scaling_factor,
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
+                clear_constraints=False,
             )
             .create_tree(name, self.action_type, tree_root_name, logger, node)
             .root
@@ -170,6 +176,8 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
             parameterization_orientation_path=self.parameterization_orientation_path,
             weight_position_path=self.weight_position_path,
             weight_orientation_path=self.weight_orientation_path,
+            node=node,
+            clear_constraints=self.clear_constraints,
         )
 
         tree = py_trees.trees.BehaviourTree(root)

--- a/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
@@ -62,6 +62,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         weight_position_path: float = 1.0,
         weight_orientation_path: float = 1.0,
         keys_to_not_write_to_blackboard: Set[str] = set(),
+        clear_constraints: bool = True,
     ):
         """
         Initializes tree-specific parameters.
@@ -101,6 +102,9 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
             Note that the keys need to be exact e.g., "move_to.cartesian,"
             "position_goal_constraint.tolerance," "orientation_goal_constraint.tolerance,"
             etc.
+        clear_constraints: Whether or not to put a ClearConstraints decorator at the top
+            of this branch. If you will be adding additional Constraints on top of this
+            tree, this should be False. Else (e.g., if this is a standalone tree), True.
         """
         # Initialize MoveToTree
         super().__init__()
@@ -132,6 +136,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         self.weight_orientation_path = weight_orientation_path
 
         self.keys_to_not_write_to_blackboard = keys_to_not_write_to_blackboard
+        self.clear_constraints = clear_constraints
 
     def create_move_to_tree(
         self,
@@ -175,6 +180,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
                 allowed_planning_time=self.allowed_planning_time,
                 max_velocity_scaling_factor=self.max_velocity_scaling_factor,
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
+                clear_constraints=False,
             )
             .create_tree(name, self.action_type, tree_root_name, logger, node)
             .root
@@ -195,6 +201,8 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
             parameterization_orientation_path=self.parameterization_orientation_path,
             weight_position_path=self.weight_position_path,
             weight_orientation_path=self.weight_orientation_path,
+            node=node,
+            clear_constraints=self.clear_constraints,
         )
 
         tree = py_trees.trees.BehaviourTree(root)

--- a/ada_feeding/ada_feeding/watchdog/ft_sensor_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/ft_sensor_condition.py
@@ -29,6 +29,9 @@ class FTSensorCondition(WatchdogCondition):
     checks that the sensor is still publishing and its data is not zero-variance.
     """
 
+    # pylint: disable=too-many-instance-attributes
+    # One over is fine, since each attribute is necessary
+
     def __init__(self, node: Node) -> None:
         """
         Initialize the FTSensorCondition class.


### PR DESCRIPTION
# Description

In service of #60 .

Previously, each behavior that needed to use the `MoveIt2` object created its own instance. This is non-ideal for two reasons: (1) unnecessary extra subscribers, service clients, etc. (2) If a programmer mistakenly puts two MoveTo behaviors into a Parallel composite, it will attempt to execute both because they are different instances.

This PR addresses that by doing the following:

1. Creates a global MoveIt2 object in the root of the blackboard, accessible via a helper function.
2. Implements a lock that the helper function returns. This lock should always be used in conjunction with the MoveIt2 object, to ensure thread-safety.
3. Implements a `ClearConstraints` decorator, to ensure that constraints from past behaviors do not bleed into the current behavior.
4. Modified the MoveTo trees to put a `ClearConstraints` decorator at the top of every `MoveTo` branch, but not lower than that (e.g., not between other constraints).

# Testing procedure

- [x] Run the code as documented in the README.
- [x] Run every action and verify that it succeeds.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
