### PR TITLE
`create_action_servers.py` should set loggers

### DIFF
--- a/ada_feeding/ada_feeding/action_server_bt.py
+++ b/ada_feeding/ada_feeding/action_server_bt.py
@@ -4,7 +4,6 @@ servers with py_trees.
 """
 # Standard imports
 from abc import ABC, abstractmethod
-import logging
 import traceback
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/action_server_bt.py
+++ b/ada_feeding/ada_feeding/action_server_bt.py
@@ -29,7 +29,6 @@ class ActionServerBT(ABC):
         name: str,
         action_type: type,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -44,7 +43,6 @@ class ActionServerBT(ABC):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
         """

--- a/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
+++ b/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
@@ -40,7 +40,6 @@ def add_pose_path_constraints(
     child: py_trees.behaviour.Behaviour,
     name: str,
     blackboard: py_trees.blackboard.Blackboard,
-    logger: logging.Logger,
     node: Node,
     keys_to_not_write_to_blackboard: Set[str] = set(),
     # Optional parameters for the pose path constraint
@@ -66,7 +65,6 @@ def add_pose_path_constraints(
     child: The child behavior. Must be an instance of MoveTo or MoveToConstraint.
     name: The name for the tree that this behavior is in.
     blackboard: The blackboard for the tree that this behavior is in.
-    logger: The logger for the tree that this behavior is in.
     node: The ROS2 node that the MoveIt2 object is associated with.
     keys_to_not_write_to_blackboard: the keys to not write to the blackboard.
         Note that the keys need to be exact e.g., "move_to.cartesian,"
@@ -242,7 +240,6 @@ def add_pose_path_constraints(
         position_constraint = SetPositionPathConstraint(
             position_path_constaint_name, child, node
         )
-        position_constraint.logger = logger
     else:
         position_constraint = child
 
@@ -254,7 +251,6 @@ def add_pose_path_constraints(
         orientation_constraint = SetOrientationPathConstraint(
             orientation_goal_constaint_name, position_constraint, node
         )
-        orientation_constraint.logger = logger
     else:
         orientation_constraint = position_constraint
 
@@ -266,7 +262,6 @@ def add_pose_path_constraints(
         clear_constraints_behavior = ClearConstraints(
             clear_constraints_name, orientation_constraint, node
         )
-        clear_constraints_behavior.logger = logger
     else:
         clear_constraints_behavior = orientation_constraint
 

--- a/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
+++ b/ada_feeding/ada_feeding/idioms/add_pose_path_constraints.py
@@ -7,7 +7,6 @@ on it, and adds a SetPositionPathConstraint and/or SetOrientationPathConstraint.
 """
 
 # Standard imports
-import logging
 from typing import Set, Tuple, Optional, Union
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/idioms/bite_transfer.py
+++ b/ada_feeding/ada_feeding/idioms/bite_transfer.py
@@ -6,7 +6,6 @@ transfer, e.g., the MoveToMouth and MoveFromMouth behaviors.
 """
 
 # Standard imports
-import logging
 import operator
 from typing import List
 

--- a/ada_feeding/ada_feeding/idioms/bite_transfer.py
+++ b/ada_feeding/ada_feeding/idioms/bite_transfer.py
@@ -27,7 +27,6 @@ def get_toggle_collision_object_behavior(
     node: Node,
     collision_object_ids: List[str],
     allow: bool,
-    logger: logging.Logger,
 ) -> py_trees.behaviour.Behaviour:
     """
     Creates a behaviour that toggles a collision object.
@@ -39,7 +38,6 @@ def get_toggle_collision_object_behavior(
     node: The ROS2 node that this behaviour belongs to.
     collision_object_ids: The IDs of the collision object to toggle.
     allow: Whether to allow or disallow the collision object.
-    logger: The logger to use for the behaviour.
 
     Returns
     -------
@@ -56,7 +54,6 @@ def get_toggle_collision_object_behavior(
         collision_object_ids=collision_object_ids,
         allow=allow,
     )
-    toggle_collision_object.logger = logger
     return toggle_collision_object
 
 
@@ -64,7 +61,6 @@ def get_toggle_face_detection_behavior(
     tree_name: str,
     behavior_name_prefix: str,
     request_data: bool,
-    logger: logging.Logger,
 ) -> py_trees.behaviour.Behaviour:
     """
     Creates a behaviour that toggles face detection.
@@ -75,7 +71,6 @@ def get_toggle_face_detection_behavior(
     behavior_name_prefix: The prefix for the name of the behaviour.
     request_data: The request data to send to the toggle_face_detection service.
         True to turn it on, False otherwise.
-    logger: The logger to use for the behaviour.
 
     Returns
     -------
@@ -97,7 +92,6 @@ def get_toggle_face_detection_behavior(
                 operator=operator.eq,
             )
         ],
-        logger=logger,
     )
     return toggle_face_detection_behavior
 
@@ -106,7 +100,6 @@ def get_toggle_watchdog_listener_behavior(
     tree_name: str,
     behavior_name_prefix: str,
     request_data: bool,
-    logger: logging.Logger,
 ) -> py_trees.behaviour.Behaviour:
     """
     Creates a behaviour that toggles the watchdog listener.
@@ -117,7 +110,6 @@ def get_toggle_watchdog_listener_behavior(
     behavior_name_prefix: The prefix for the name of the behaviour.
     request_data: The request data to send to the toggle_watchdog_listener service.
         True to turn it on, False otherwise.
-    logger: The logger to use for the behaviour.
 
     Returns
     -------
@@ -143,6 +135,5 @@ def get_toggle_watchdog_listener_behavior(
                 operator=operator.eq,
             )
         ],
-        logger=logger,
     )
     return toggle_watchdog_listener

--- a/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
+++ b/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
@@ -15,9 +15,7 @@ Specifically, it does the following:
 """
 
 # Standard imports
-import logging
 import operator
-from typing import Optional
 
 # Third-part_y imports
 import py_trees

--- a/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
+++ b/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
@@ -53,7 +53,6 @@ def pre_moveto_config(
     t_x: float = 0.0,
     t_y: float = 0.0,
     t_z: float = 0.0,
-    logger: Optional[logging.Logger] = None,
 ) -> py_trees.behaviour.Behaviour:
     """
     Returns a behavior that calls the ROS services that should be called before
@@ -81,7 +80,6 @@ def pre_moveto_config(
     t_x: The magnitude of the x component of the torque threshold. No threshold if 0.0.
     t_y: The magnitude of the y component of the torque threshold. No threshold if 0.0.
     t_z: The magnitude of the z component of the torque threshold. No threshold if 0.0.
-    logger: The logger for the tree that this behavior is in.
     """
 
     # pylint: disable=too-many-arguments, too-many-locals
@@ -103,7 +101,6 @@ def pre_moveto_config(
                 name,
                 turn_watchdog_listener_off_prefix,
                 False,
-                logger,
             )
             children.append(turn_watchdog_listener_off)
 
@@ -128,7 +125,6 @@ def pre_moveto_config(
                     operator=operator.eq,
                 )
             ],
-            logger=logger,
         )
         children.append(re_tare_ft_sensor)
 
@@ -138,7 +134,6 @@ def pre_moveto_config(
                 name,
                 turn_watchdog_listener_on_prefix,
                 True,
-                logger,
             )
             children.append(turn_watchdog_listener_on)
 
@@ -184,12 +179,10 @@ def pre_moveto_config(
             )
             for i in range(len(ft_threshold_request.parameters))
         ],
-        logger=logger,
     )
     children.append(set_force_torque_thresholds)
 
     # Link all the behaviours together in a sequence with memory
     root = py_trees.composites.Sequence(name=name, memory=True, children=children)
