### PR TITLE
Add wall to MoveToMouth kinematic motion

### DIFF
--- a/ada_feeding/ada_feeding/idioms/bite_transfer.py
+++ b/ada_feeding/ada_feeding/idioms/bite_transfer.py
@@ -16,7 +16,11 @@ from rclpy.node import Node
 from std_srvs.srv import SetBool
 
 # Local imports
-from ada_feeding.behaviors import ToggleCollisionObject
+from ada_feeding.behaviors import (
+    ModifyCollisionObject,
+    ModifyCollisionObjectOperation,
+    ToggleCollisionObject,
+)
 from .retry_call_ros_service import retry_call_ros_service
 
 
@@ -136,3 +140,99 @@ def get_toggle_watchdog_listener_behavior(
         ],
     )
     return toggle_watchdog_listener
+
+
+def get_add_in_front_of_wheelchair_wall_behavior(
+    tree_name: str,
+    behavior_name_prefix: str,
+    collision_object_id: str,
+    node: Node,
+    blackboard: Blackboard,
+):
+    """
+    Creates a behavior that adds a collision wall between the staging pose and the user,
+    to prevent the robot from moving closer to the user.
+
+    Parameters
+    ----------
+    tree_name: The name of the tree that this behaviour belongs to.
+    behavior_name_prefix: The prefix for the name of the behaviour.
+    collision_object_id: The ID of the collision object to add.
+    node: The ROS2 node that this behaviour belongs to.
+
+    Returns
+    -------
+    behavior: The behaviour that adds the collision wall.
+    """
+    # Create the behavior to add a collision wall between the staging pose and the user,
+    # to prevent the robot from moving closer to the user.
+    in_front_of_wheelchair_wall_prim_type = (
+        1  # Box=1. See shape_msgs/SolidPrimitive.msg
+    )
+    in_front_of_wheelchair_wall_dims = [
+        0.75,
+        0.01,
+        0.4,
+    ]  # Box has 3 dims: [x, y, z]
+    add_in_front_of_wheelchair_wall = ModifyCollisionObject(
+        name=Blackboard.separator.join([tree_name, behavior_name_prefix]),
+        node=node,
+        operation=ModifyCollisionObjectOperation.ADD,
+        collision_object_id=collision_object_id,
+        collision_object_position_input_key="position",
+        collision_object_orientation_input_key="quat_xyzw",
+        prim_type=in_front_of_wheelchair_wall_prim_type,
+        dims=in_front_of_wheelchair_wall_dims,
+    )
+
+    # Write the position, orientation, and frame_id to the blackboard
+    position_key = Blackboard.separator.join([behavior_name_prefix, "position"])
+    blackboard.register_key(
+        key=position_key,
+        access=py_trees.common.Access.WRITE,
+    )
+    blackboard.set(position_key, (0.37, 0.17, 0.85))
+    quat_xyzw_key = Blackboard.separator.join([behavior_name_prefix, "quat_xyzw"])
+    blackboard.register_key(
+        key=quat_xyzw_key,
+        access=py_trees.common.Access.WRITE,
+    )
+    blackboard.set(quat_xyzw_key, (0.0, 0.0, 0.0, 1.0))
+    frame_id_key = Blackboard.separator.join([behavior_name_prefix, "frame_id"])
+    blackboard.register_key(
+        key=frame_id_key,
+        access=py_trees.common.Access.WRITE,
+    )
+    blackboard.set(frame_id_key, "root")
+
+    return add_in_front_of_wheelchair_wall
+
+
+def get_remove_in_front_of_wheelchair_wall_behavior(
+    tree_name: str,
+    behavior_name_prefix: str,
+    collision_object_id: str,
+    node: Node,
+):
+    """
+    Creates a behavior that removes the collision wall between the staging pose and the user.
+
+    Parameters
+    ----------
+    tree_name: The name of the tree that this behaviour belongs to.
+    behavior_name_prefix: The prefix for the name of the behaviour.
+    node: The ROS2 node that this behaviour belongs to.
+
+    Returns
+    -------
+    behavior: The behaviour that removes the collision wall.
+    """
+    # Create the behavior to remove the collision wall between the staging pose and the user.
+    remove_in_front_of_wheelchair_wall = ModifyCollisionObject(
+        name=Blackboard.separator.join([tree_name, behavior_name_prefix]),
+        node=node,
+        operation=ModifyCollisionObjectOperation.REMOVE,
+        collision_object_id=collision_object_id,
+    )
+
+    return remove_in_front_of_wheelchair_wall

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_ft_thresholds_tree.py
@@ -6,7 +6,6 @@ tree and provides functions to wrap that behavior tree in a ROS2 action server.
 """
 
 # Standard imports
-from functools import partial
 from typing import List, Set
 
 # Third-party imports
@@ -187,8 +186,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
             # the watchdog listener back on
             # pylint: disable=duplicate-code
             # This is similar to any other tree that needs to cleanup pre_moveto_config
-            turn_watchdog_listener_on_fn = partial(
-                get_toggle_watchdog_listener_behavior,
+            turn_watchdog_listener_on = get_toggle_watchdog_listener_behavior(
                 name,
                 turn_watchdog_listener_on_prefix,
                 True,
@@ -199,7 +197,7 @@ class MoveToConfigurationWithFTThresholdsTree(MoveToTree):
                 name=name + " ToggleWatchdogListenerOffScope",
                 pre_behavior=pre_moveto_behavior,
                 workers=[move_to_configuration_root],
-                post_behavior=turn_watchdog_listener_on_fn(),
+                post_behavior=turn_watchdog_listener_on,
             )
         else:
             # Combine them in a sequence with memory


### PR DESCRIPTION
# Description

In serice of #96. I saw one case where the kinematic motion in `MoveToMouth` moved closer to the face than it needed to. To address this, we should add the "in front of wheelchair wall" to `MoveToMouth`, just like exists for `MoveFromMouth`'s kinematic motion.

# Testing procedure

Launch the code as documented in the README. Then, verify that each of the following actions succeed:

- [x] MoveToRestingPosition
- [x] MoveToMouth
- [x] MoveFromMouthToRestingPosition

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