-    root.logger = logger
 
     return root

--- a/ada_feeding/ada_feeding/idioms/retry_call_ros_service.py
+++ b/ada_feeding/ada_feeding/idioms/retry_call_ros_service.py
@@ -26,7 +26,6 @@ def retry_call_ros_service(
     response_checks: Optional[List[py_trees.common.ComparisonExpression]] = None,
     max_retries: int = 3,
     wait_for_server_timeout_sec: float = 0.0,
-    logger: Optional[logging.Logger] = None,
 ) -> py_trees.behaviour.Behaviour:
     """
     Creates a behavior that calls a ROS service and optionally checkes the response.
@@ -53,7 +52,6 @@ def retry_call_ros_service(
     max_retries: The maximum number of retries.
     wait_for_server_timeout_sec: The timeout for waiting for the server to be
         available.
-    logger: The logger for the tree that this behavior is in.
     """
 
     # pylint: disable=too-many-arguments, too-many-locals
@@ -92,8 +90,6 @@ def retry_call_ros_service(
             **call_ros_service_behavior_params,
             key_request=key_request,
         )
-    if logger is not None:
-        call_ros_service_behavior.logger = logger
 
     # Create the check response behavior
     if response_checks is not None:
@@ -107,8 +103,6 @@ def retry_call_ros_service(
                 name=check_response_behavior_name,
                 check=response_check,
             )
-            if logger is not None:
-                check_response_behavior.logger = logger
             children.append(check_response_behavior)
 
         # Chain the behaviours together in a sequence
@@ -117,8 +111,6 @@ def retry_call_ros_service(
             memory=True,
             children=children,
         )
-        if logger is not None:
-            child.logger = logger
     else:
         child = call_ros_service_behavior
 
@@ -128,6 +120,4 @@ def retry_call_ros_service(
         child=child,
         num_failures=max_retries,
     )
-    if logger is not None:
-        retry_behavior.logger = logger
     return retry_behavior

--- a/ada_feeding/ada_feeding/idioms/retry_call_ros_service.py
+++ b/ada_feeding/ada_feeding/idioms/retry_call_ros_service.py
@@ -7,7 +7,6 @@ number of times if there is a failure.
 """
 
 # Standard imports
-import logging
 from typing import Any, List, Optional
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -20,14 +20,13 @@ from ada_feeding import ActionServerBT
 class AcquireFoodTree(MoveToTree):
     """
     A behvaior tree to select and execute an acquisition
-    action (see ada_feeding_msgs.action.AcquisitionSchema) 
+    action (see ada_feeding_msgs.action.AcquisitionSchema)
     for a given food mask in ada_feeding_msgs.action.AcquireFood.
     """
 
     # pylint: disable=too-many-instance-attributes, too-many-arguments
     # Many arguments is fine for this class since it has to be able to configure all parameters
     # of its constraints.
-
 
     def __init__(
         self,
@@ -56,7 +55,6 @@ class AcquireFoodTree(MoveToTree):
     def create_move_to_tree(
         self,
         name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -65,7 +63,6 @@ class AcquireFoodTree(MoveToTree):
         Parameters
         ----------
         name: The name of the behavior tree.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 
@@ -86,7 +83,6 @@ class AcquireFoodTree(MoveToTree):
         # TODO: fix is_planning / planning_time in non-MoveTo Behavior
         return feedback_msg
 
-
     # Override result to add other elements to result msg
     @override
     def get_result(self, tree: py_trees.trees.BehaviourTree) -> object:
@@ -95,8 +91,3 @@ class AcquireFoodTree(MoveToTree):
 
         # TODO: add action_index, posthoc, action_select_hash
         return result_msg
-
-
-
-
-        

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -6,7 +6,6 @@ wrap that behavior tree in a ROS2 action server.
 """
 
 # Standard imports
-import logging
 from overrides import override
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
@@ -10,7 +10,6 @@ wrap that behaviour tree in a ROS2 action server.
 
 # Standard imports
 from functools import partial
-import logging
 from typing import List, Tuple
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
@@ -161,7 +161,6 @@ class MoveFromMouthTree(MoveToTree):
         self,
         name: str,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -173,7 +172,6 @@ class MoveFromMouthTree(MoveToTree):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behaviour tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviours within the tree connect to ROS topics/services/actions.
 
@@ -200,7 +198,6 @@ class MoveFromMouthTree(MoveToTree):
             toggle_watchdog_listener=False,
             f_mag=self.force_threshold,
             t_mag=self.torque_threshold,
-            logger=logger,
         )
 
         # Create the behavior to allow collisions between the robot and the
@@ -214,7 +211,6 @@ class MoveFromMouthTree(MoveToTree):
             node,
             [self.wheelchair_collision_object_id],
             True,
-            logger,
         )
 
         # Create the behaviour to move the robot to the staging configuration
@@ -247,7 +243,6 @@ class MoveFromMouthTree(MoveToTree):
                 move_to_staging_configuration_name,
                 self.action_type,
                 tree_root_name,
-                logger,
                 node,
             )
             .root
@@ -262,7 +257,6 @@ class MoveFromMouthTree(MoveToTree):
             node,
             [self.wheelchair_collision_object_id],
             False,
-            logger,
         )
 
         # Create the behavior to add a collision wall between the staging pose and the user,
@@ -286,7 +280,6 @@ class MoveFromMouthTree(MoveToTree):
             prim_type=in_front_of_wheelchair_wall_prim_type,
             dims=in_front_of_wheelchair_wall_dims,
         )
-        add_in_front_of_wheelchair_wall.logger = logger
         # Write the position, orientation, and frame_id to the blackboard
         position_key = Blackboard.separator.join(
             [add_wheelchair_wall_prefix, "position"]
@@ -334,7 +327,6 @@ class MoveFromMouthTree(MoveToTree):
                 move_to_end_configuration_name,
                 self.action_type,
                 tree_root_name,
-                logger,
                 node,
             )
             .root
@@ -348,7 +340,6 @@ class MoveFromMouthTree(MoveToTree):
                 operation=ModifyCollisionObjectOperation.REMOVE,
                 collision_object_id=in_front_of_wheelchair_wall_id,
             )
-            retval.logger = logger
             return retval
 
         # Link all the behaviours together in a sequence with memory
@@ -373,7 +364,6 @@ class MoveFromMouthTree(MoveToTree):
                 ),
             ],
         )
-        root.logger = logger
 
         # raise Exception(py_trees.display.unicode_blackboard())
 

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
@@ -101,7 +101,6 @@ class MoveToConfigurationTree(MoveToTree):
         self,
         name: str,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -113,7 +112,6 @@ class MoveToConfigurationTree(MoveToTree):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 
@@ -232,7 +230,6 @@ class MoveToConfigurationTree(MoveToTree):
         # Create the MoveTo behavior
         move_to_name = Blackboard.separator.join([name, move_to_namespace_prefix])
         move_to = MoveTo(move_to_name, tree_root_name, node)
-        move_to.logger = logger
 
         # Add the joint goal constraint to the MoveTo behavior
         joint_goal_constaint_name = Blackboard.separator.join(
@@ -241,7 +238,6 @@ class MoveToConfigurationTree(MoveToTree):
         joint_constraints = SetJointGoalConstraint(
             joint_goal_constaint_name, move_to, node
         )
-        joint_constraints.logger = logger
 
         # Clear the constraints
         if self.clear_constraints:
@@ -249,7 +245,6 @@ class MoveToConfigurationTree(MoveToTree):
                 [name, clear_constraints_namespace_prefix]
             )
             root = ClearConstraints(clear_constraints_name, joint_constraints, node)
-            root.logger = logger
         else:
             root = joint_constraints
 

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_tree.py
@@ -6,7 +6,6 @@ wrap that behavior tree in a ROS2 action server.
 """
 
 # Standard imports
-import logging
 from typing import List, Set
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -7,7 +7,6 @@ tree and provides functions to wrap that behavior tree in a ROS2 action server.
 
 # Standard imports
 from functools import partial
-import logging
 from typing import List, Set
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -132,7 +132,6 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         self,
         name: str,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -141,7 +140,6 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
         Parameters
         ----------
         name: The name of the behavior tree.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 
@@ -166,7 +164,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
                 clear_constraints=self.clear_constraints,
             )
-            .create_tree(name, self.action_type, tree_root_name, logger, node)
+            .create_tree(name, self.action_type, tree_root_name, node)
             .root
         )
 
@@ -183,7 +181,6 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
             t_x=self.t_x,
             t_y=self.t_y,
             t_z=self.t_z,
-            logger=logger,
         )
 
         if self.toggle_watchdog_listener:
@@ -196,7 +193,6 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                 name,
                 turn_watchdog_listener_on_prefix,
                 True,
-                logger,
             )
 
             # Create the main tree
@@ -206,7 +202,6 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                 workers=[move_to_configuration_root],
                 post_behavior=turn_watchdog_listener_on_fn(),
             )
-            root.logger = logger
         else:
             # Combine them in a sequence with memory
             root = py_trees.composites.Sequence(
@@ -214,7 +209,6 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                 memory=True,
                 children=[pre_moveto_behavior, move_to_configuration_root],
             )
-            root.logger = logger
 
         tree = py_trees.trees.BehaviourTree(root)
         return tree

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
@@ -6,7 +6,6 @@ tree and provides functions to wrap that behavior tree in a ROS2 action server.
 """
 
 # Standard imports
-import logging
 from typing import List, Optional, Tuple, Set, Union
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_pose_path_constraints_tree.py
@@ -130,7 +130,6 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         self,
         name: str,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -142,7 +141,6 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 
@@ -165,7 +163,7 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
                 clear_constraints=False,
             )
-            .create_tree(name, self.action_type, tree_root_name, logger, node)
+            .create_tree(name, self.action_type, tree_root_name, node)
             .root
         )
 
@@ -174,7 +172,6 @@ class MoveToConfigurationWithPosePathConstraintsTree(MoveToTree):
             child=move_to_configuration_root,
             name=name,
             blackboard=self.blackboard,
-            logger=logger,
             keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
             position_path=self.position_path,
             quat_xyzw_path=self.quat_xyzw_path,

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -57,7 +57,6 @@ class MoveToDummyTree(ActionServerBT):
         name: str,
         action_type: type,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -74,7 +73,6 @@ class MoveToDummyTree(ActionServerBT):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 
@@ -92,7 +90,6 @@ class MoveToDummyTree(ActionServerBT):
         # Create the behaviors in the tree
         if self.tree is None:
             root = MoveToDummy(name, self.dummy_plan_time, self.dummy_motion_time)
-            root.logger = logger
             # Create the tree
             self.tree = py_trees.trees.BehaviourTree(root)
             # Create the blackboard

--- a/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_dummy_tree.py
@@ -6,7 +6,6 @@ wrap that behavior tree in a ROS2 action server.
 """
 
 # Standard imports
-import logging
 
 # Third-party imports
 import py_trees

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -10,7 +10,6 @@ wrap that behaviour tree in a ROS2 action server.
 
 # Standard imports
 from functools import partial
-import logging
 from typing import List, Tuple
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -6,7 +6,6 @@ wrap that behavior tree in a ROS2 action server.
 """
 
 # Standard imports
-import logging
 from typing import Optional, Set, Tuple, Union
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_tree.py
@@ -137,7 +137,6 @@ class MoveToPoseTree(MoveToTree):
         self,
         name: str,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -149,7 +148,6 @@ class MoveToPoseTree(MoveToTree):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 
@@ -427,7 +425,6 @@ class MoveToPoseTree(MoveToTree):
         # Create the MoveTo behavior
         move_to_name = Blackboard.separator.join([name, move_to_namespace_prefix])
         move_to = MoveTo(move_to_name, tree_root_name, node)
-        move_to.logger = logger
 
         # Add the position goal constraint to the MoveTo behavior
         if self.position is not None:
@@ -437,7 +434,6 @@ class MoveToPoseTree(MoveToTree):
             position_constraint = SetPositionGoalConstraint(
                 position_goal_constaint_name, move_to, node
             )
-            position_constraint.logger = logger
         else:
             position_constraint = move_to
 
@@ -449,7 +445,6 @@ class MoveToPoseTree(MoveToTree):
             orientation_constraint = SetOrientationGoalConstraint(
                 orientation_goal_constraint_name, position_constraint, node
             )
-            orientation_constraint.logger = logger
         else:
             orientation_constraint = position_constraint
 
@@ -461,7 +456,6 @@ class MoveToPoseTree(MoveToTree):
             root = ClearConstraints(
                 clear_constraints_name, orientation_constraint, node
             )
-            root.logger = logger
         else:
             root = orientation_constraint
 

--- a/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
@@ -159,7 +159,6 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         self,
         name: str,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -171,7 +170,6 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 
@@ -204,7 +202,7 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
                 keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
                 clear_constraints=False,
             )
-            .create_tree(name, self.action_type, tree_root_name, logger, node)
+            .create_tree(name, self.action_type, tree_root_name, node)
             .root
         )
 
@@ -212,7 +210,6 @@ class MoveToPoseWithPosePathConstraintsTree(MoveToTree):
             child=move_to_pose_root,
             name=name,
             blackboard=self.blackboard,
-            logger=logger,
             keys_to_not_write_to_blackboard=self.keys_to_not_write_to_blackboard,
             position_path=self.position_path,
             quat_xyzw_path=self.quat_xyzw_path,

--- a/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_pose_with_pose_path_constraints_tree.py
@@ -6,7 +6,6 @@ provides functions to wrap that behavior tree in a ROS2 action server.
 """
 
 # Standard imports
-import logging
 from typing import Optional, Set, Tuple, Union
 
 # Third-party imports

--- a/ada_feeding/ada_feeding/trees/move_to_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_tree.py
@@ -11,7 +11,6 @@ Subclasses should only need to define create_move_to_tree.
 
 # Standard imports
 from abc import ABC, abstractmethod
-import logging
 
 # Third-party imports
 import py_trees
@@ -36,7 +35,6 @@ class MoveToTree(ActionServerBT, ABC):
         name: str,
         action_type: type,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -49,7 +47,6 @@ class MoveToTree(ActionServerBT, ABC):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 
@@ -66,7 +63,7 @@ class MoveToTree(ActionServerBT, ABC):
         # Import the action type
         self.action_type = action_type
 
-        return self.create_move_to_tree(name, tree_root_name, logger, node)
+        return self.create_move_to_tree(name, tree_root_name, node)
 
     def create_blackboard(self, name: str, tree_root_name: str) -> None:
         """
@@ -114,7 +111,6 @@ class MoveToTree(ActionServerBT, ABC):
         self,
         name: str,
         tree_root_name: str,
-        logger: logging.Logger,
         node: Node,
     ) -> py_trees.trees.BehaviourTree:
         """
@@ -130,7 +126,6 @@ class MoveToTree(ActionServerBT, ABC):
         tree_root_name: The name of the tree. This is necessary because sometimes
             trees create subtrees, but still need to track the top-level tree
             name to read/write the correct blackboard variables.
-        logger: The logger to use for the behavior tree.
         node: The ROS2 node that this tree is associated with. Necessary for
             behaviors within the tree connect to ROS topics/services/actions.
 

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -310,6 +310,26 @@ class CreateActionServers(Node):
         self.get_logger().info("Received cancel request, accepting")
         return CancelResponse.ACCEPT
 
+    def setup_tree(self, tree: py_trees.trees.BehaviourTree) -> None:
+        """
+        Runs the initial setup on a behavior tree after creating it.
+
+        Specifically, this function: (1) sets every behavior's logger
+        to be the node's logger; and (2) calls teh tree's `setup` function.
+
+        Parameters
+        ----------
+        tree: The behavior tree to setup.
+        """
+
+        # Set every behavior's logger to be the node's logger
+        for node in tree.root.iterate():
+            node.logger = self.get_logger()
+
+        # Call the tree's setup function
+        # TODO: consider adding a timeout here
+        tree.setup(node=self)
+
     # pylint: disable=too-many-arguments
     # This is appropriate
     def get_execute_callback(
@@ -344,7 +364,7 @@ class CreateActionServers(Node):
         tree = tree_action_server.create_tree(
             server_name, action_type, server_name, self.get_logger(), self
         )
-        tree.setup(node=self)  # TODO: consider adding a timeout here
+        self.setup_tree(tree)
         self._trees.append(tree)
 
         async def execute_callback(goal_handle: ServerGoalHandle) -> Awaitable:

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -362,7 +362,7 @@ class CreateActionServers(Node):
         tree_action_server = self._tree_classes[tree_class](**tree_kwargs)
         # Create and setup the tree once
         tree = tree_action_server.create_tree(
-            server_name, action_type, server_name, self.get_logger(), self
+            server_name, action_type, server_name, self
         )
         self.setup_tree(tree)
         self._trees.append(tree)


### PR DESCRIPTION
# Description

In service of #101 . This PR removes the `logger` from being passed into and set in every tree creation function, and instead has `create_action_servers.py` iterate over the tree and set the logger. This also allows us to set the logger for behaviors that are added via idiom.

# Testing procedure

Setup the nodes following the instructions in the README. Verify that each of the following succeed and log as expected:
- [x] `ros2 action send_goal /MoveAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
- [x] `ros2 action send_goal /AcquireFood ada_feeding_msgs/action/AcquireFood "{header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, detected_food: {roi: {x_offset: 0, y_offset: 0, height: 0, width: 0, do_rectify: false}, mask: {header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, format: '', data: []}, item_id: '', confidence: 0.0}}" --feedback`
- [x] `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`
- [x] `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveTo "{}" --feedback`
- [x] `ros2 action send_goal /MoveFromMouthToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`
- [x] `ros2 action send_goal /MoveFromMouthToAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
- [x] `ros2 action send_goal /MoveToStowLocation ada_feeding_msgs/action/MoveTo "{}" --feedback`

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
