### PR TITLE
Move2Plan/Execute (MoveTo Behavior Overhaul)

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/acquisition/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/__init__.py
@@ -3,3 +3,4 @@ This subpackage contains custom py_tree behaviors for Food Acquisition.
 """
 
 from .compute_food_frame import ComputeFoodFrame
+from .compute_action_constraints import ComputeActionConstraints

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_action_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_action_constraints.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines behaviors that take an AcquisitionSchema.msg object
+(or return from AcquisitionSelect.srv) and computes the outputs
+needed to send MoveIt2Plan calls.
+"""
+
+# Standard imports
+from typing import Union, Optional
+
+# Third-party imports
+from geometry_msgs.msg import Point
+import numpy as np
+from overrides import override
+import py_trees
+import ros2_numpy
+
+# Local imports
+from ada_feeding_msgs.srv import AcquisitionSelect
+from ada_feeding.helpers import BlackboardKey
+from ada_feeding.behaviors import BlackboardBehavior
+
+
+class ComputeActionConstraints(BlackboardBehavior):
+    """
+    Checks AcquisitionSelect response, implements stochastic
+    policy choice, and then decomposes into individual
+    BlackboardKey objects for MoveIt2 Behaviors.
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    # pylint: disable=too-many-arguments
+    # These are effectively config definitions
+    # They require a lot of arguments.
+
+    def blackboard_inputs(
+        self,
+        action_select_response: Union[BlackboardKey, AcquisitionSelect.Response],
+        move_above_dist_m: Union[BlackboardKey, float] = 0.05,
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Parameters
+        ----------
+        action_select_response: response from AcquisitionSelect.srv
+        move_above_dist_m: how far from the food to start
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        move_above_pose: Optional[BlackboardKey],  # Pose, in Food Frame
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        action_select_request (AcquisitionSelect.Request): request to send to AcquisitionSelect
+                                                           (copies mask input)
+        food_frame (geometry_msgs/TransformStamped): transform from world_frame to food_frame
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        # Input Validation
+        if not self.blackboard_exists("action_select_response"):
+            return py_trees.common.Status.FAILURE
+        response = self.blackboard_get("action_select_response")
+        if response.status != "Success":
+            self.logger.error(f"Bad Action Select Response: {response.status}")
+            return py_trees.common.Status.FAILURE
+        prob = np.array(response.probabilities)
+        if (
+            len(response.actions) == 0
+            or len(response.actions) != len(response.probabilities)
+            or not np.isclose(np.sum(prob), 1.0)
+        ):
+            self.logger.error(f"Malformed action select response: {response}")
+            return py_trees.common.Status.FAILURE
+
+        # Sample Action
+        index = np.random.choice(np.arange(prob.size), p=prob)
+        action = response.actions[index]
+
+        ### Construct Constraints
+
+        # Re-scale pre-transform to move_above_dist_m
+        position = ros2_numpy.numpify(action.pre_transform.position)
+        if np.isclose(np.linalg.norm(position), 0.0):
+            self.logger.error(
+                f"Malformed action pre_transform: {action.pre_transform.position}"
+            )
+            return py_trees.common.Status.FAILURE
+        position = (
+            position
+            * self.blackboard_get("move_above_dist_m")
+            / np.linalg.norm(position)
+        )
+        action.pre_transform.position = ros2_numpy.msgify(Point, position)
+        self.blackboard_set("move_above_pose", action.pre_transform)
+
+        return py_trees.common.Status.SUCCESS

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_action_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_action_constraints.py
@@ -83,6 +83,7 @@ class ComputeActionConstraints(BlackboardBehavior):
 
         # Input Validation
         if not self.blackboard_exists("action_select_response"):
+            self.logger.error("Missing Action Select Response")
             return py_trees.common.Status.FAILURE
         response = self.blackboard_get("action_select_response")
         if response.status != "Success":

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -93,9 +93,7 @@ class ComputeFoodFrame(BlackboardBehavior):
 
     @override
     def setup(self, **kwargs):
-        """
-        Middleware (i.e. TF) setup
-        """
+        # Docstring copied from @override
 
         # pylint: disable=attribute-defined-outside-init
         # It is okay for attributes in behaviors to be
@@ -109,9 +107,7 @@ class ComputeFoodFrame(BlackboardBehavior):
 
     @override
     def initialise(self):
-        """
-        Behavior initialization
-        """
+        # Docstring copied from @override
 
         # pylint: disable=attribute-defined-outside-init
         # It is okay for attributes in behaviors to be
@@ -142,9 +138,8 @@ class ComputeFoodFrame(BlackboardBehavior):
 
     @override
     def update(self) -> py_trees.common.Status:
-        """
-        Behavior tick (DO NOT BLOCK)
-        """
+        # Docstring copied from @override
+
         # pylint: disable=too-many-locals
         # I think this is reasonable to understand
         # the logic of this function.

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -64,7 +64,7 @@ class ComputeFoodFrame(BlackboardBehavior):
                                    (relative to world_frame)
         world_frame (string): ID of the TF frame to represent the food frame in
         """
-        # pylint: disable=unused-argument
+        # pylint: disable=unused-argument, duplicate-code
         # Arguments are handled generically in base class.
         super().blackboard_inputs(
             **{key: value for key, value in locals().items() if key != "self"}
@@ -85,7 +85,7 @@ class ComputeFoodFrame(BlackboardBehavior):
                                                            (copies mask input)
         food_frame (geometry_msgs/TransformStamped): transform from world_frame to food_frame
         """
-        # pylint: disable=unused-argument
+        # pylint: disable=unused-argument, duplicate-code
         # Arguments are handled generically in base class.
         super().blackboard_outputs(
             **{key: value for key, value in locals().items() if key != "self"}

--- a/ada_feeding/ada_feeding/behaviors/blackboard_behavior.py
+++ b/ada_feeding/ada_feeding/behaviors/blackboard_behavior.py
@@ -135,4 +135,4 @@ class BlackboardBehavior(py_trees.behaviour.Behaviour):
         if self._outputs[key] is not None:
             self.blackboard.set(self._outputs[key], output)
         else:
-            self.logger.debug(f"Not writing to 'None' output key: {self._outputs[key]}")
+            self.logger.debug(f"Not writing to 'None' output key: {key}")

--- a/ada_feeding/ada_feeding/behaviors/moveit2/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/__init__.py
@@ -4,3 +4,9 @@ This subpackage contains custom py_tree behaviors for MoveIt2
 
 from .moveit2_plan import MoveIt2Plan, MoveIt2ConstraintType
 from .moveit2_execute import MoveIt2Execute
+from .moveit2_constraints import (
+    MoveIt2JointConstraint,
+    MoveIt2PositionConstraint,
+    MoveIt2OrientationConstraint,
+    MoveIt2PoseConstraint,
+)

--- a/ada_feeding/ada_feeding/behaviors/moveit2/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/__init__.py
@@ -3,3 +3,4 @@ This subpackage contains custom py_tree behaviors for MoveIt2
 """
 
 from .moveit2_plan import MoveIt2Plan, MoveIt2ConstraintType
+from .moveit2_execute import MoveIt2Execute

--- a/ada_feeding/ada_feeding/behaviors/moveit2/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/__init__.py
@@ -1,0 +1,5 @@
+"""
+This subpackage contains custom py_tree behaviors for MoveIt2
+"""
+
+from .moveit2_plan import MoveIt2Plan, MoveIt2ConstraintType

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
@@ -119,6 +119,8 @@ class MoveIt2JointConstraint(BlackboardBehavior):
         constraints = self.blackboard_get("constraints")
         if constraints is None:
             constraints = []
+        else:
+            constraints = constraints.copy()
         constraints.append(constraint)
         self.blackboard_set("constraints", constraints)
         return py_trees.common.Status.SUCCESS
@@ -232,6 +234,8 @@ class MoveIt2PositionConstraint(BlackboardBehavior):
         constraints = self.blackboard_get("constraints")
         if constraints is None:
             constraints = []
+        else:
+            constraints = constraints.copy()
         constraints.append(constraint)
         self.blackboard_set("constraints", constraints)
         return py_trees.common.Status.SUCCESS
@@ -351,6 +355,8 @@ class MoveIt2OrientationConstraint(BlackboardBehavior):
         constraints = self.blackboard_get("constraints")
         if constraints is None:
             constraints = []
+        else:
+            constraints = constraints.copy()
         constraints.append(constraint)
         self.blackboard_set("constraints", constraints)
         return py_trees.common.Status.SUCCESS
@@ -502,6 +508,8 @@ class MoveIt2PoseConstraint(BlackboardBehavior):
         constraints = self.blackboard_get("constraints")
         if constraints is None:
             constraints = []
+        else:
+            constraints = constraints.copy()
         constraints.append(constraint_orient)
         constraints.append(constraint_pos)
         self.blackboard_set("constraints", constraints)

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines behaviors that package individual
+blackboard keys / constants into a dictionary
+of constraints that can be passed to MoveIt2Plan.
+"""
+
+# Standard imports
+from typing import Any, Union, Optional, Dict, List, Tuple
+
+# Third-party imports
+from geometry_msgs.msg import (
+    TransformStamped,
+    Transform,
+    PointStamped,
+    Point,
+    QuaternionStamped,
+    Quaternion,
+)
+from overrides import override
+import py_trees
+
+# Local imports
+from ada_feeding.behaviors.moveit2 import MoveIt2ConstraintType
+from ada_feeding.helpers import BlackboardKey
+from ada_feeding.behaviors import BlackboardBehavior
+
+
+class MoveIt2JointConstraint(BlackboardBehavior):
+    """
+    Adds Joint Constraint to Blackboard Dictionary
+    See pymoveit2:set_joint_goal() for more info
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    # pylint: disable=too-many-arguments
+    # These are effectively config definitions
+    # They require a lot of arguments.
+
+    def blackboard_inputs(
+        self,
+        joint_positions: Union[BlackboardKey, List[float]],
+        joint_names: Union[BlackboardKey, Optional[List[str]]] = None,
+        tolerance: Union[BlackboardKey, float] = 0.001,
+        weight: Union[BlackboardKey, float] = 1.0,
+        constraints: Union[
+            BlackboardKey, Optional[List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+        ] = None,
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Docstring copied from set_joint_goal():
+        With `joint_names` specified, `joint_positions` can be
+        defined for specific joints in an arbitrary order. Otherwise, first **n** joints
+        passed into the constructor is used, where **n** is the length of `joint_positions`.
+
+        Parameters
+        ----------
+        constraints: previous set of constraints to append to
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        constraints: Optional[
+            BlackboardKey
+        ],  # List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        constraints: list of constraints to send to MoveIt2Plan
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        # pylint: disable=too-many-boolean-expressions
+        # This is just checking all inputs, should be
+        # easy to read.
+        if (
+            not self.blackboard_exists("joint_positions")
+            or not self.blackboard_exists("joint_names")
+            or not self.blackboard_exists("tolerance")
+            or not self.blackboard_exists("weight")
+            or not self.blackboard_exists("constraints")
+        ):
+            return py_trees.common.Status.FAILURE
+
+        constraint = (
+            MoveIt2ConstraintType.JOINT,
+            {
+                "joint_positions": self.blackboard_get("joint_positions"),
+                "joint_names": self.blackboard_get("joint_names"),
+                "tolerance": self.blackboard_get("tolerance"),
+                "weight": self.blackboard_get("weight"),
+            },
+        )
+
+        constraints = self.blackboard_get("constraints")
+        if constraints is None:
+            constraints = []
+        constraints.append(constraint)
+        self.blackboard_set("constraints", constraints)
+        return py_trees.common.Status.SUCCESS
+
+
+class MoveIt2PositionConstraint(BlackboardBehavior):
+    """
+    Adds Position Constraint to Blackboard Dictionary
+    See pymoveit2:set_position_goal() for more info
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    # pylint: disable=too-many-arguments
+    # These are effectively config definitions
+    # They require a lot of arguments.
+
+    def blackboard_inputs(
+        self,
+        position: Union[
+            BlackboardKey, Union[PointStamped, Point, Tuple[float, float, float]]
+        ],
+        frame_id: Union[BlackboardKey, Optional[str]] = None,
+        target_link: Union[BlackboardKey, Optional[str]] = None,
+        tolerance: Union[BlackboardKey, float] = 0.001,
+        weight: Union[BlackboardKey, float] = 1.0,
+        constraints: Union[
+            BlackboardKey, Optional[List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+        ] = None,
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Docstring copied from set_position_goal():
+        Set Cartesian position goal of `target_link` with respect to `frame_id`.
+          - `frame_id` defaults to the base link
+          - `target_link` defaults to end effector
+
+        Note: if position is PointStamped,
+              use position.header.frame_id for frame_id (if not "")
+
+        Parameters
+        ----------
+        constraints: previous set of constraints to append to
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        constraints: Optional[
+            BlackboardKey
+        ],  # List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        constraints: list of constraints to send to MoveIt2Plan
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        # pylint: disable=too-many-boolean-expressions
+        # This is just checking all inputs, should be
+        # easy to read.
+        if (
+            not self.blackboard_exists("position")
+            or not self.blackboard_exists("frame_id")
+            or not self.blackboard_exists("target_link")
+            or not self.blackboard_exists("tolerance")
+            or not self.blackboard_exists("weight")
+            or not self.blackboard_exists("constraints")
+        ):
+            return py_trees.common.Status.FAILURE
+
+        position = self.blackboard_get("position")
+        constraint = (
+            MoveIt2ConstraintType.POSITION,
+            {
+                "position": position.point
+                if isinstance(position, PointStamped)
+                else position,
+                "frame_id": position.header.frame_id
+                if (
+                    isinstance(position, PointStamped)
+                    and len(position.header.frame_id) > 0
+                )
+                else self.blackboard_get("frame_id"),
+                "target_link": self.blackboard_get("target_link"),
+                "tolerance": self.blackboard_get("tolerance"),
+                "weight": self.blackboard_get("weight"),
+            },
+        )
+
+        constraints = self.blackboard_get("constraints")
+        if constraints is None:
+            constraints = []
+        constraints.append(constraint)
+        self.blackboard_set("constraints", constraints)
+        return py_trees.common.Status.SUCCESS
+
+
+class MoveIt2OrientationConstraint(BlackboardBehavior):
+    """
+    Adds Orientation Constraint to Blackboard Dictionary
+    See pymoveit2:set_orientation_goal() for more info
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    # pylint: disable=too-many-arguments
+    # These are effectively config definitions
+    # They require a lot of arguments.
+
+    def blackboard_inputs(
+        self,
+        quat_xyzw: Union[
+            BlackboardKey,
+            Union[QuaternionStamped, Quaternion, Tuple[float, float, float, float]],
+        ],
+        frame_id: Union[BlackboardKey, Optional[str]] = None,
+        target_link: Union[BlackboardKey, Optional[str]] = None,
+        tolerance: Union[
+            BlackboardKey, Union[float, Tuple[float, float, float]]
+        ] = 0.001,
+        weight: Union[BlackboardKey, float] = 1.0,
+        parameterization: int = 0,  # 0: Euler, 1: Rotation Vector
+        constraints: Union[
+            BlackboardKey, Optional[List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+        ] = None,
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Docstring copied from set_position_goal():
+        Set Cartesian orientation goal of `target_link` with respect to `frame_id`.
+          - `frame_id` defaults to the base link
+          - `target_link` defaults to end effector
+
+        Note: if quat_xyzw is QuaternionStamped,
+              use quat_xyzw.header.frame_id for frame_id. (if not "")
+
+        Parameters
+        ----------
+        constraints: previous set of constraints to append to
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        constraints: Optional[
+            BlackboardKey
+        ],  # List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        constraints: list of constraints to send to MoveIt2Plan
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        # pylint: disable=too-many-boolean-expressions
+        # This is just checking all inputs, should be
+        # easy to read.
+        if (
+            not self.blackboard_exists("quat_xyzw")
+            or not self.blackboard_exists("frame_id")
+            or not self.blackboard_exists("target_link")
+            or not self.blackboard_exists("tolerance")
+            or not self.blackboard_exists("weight")
+            or not self.blackboard_exists("constraints")
+            or not self.blackboard_exists("parameterization")
+        ):
+            return py_trees.common.Status.FAILURE
+
+        quat_xyzw = self.blackboard_get("quat_xyzw")
+        constraint = (
+            MoveIt2ConstraintType.ORIENTATION,
+            {
+                "quat_xyzw": quat_xyzw.quaternion
+                if isinstance(quat_xyzw, QuaternionStamped)
+                else quat_xyzw,
+                "frame_id": quat_xyzw.header.frame_id
+                if (
+                    isinstance(quat_xyzw, QuaternionStamped)
+                    and len(quat_xyzw.header.frame_id) > 0
+                )
+                else self.blackboard_get("frame_id"),
+                "target_link": self.blackboard_get("target_link"),
+                "tolerance": self.blackboard_get("tolerance"),
+                "weight": self.blackboard_get("weight"),
+                "parameterization": self.blackboard_get("parameterization"),
+            },
+        )
+
+        constraints = self.blackboard_get("constraints")
+        if constraints is None:
+            constraints = []
+        constraints.append(constraint)
+        self.blackboard_set("constraints", constraints)
+        return py_trees.common.Status.SUCCESS
+
+
+class MoveIt2PoseConstraint(BlackboardBehavior):
+    """
+    Adds Pose Constraint to Blackboard Dictionary
+    See pymoveit2:set_pose_goal() for more info.
+    This is a direct combo of position + orientation
+    useful for Transform/TransformStamped ROS objects.
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    # pylint: disable=too-many-arguments
+    # These are effectively config definitions
+    # They require a lot of arguments.
+
+    def blackboard_inputs(
+        self,
+        transform: Union[BlackboardKey, Union[TransformStamped, Transform]],
+        frame_id: Union[BlackboardKey, Optional[str]] = None,
+        target_link: Union[BlackboardKey, Optional[str]] = None,
+        tolerance_position: Union[BlackboardKey, float] = 0.001,
+        tolerance_orientation: Union[
+            BlackboardKey, Union[float, Tuple[float, float, float]]
+        ] = 0.001,
+        weight_position: Union[BlackboardKey, float] = 1.0,
+        weight_orientation: Union[BlackboardKey, float] = 1.0,
+        parameterization: int = 0,  # 0: Euler, 1: Rotation Vector
+        constraints: Union[
+            BlackboardKey, Optional[List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+        ] = None,
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Docstring copied from set_position_goal():
+        Set Cartesian orientation goal of `target_link` with respect to `frame_id`.
+          - `frame_id` defaults to the base link
+          - `target_link` defaults to end effector
+
+        Note: if transform is TransformStamped:
+          - `frame_id` is transform.header.frame_id (if not "")
+          - `target_link` is transform.child_frame_id (if not "")
+
+        Parameters
+        ----------
+        constraints: previous set of constraints to append to
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        constraints: Optional[
+            BlackboardKey
+        ],  # List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        constraints: list of constraints to send to MoveIt2Plan
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        # pylint: disable=too-many-boolean-expressions
+        # This is just checking all inputs, should be
+        # easy to read.
+        if (
+            not self.blackboard_exists("transform")
+            or not self.blackboard_exists("frame_id")
+            or not self.blackboard_exists("target_link")
+            or not self.blackboard_exists("tolerance_position")
+            or not self.blackboard_exists("weight_position")
+            or not self.blackboard_exists("tolerance_orientation")
+            or not self.blackboard_exists("weight_orientation")
+            or not self.blackboard_exists("constraints")
+            or not self.blackboard_exists("parameterization")
+        ):
+            return py_trees.common.Status.FAILURE
+
+        transform = self.blackboard_get("transform")
+        constraint_orient = (
+            MoveIt2ConstraintType.ORIENTATION,
+            {
+                "quat_xyzw": transform.transform.rotation
+                if isinstance(transform, TransformStamped)
+                else transform.rotation,
+                "frame_id": transform.header.frame_id
+                if (
+                    isinstance(transform, TransformStamped)
+                    and len(transform.header.frame_id) > 0
+                )
+                else self.blackboard_get("frame_id"),
+                "target_link": transform.child_frame_id
+                if (
+                    isinstance(transform, TransformStamped)
+                    and len(transform.child_frame_id) > 0
+                )
+                else self.blackboard_get("target_link"),
+                "tolerance": self.blackboard_get("tolerance_orientation"),
+                "weight": self.blackboard_get("weight_orientation"),
+                "parameterization": self.blackboard_get("parameterization"),
+            },
+        )
+
+        constraint_pos = (
+            MoveIt2ConstraintType.POSITION,
+            {
+                "position": transform.transform.translation
+                if isinstance(transform, TransformStamped)
+                else transform.translation,
+                "frame_id": transform.header.frame_id
+                if (
+                    isinstance(transform, TransformStamped)
+                    and len(transform.header.frame_id) > 0
+                )
+                else self.blackboard_get("frame_id"),
+                "target_link": transform.child_frame_id
+                if (
+                    isinstance(transform, TransformStamped)
+                    and len(transform.child_frame_id) > 0
+                )
+                else self.blackboard_get("target_link"),
+                "tolerance": self.blackboard_get("tolerance_position"),
+                "weight": self.blackboard_get("weight_position"),
+            },
+        )
+
+        constraints = self.blackboard_get("constraints")
+        if constraints is None:
+            constraints = []
+        constraints.append(constraint_orient)
+        constraints.append(constraint_pos)
+        self.blackboard_set("constraints", constraints)
+        return py_trees.common.Status.SUCCESS

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
@@ -104,6 +104,7 @@ class MoveIt2JointConstraint(BlackboardBehavior):
             or not self.blackboard_exists("weight")
             or not self.blackboard_exists("constraints")
         ):
+            self.logger.error("MoveIt2Constraint: Missing input arguments.")
             return py_trees.common.Status.FAILURE
 
         constraint = (
@@ -210,6 +211,7 @@ class MoveIt2PositionConstraint(BlackboardBehavior):
             or not self.blackboard_exists("weight")
             or not self.blackboard_exists("constraints")
         ):
+            self.logger.error("MoveIt2Constraint: Missing input arguments.")
             return py_trees.common.Status.FAILURE
 
         position = self.blackboard_get("position")
@@ -284,6 +286,9 @@ class MoveIt2OrientationConstraint(BlackboardBehavior):
         Note: if quat_xyzw is QuaternionStamped,
               use quat_xyzw.header.frame_id for frame_id. (if not "")
 
+        Details on parameterization:
+        https://github.com/ros-planning/moveit_msgs/blob/master/msg/OrientationConstraint.msg
+
         Parameters
         ----------
         constraints: previous set of constraints to append to
@@ -330,6 +335,7 @@ class MoveIt2OrientationConstraint(BlackboardBehavior):
             or not self.blackboard_exists("constraints")
             or not self.blackboard_exists("parameterization")
         ):
+            self.logger.error("MoveIt2Constraint: Missing input arguments.")
             return py_trees.common.Status.FAILURE
 
         quat_xyzw = self.blackboard_get("quat_xyzw")
@@ -407,6 +413,9 @@ class MoveIt2PoseConstraint(BlackboardBehavior):
           - `frame_id` is pose.header.frame_id (if not "")
           - `target_link` is pose.child_frame_id (if not "")
 
+        Details on parameterization:
+        https://github.com/ros-planning/moveit_msgs/blob/master/msg/OrientationConstraint.msg
+
         Parameters
         ----------
         constraints: previous set of constraints to append to
@@ -455,6 +464,7 @@ class MoveIt2PoseConstraint(BlackboardBehavior):
             or not self.blackboard_exists("constraints")
             or not self.blackboard_exists("parameterization")
         ):
+            self.logger.error("MoveIt2Constraint: Missing input arguments.")
             return py_trees.common.Status.FAILURE
 
         pose = self.blackboard_get("pose")

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_execute.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_execute.py
@@ -60,7 +60,7 @@ class MoveIt2Execute(BlackboardBehavior):
         self,
         error_code: Optional[
             BlackboardKey
-        ],  # Union[MoveItErrorCodes, GoalStatus] == int
+        ] = None,  # Union[MoveItErrorCodes, GoalStatus] == int
     ) -> None:
         """
         Blackboard Outputs

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_execute.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_execute.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the MoveIt2Excute behavior, which uses pymoveit2
+to execute and JointTrajectory.
+"""
+
+# Standard imports
+from typing import Union, Optional
+
+# Third-party imports
+from action_msgs.msg import GoalStatus
+from overrides import override
+from moveit_msgs.msg import MoveItErrorCodes
+import py_trees
+from pymoveit2 import MoveIt2State
+from trajectory_msgs.msg import JointTrajectory
+
+# Local imports
+from ada_feeding.helpers import BlackboardKey, get_moveit2_object
+from ada_feeding.behaviors import BlackboardBehavior
+
+
+class MoveIt2Execute(BlackboardBehavior):
+    """
+    Runs moveit2.py execute with the provided
+    JointTrajectory.
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    def blackboard_inputs(
+        self, trajectory: Union[BlackboardKey, Optional[JointTrajectory]]
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Parameters
+        ----------
+        trajectory: JointTrajectory to execute. If None, return SUCCESS immediately.
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        error_code: Optional[
+            BlackboardKey
+        ],  # Union[MoveItErrorCodes, GoalStatus] == int
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        error_code: specifies the manner of execution (or goal) failure
+                    See actionlib_msgs/GoalStatus and moveit_msgs/MoveItErrorCodes for more info
+                    <0: MoveItErrorCodes Failure
+                    0, 3: Never Returned (GoalStatus PENDING, SUCCEEDED)
+                    1: MoveItErrorCodes Success (GoalStatus ACTIVE never returned)
+                    2, >4: GoalStatus Failure
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def setup(self, **kwargs):
+        # Docstring copied from @override
+
+        # pylint: disable=attribute-defined-outside-init
+        # It is okay for attributes in behaviors to be
+        # defined in the setup / initialise functions.
+
+        # Get Node from Kwargs
+        self.node = kwargs["node"]
+
+        # Get the MoveIt2 object.
+        self.moveit2, self.moveit2_lock = get_moveit2_object(
+            self.blackboard,
+            self.node,
+        )
+
+    @override
+    def initialise(self) -> None:
+        # Docstring copied from @override
+
+        # pylint: disable=attribute-defined-outside-init
+        # It is okay for attributes in behaviors to be
+        # defined in the setup / initialise functions.
+
+        self.motion_future = None
+
+        # First tick: send the trajectory to MoveIt
+        # Note: this *could* block, but it is unlikely
+        with self.moveit2_lock:
+            if (
+                self.blackboard_exists("trajectory")
+                and self.blackboard_get("trajectory") is not None
+            ):
+                self.moveit2.execute(self.blackboard_get("trajectory"))
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        # pylint: disable=attribute-defined-outside-init, too-many-return-statements
+        # It is okay for attributes in behaviors to be
+        # defined in the setup / initialise functions.
+
+        # Handle empty trajectory
+        if (
+            not self.blackboard_exists("trajectory")
+            or self.blackboard_get("trajectory") is None
+        ):
+            self.blackboard_set("error_code", MoveItErrorCodes.SUCCESS)
+            return py_trees.common.Status.SUCCESS
+
+        # Lock MoveIt2 Object
+        if self.moveit2_lock.locked():
+            return py_trees.common.Status.RUNNING
+        with self.moveit2_lock:
+            if self.motion_future is None:
+                query_state = self.moveit2.query_state()
+                if query_state == MoveIt2State.REQUESTING:
+                    # The goal has been sent to the action server, but not yet accepted
+                    return py_trees.common.Status.RUNNING
+                if query_state == MoveIt2State.EXECUTING:
+                    # The goal has been accepted and is executing. In this case
+                    # don't return a status since we drop down into the below
+                    # for when the robot is in motion.
+                    self.motion_future = self.moveit2.get_execution_future()
+                elif query_state == MoveIt2State.IDLE:
+                    last_error_code = self.moveit2.get_last_execution_error_code()
+                    self.blackboard_set("error_code", last_error_code)
+                    if last_error_code is None or last_error_code.val != 1:
+                        # If we get here then something went wrong (e.g., controller
+                        # is already executing a trajectory, action server not
+                        # available, goal was rejected, etc.)
+                        self.logger.error(
+                            f"{self.name} [MoveTo::update()] Failed to execute trajectory before "
+                            "goal was accepted!"
+                        )
+                        return py_trees.common.Status.FAILURE
+                    # If we get here, the goal finished executing within the
+                    # last tick.
+                    return py_trees.common.Status.SUCCESS
+
+            if self.motion_future.done():
+                # The goal has finished executing
+                if self.motion_future.result().status == GoalStatus.STATUS_SUCCEEDED:
+                    error_code = self.motion_future.result().result.error_code
+                    self.blackboard_set("error_code", error_code)
+                    if error_code.val == MoveItErrorCodes.SUCCESS:
+                        # The goal succeeded
+                        return py_trees.common.Status.SUCCESS
+                    # The goal failed (execution)
+                    return py_trees.common.Status.FAILURE
+                # The goal failed (actionlib)
+                self.blackboard_set("error_code", self.motion_future.result().status)
+                return py_trees.common.Status.FAILURE
+
+        # The goal is still executing
+        return py_trees.common.Status.RUNNING

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -364,6 +364,16 @@ class MoveIt2Plan(BlackboardBehavior):
             )
             return py_trees.common.Status.RUNNING
 
+    @override
+    def terminate(self, new_status: py_trees.common.Status) -> None:
+        # Docstring copied from @override
+
+        # Clear constraints just in case
+        # Note plan_async should already do this
+        with self.moveit2_lock:
+            self.moveit2.clear_goal_constraints()
+            self.moveit2.clear_path_constraints()
+
     def joint_constraint_satisfied(self, constraint_kwargs: Dict[str, Any]) -> bool:
         """
         Check if current joint state satisfies provided joint constraint.

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the MoveIt2Plan behavior, which uses pymoveit2
+to plan a path using the provided path and goal constraints.
+"""
+
+# Standard imports
+import csv
+from enum import Enum
+import math
+import os
+import time
+from typing import Any, Union, Optional, Dict, List, Tuple
+
+# Third-party imports
+from ament_index_python.packages import get_package_share_directory
+from geometry_msgs.msg import Point, Quaternion
+import numpy as np
+from overrides import override
+import py_trees
+import ros2_numpy
+from scipy.spatial.transform import Rotation as R
+import tf2_py as tf2
+from trajectory_msgs.msg import JointTrajectory
+
+# Local imports
+from ada_feeding.helpers import (
+    BlackboardKey,
+    get_moveit2_object,
+    get_tf_object,
+)
+from ada_feeding.behaviors import BlackboardBehavior
+
+
+class MoveIt2ConstraintType(Enum):
+    """
+    Used to specify the type of constraint_kwargs
+    Passed to MoveIt2Plan
+    """
+
+    JOINT = 0
+    POSITION = 1
+    ORIENTATION = 2
+
+
+class MoveIt2Plan(BlackboardBehavior):
+    """
+    Runs moveit2.py plan_async with the provided
+    path and goal constraints.
+
+    Returns SUCCESS with the found trajectory.
+    Or SUCCESS + None if the goal constraints are all satisfied.
+
+    Or FAILURE + None if no trajectory can be found.
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    # pylint: disable=too-many-arguments
+    # These are effectively config definitions
+    # They require a lot of arguments.
+
+    def blackboard_inputs(
+        self,
+        goal_constraints: Union[
+            BlackboardKey, List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]
+        ],
+        path_constraints: Optional[
+            Union[BlackboardKey, List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+        ] = None,
+        ignore_violated_path_constraints: Union[BlackboardKey, bool] = False,
+        pipeline_id: Union[BlackboardKey, str] = "ompl",
+        planner_id: Union[BlackboardKey, str] = "RRTstarkConfigDefault",
+        allowed_planning_time: Union[BlackboardKey, float] = 0.5,
+        max_velocity_scale: Union[BlackboardKey, float] = 0.1,
+        max_acceleration_scale: Union[BlackboardKey, float] = 0.1,
+        cartesian: Union[BlackboardKey, bool] = False,
+        cartesian_max_step: Union[BlackboardKey, float] = 0.0025,
+        cartesian_jump_threshold: Union[BlackboardKey, float] = 0.0,
+        cartesian_fraction_threshold: Union[BlackboardKey, float] = 0.0,
+        debug_trajectory_viz: Union[BlackboardKey, bool] = False,
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Parameters
+        ----------
+        goal_constraints: list of constraints, each one is a pair mapping the type to the kwargs
+                        passed to the corresponding pymoveit2 function. See moveit2.py:set_X_goal()
+        path_constraints: list of constraints, each one is a pair mapping the type to the kwargs
+                        passed to the corresponding pymoveit2 function.
+                        See moveit2.py:set_path_X_constraint()
+        ignore_violated_path_constraints: if True, if a path constraint starts violated,
+                                          it's okay to plan without it.
+        pipeline_id: MoveIt2 Pipeline, usually "ompl"
+        planner_id: MoveIt2 planner to use
+        allowed_planning_time: Anytime planner timeout, passed to MoveIt2 Directly.
+                                NOTE: Not guaranteed, use a Timeout decorator for that.
+        max_velocity_scale: [0,1] determines max joint of the trajectory
+        max_acceleration_scale: [0,1] determines max joint acceleration of the trajectory
+        cartesian: True to use MoveIt2's cartesian planner, uses the below parameters
+        cartesian_max_step: % of the geodesic to step for each IK of the cartesian planner
+        cartesian_jump_threshold: If >0, large joint jumps between cartesian planner IKs
+                                  will cause planning to stop
+        cartesian_fraction_threshold: [0,1], % of the geodesic that must be planned collision-free
+                                      to return success.
+        debug_trajectory_viz: Whether to generate and save a visualization of the
+            trajectory in joint space. This is useful for debugging, but should
+            be disabled in production.
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        trajectory: Optional[BlackboardKey],  # Optional[JointTrajectory]
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        trajectory (JointTrajectory): planned, timed trajectory, or None if planning failed
+                                      or goal is already satisfied
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def setup(self, **kwargs):
+        # Docstring copied from @override
+
+        # pylint: disable=attribute-defined-outside-init
+        # It is okay for attributes in behaviors to be
+        # defined in the setup / initialise functions.
+
+        # Get Node from Kwargs
+        self.node = kwargs["node"]
+
+        # Get the MoveIt2 object.
+        self.moveit2, self.moveit2_lock = get_moveit2_object(
+            self.blackboard,
+            self.node,
+        )
+
+        # Get TF Listener from blackboard
+        self.tf_buffer, _, self.tf_lock = get_tf_object(self.blackboard, self.node)
+
+    @override
+    def initialise(self) -> None:
+        # Docstring copied from @override
+
+        # pylint: disable=attribute-defined-outside-init
+        # It is okay for attributes in behaviors to be
+        # defined in the setup / initialise functions.
+
+        self.planning_future = None
+
+        # Copy config to MoveIt2 object.
+        # Note: this *could* block, but it is unlikely
+        with self.moveit2_lock:
+            self.moveit2.planner_id = self.blackboard_get("planner_id")
+            self.moveit2.pipeline_id = self.blackboard_get("pipeline_id")
+            self.moveit2.max_velocity = self.blackboard_get("max_velocity_scale")
+            self.moveit2.max_acceleration = self.blackboard_get(
+                "max_acceleration_scale"
+            )
+            self.moveit2.allowed_planning_time = self.blackboard_get(
+                "allowed_planning_time"
+            )
+            self.moveit2.cartesian_jump_threshold = self.blackboard_get(
+                "cartesian_jump_threshold"
+            )
+            # If the plan is cartesian, it should always avoid collisions
+            self.moveit2.cartesian_avoid_collisions = True
+
+            # Clear constraints
+            self.moveit2.clear_goal_constraints()
+            self.moveit2.clear_path_constraints()
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        # pylint: disable=too-many-return-statements, too-many-statements, too-many-branches
+        # All raised exceptions map to a return statement.
+        # This is the main function, it is okay for it to be long.
+
+        # Lock MoveIt2 Object
+        if self.moveit2_lock.locked():
+            return py_trees.common.Status.RUNNING
+        if self.tf_lock.locked():
+            return py_trees.common.Status.RUNNING
+        with self.moveit2_lock, self.tf_lock:
+            ### Check if plan done
+            if self.planning_future is not None:
+                if self.planning_future.done():
+                    traj = self.moveit2.get_trajectory(
+                        self.planning_future,
+                        cartesian=self.blackboard_get("cartesian"),
+                        cartesian_fraction_threshold=self.blackboard_get(
+                            "cartesian_fraction_threshold"
+                        ),
+                    )
+
+                    if traj is None:
+                        self.logger.error(
+                            f"{self.name} [MoveIt2Plan::update()] Planning Failure!"
+                        )
+                        return py_trees.common.Status.FAILURE
+
+                    # MoveIt's default cartesian interpolator doesn't respect velocity
+                    # scaling, so we need to manually add that.
+                    if (
+                        self.blackboard_get("cartesian")
+                        and self.blackboard_get("max_velocity_scale") > 0.0
+                    ):
+                        MoveIt2Plan.scale_velocity(traj, self.moveit2.max_velocity)
+
+                    # Save the trajectory visualization
+                    if self.blackboard_get("debug_trajectory_viz"):
+                        MoveIt2Plan.visualize_trajectory(self.name, traj)
+
+                    # Write blackboard outputs and SUCCEED
+                    self.blackboard_set("trajectory", traj)
+                    return py_trees.common.Status.SUCCESS
+
+            ### New Plan
+            ### Add Constraints to MoveIt Object
+
+            # Check all goal constraints
+            goals_satisfied = True
+
+            for constraint_type, constraint_kwargs in self.blackboard_get(
+                "goal_constraints"
+            ):
+                try:
+                    if constraint_type == MoveIt2ConstraintType.JOINT:
+                        goals_satisfied = self.joint_constraint_satisfied(
+                            constraint_kwargs
+                        )
+                        self.moveit2.set_joint_goal(**constraint_kwargs)
+                    elif constraint_type == MoveIt2ConstraintType.POSITION:
+                        goals_satisfied = self.position_constraint_satisfied(
+                            constraint_kwargs
+                        )
+                        self.moveit2.set_position_goal(**constraint_kwargs)
+                    elif constraint_type == MoveIt2ConstraintType.ORIENTATION:
+                        goals_satisfied = self.orientation_constraint_satisfied(
+                            constraint_kwargs
+                        )
+                        self.moveit2.set_orientation_goal(**constraint_kwargs)
+                except tf2.LookupException:
+                    # Wait on Frame Transform
+                    # Use Timeout decorator to fail
+                    return py_trees.common.Status.RUNNING
+                except (IndexError, AttributeError):
+                    self.logger.error(f"Malformed Goal Constraint: {constraint_kwargs}")
+                    return py_trees.common.Status.FAILURE
+
+                if not goals_satisfied:
+                    break
+
+            # If all goals are satisfied, return SUCCESS, no planning necessary
+            if goals_satisfied:
+                self.moveit2.clear_goal_constraints()
+                self.moveit2.clear_path_constraints()
+                self.blackboard_set("trajectory", None)
+                return py_trees.common.Status.SUCCESS
+
+            # Check all path constraints
+            paths_satisfied = True
+            for constraint_type, constraint_kwargs in self.blackboard_get(
+                "path_constraints"
+            ):
+                try:
+                    if constraint_type == MoveIt2ConstraintType.JOINT:
+                        if self.joint_constraint_satisfied(constraint_kwargs):
+                            self.moveit2.set_path_joint_constraint(**constraint_kwargs)
+                        elif not self.blackboard_get(
+                            "ignore_violated_path_constraints"
+                        ):
+                            paths_satisfied = False
+                            break
+                    elif constraint_type == MoveIt2ConstraintType.POSITION:
+                        if self.position_constraint_satisfied(constraint_kwargs):
+                            self.moveit2.set_path_position_constraint(
+                                **constraint_kwargs
+                            )
+                        elif not self.blackboard_get(
+                            "ignore_violated_path_constraints"
+                        ):
+                            paths_satisfied = False
+                            break
+                    elif constraint_type == MoveIt2ConstraintType.ORIENTATION:
+                        if self.orientation_constraint_satisfied(constraint_kwargs):
+                            self.moveit2.set_path_orientation_constraint(
+                                **constraint_kwargs
+                            )
+                        elif not self.blackboard_get(
+                            "ignore_violated_path_constraints"
+                        ):
+                            paths_satisfied = False
+                            break
+                except tf2.LookupException:
+                    # Wait on Frame Transform
+                    # Use Timeout decorator to fail
+                    return py_trees.common.Status.RUNNING
+                except (IndexError, AttributeError):
+                    self.logger.error(f"Malformed Goal Constraint: {constraint_kwargs}")
+                    return py_trees.common.Status.FAILURE
+
+            # If any path constraints are unsatisfied, return FAILURE
+            if not paths_satisfied:
+                self.moveit2.clear_goal_constraints()
+                self.moveit2.clear_path_constraints()
+                self.blackboard_set("trajectory", None)
+                return py_trees.common.Status.FAILURE
+
+            ### Begin Planning
+            # pylint: disable=attribute-defined-outside-init
+            self.planning_future = self.moveit2.plan_async(
+                cartesian=self.blackboard_get("cartesian"),
+                max_step=self.blackboard_get("cartesian_max_step"),
+            )
+            return py_trees.common.Status.RUNNING
+
+    def joint_constraint_satisfied(self, constraint_kwargs: Dict[str, Any]) -> bool:
+        """
+        Check if current joint state satisfies provided joint constraint.
+
+        Assume self.moveit2 is locked.
+
+        Parameters
+        ----------
+        constraint_kwargs: See moveit2.py; dictionary with keys: "joint_positions"
+                           "joint_names", "tolerance"
+        Returns
+        -------
+        True if the constraint is satisfied
+        """
+
+        # pylint: disable=protected-access
+        # We effectively need to to introspection
+        # to copy the functionality of MoveIt constraints.
+        # And this is read-only access.
+
+        curr_joint_state = self.moveit2.joint_state
+        tol = constraint_kwargs["tolerance"]
+
+        for i, des_position in enumerate(constraint_kwargs["joint_positions"]):
+            curr_position = curr_joint_state.position[i]
+            if len(constraint_kwargs["joint_names"]) > i:
+                index = curr_joint_state.name.index(constraint_kwargs["joint_names"][i])
+                curr_position = curr_joint_state.position[index]
+            if abs(curr_position - des_position) > tol:
+                return False
+
+        return True
+
+    def position_constraint_satisfied(self, constraint_kwargs: Dict[str, Any]) -> bool:
+        """
+        Check if current position state satisfies provided position constraint.
+
+        Assume self.moveit2_lock and self.tf_lock are locked.
+
+        Assume TF from frame_id to target_link exists.
+
+        Parameters
+        ----------
+        constraint_kwargs: See moveit2.py; dictionary with keys: "position"
+                           "frame_id", "target_link", "tolerance"
+        Returns
+        -------
+        True if the constraint is satisfied
+        """
+
+        # pylint: disable=protected-access
+        # We effectively need to to introspection
+        # to copy the functionality of MoveIt constraints.
+        # And this is read-only access.
+
+        tol = constraint_kwargs["tolerance"]
+
+        t_stamped = self.tf_buffer.lookup_transform(
+            constraint_kwargs["frame_id"]
+            if constraint_kwargs["frame_id"] is not None
+            else self.moveit2.__base_link_name,
+            constraint_kwargs["target_link"]
+            if constraint_kwargs["target_link"] is not None
+            else self.moveit2.__end_effector_name,
+            self.node.get_clock().now(),
+        )
+        current = ros2_numpy.numpify(t_stamped.transform.translation)
+        desired = None
+        if isinstance(constraint_kwargs["position"], Point):
+            desired = ros2_numpy.numpify(constraint_kwargs["position"])
+        else:
+            desired = np.array(constraint_kwargs["position"])
+
+        return np.linalg.norm(desired - current) <= tol
+
+    def orientation_constraint_satisfied(
+        self, constraint_kwargs: Dict[str, Any]
+    ) -> bool:
+        """
+        Check if current orientation satisfies provided orientation constraint.
+
+        Assume self.moveit2_lock and self.tf_lock are locked.
+
+        Assume TF from frame_id to target_link exists.
+
+        Parameters
+        ----------
+        constraint_kwargs: See moveit2.py; dictionary with keys: "quat_xyzw"
+                           "frame_id", "target_link", "tolerance", and "parameterization"
+        Returns
+        -------
+        True if the constraint is satisfied
+        """
+
+        # pylint: disable=protected-access
+        # We effectively need to to introspection
+        # to copy the functionality of MoveIt constraints.
+        # And this is read-only access.
+
+        tol = np.array(constraint_kwargs["tolerance"]) * np.ones(3)
+
+        t_stamped = self.tf_buffer.lookup_transform(
+            constraint_kwargs["frame_id"]
+            if constraint_kwargs["frame_id"] is not None
+            else self.moveit2.__base_link_name,
+            constraint_kwargs["target_link"]
+            if constraint_kwargs["target_link"] is not None
+            else self.moveit2.__end_effector_name,
+            self.node.get_clock().now(),
+        )
+        current = R.from_quat(list(ros2_numpy.numpify(t_stamped.transform.rotation)))
+        desired = None
+        if isinstance(constraint_kwargs["quat_xyzw"], Quaternion):
+            desired = R.from_quat(
+                list(ros2_numpy.numpify(constraint_kwargs["quat_xyzw"]))
+            )
+        else:
+            desired = R.from_quat(list(constraint_kwargs["quat_xyzw"]))
+
+        diff = R.from_matrix(np.dot(current.as_matrix(), desired.as_matrix().T))
+
+        # For specifics, see:
+        # https://github.com/ros-planning/moveit2/blob/f9989626491ca63e9f7f612964b03afcf0749bea/moveit_core/kinematic_constraints/src/kinematic_constraint.cpp
+        if constraint_kwargs["parameterization"] == 0:  # Euler Angles
+            diff_xyz = diff.as_euler("xyz", degrees=False)
+        else:  # Rotation Vector
+            diff_xyz = diff.as_rotvec()
+
+        return np.all(diff_xyz <= tol)
+
+    @staticmethod
+    def scale_velocity(traj: JointTrajectory, scale_factor: float) -> None:
+        """
+        Scale the velocity of the trajectory by the given factor. The resulting
+        trajectory should execute the same trajectory with the same continuity,
+        but just take 1/scale_factor as long to execute.
+
+        This function keeps positions the same and scales time, velocities, and
+        accelerations. It does not modify effort.
+
+        Parameters
+        ----------
+        traj: The trajectory to scale.
+        scale_factor: The factor to scale the velocity by, in [0, 1].
+        """
+        for point in traj.points:
+            # Scale time_from_start
+            nsec = point.time_from_start.sec * 10.0**9
+            nsec += point.time_from_start.nanosec
+            nsec /= scale_factor  # scale time
+            sec = int(math.floor(nsec / 10.0**9))
+            point.time_from_start.sec = sec
+            point.time_from_start.nanosec = int(nsec - sec * 10.0**9)
+
+            # Scale the velocities
+            # pylint: disable=consider-using-enumerate
+            # Necessary because we want to destructively modify the trajectory
+            for i in range(len(point.velocities)):
+                point.velocities[i] *= scale_factor
+
+            # Scale the accelerations
+            for i in range(len(point.accelerations)):
+                point.accelerations[i] *= scale_factor**2
+
+    @staticmethod
+    def visualize_trajectory(action_name: str, traj: JointTrajectory) -> None:
+        """
+        Generates a visualization of the positions, velocities, and accelerations
+        of each joint in the trajectory. Saves the visualization in the share
+        directory for `ada_feeding`, as `trajectories/{timestamp}_{action}.png`.
+        Also saves a CSV of the trajectory.
+
+        Parameters
+        ----------
+        action_name: The name of the action that generated this trajectory.
+        traj: The trajectory to visualize.
+        """
+
+        # pylint: disable=too-many-locals
+        # Necessary because this function saves both the image and CSV
+
+        # pylint: disable=import-outside-toplevel
+        # No need to import graphing libraries if we aren't saving the trajectory
+        import matplotlib.pyplot as plt
+
+        # Get the filepath, excluding the extension
+        file_dir = os.path.join(
+            get_package_share_directory("ada_feeding"),
+            "trajectories",
+        )
+        if not os.path.exists(file_dir):
+            os.mkdir(file_dir)
+        filepath = os.path.join(
+            file_dir,
+            f"{int(time.time()*10**9)}_{action_name}",
+        )
+
+        # Generate the CSV header
+        csv_header = ["time_from_start"]
+        for descr in ["Position", "Velocity", "Acceleration"]:
+            for joint_name in traj.joint_names:
+                csv_header.append(f"{joint_name} {descr}")
+        csv_data = [csv_header]
+
+        # Generate the axes for the graph
+        nrows = 2
+        ncols = int(math.ceil(len(traj.joint_names) / float(nrows)))
+        fig, axes = plt.subplots(nrows, ncols, figsize=(20, 10))
+        positions = [[] for _ in traj.joint_names]
+        velocities = [[] for _ in traj.joint_names]
+        accelerations = [[] for _ in traj.joint_names]
+        time_from_start = []
+
+        # Loop over the trajectory
+        for point in traj.points:
+            timestamp = (
+                point.time_from_start.sec + point.time_from_start.nanosec * 10.0**-9
+            )
+            row = [timestamp]
+            time_from_start.append(timestamp)
+            for descr in ["positions", "velocities", "accelerations"]:
+                for i, joint_name in enumerate(traj.joint_names):
+                    row.append(getattr(point, descr)[i])
+                    if descr == "positions":
+                        positions[i].append(getattr(point, descr)[i])
+                    elif descr == "velocities":
+                        velocities[i].append(getattr(point, descr)[i])
+                    elif descr == "accelerations":
+                        accelerations[i].append(getattr(point, descr)[i])
+            csv_data.append(row)
+
+        # Generate and save the figure
+        for i, joint_name in enumerate(traj.joint_names):
+            ax = axes[i // ncols, i % ncols]
+            ax.plot(time_from_start, positions[i], label="Position (rad)")
+            ax.plot(time_from_start, velocities[i], label="Velocity (rad/s)")
+            ax.plot(time_from_start, accelerations[i], label="Acceleration (rad/s^2)")
+            ax.set_xlabel("Time (s)")
+            ax.set_title(joint_name)
+            ax.legend()
+        fig.tight_layout()
+        fig.savefig(filepath + ".png")
+        plt.clf()
+
+        # Save the CSV
+        with open(filepath + ".csv", "w", encoding="utf-8") as csv_file:
+            csv_writer = csv.writer(csv_file)
+            csv_writer.writerows(csv_data)

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -10,13 +10,21 @@ wrap that behavior tree in a ROS2 action server.
 # Third-party imports
 from overrides import override
 import py_trees
+from py_trees.blackboard import Blackboard
+import py_trees_ros
 
 # Local imports
 from ada_feeding import ActionServerBT
-from ada_feeding.behaviors.acquisition import ComputeFoodFrame
+from ada_feeding.behaviors.acquisition import ComputeFoodFrame, ComputeActionConstraints
+from ada_feeding.behaviors.moveit2 import (
+    MoveIt2PoseConstraint,
+    MoveIt2Plan,
+    MoveIt2Execute,
+)
 from ada_feeding.helpers import BlackboardKey
 from ada_feeding.visitors import MoveToVisitor
 from ada_feeding_msgs.action import AcquireFood
+from ada_feeding_msgs.srv import AcquisitionSelect
 
 
 class AcquireFoodTree(ActionServerBT):
@@ -51,9 +59,10 @@ class AcquireFoodTree(ActionServerBT):
             name=name,
             memory=True,
             children=[
+                # Compute Food Frame
                 py_trees.decorators.Timeout(
-                    duration=1.0,
                     name="ComputeFoodFrameTimeout",
+                    duration=1.0,
                     child=ComputeFoodFrame(
                         name="ComputeFoodFrame",
                         ns=name,
@@ -63,8 +72,66 @@ class AcquireFoodTree(ActionServerBT):
                             # Default food_frame_id = "food"
                             # Default world_frame = "world"
                         },
-                        outputs={"action_select_request": None, "food_frame": None},
+                        outputs={
+                            "action_select_request": BlackboardKey("action_request"),
+                            "food_frame": None,
+                        },
                     ),
+                ),
+                # Get Action to Use
+                py_trees_ros.service_clients.FromBlackboard(
+                    name="AcquisitionSelect",
+                    service_name="~/action_select",
+                    service_type=AcquisitionSelect,
+                    # Need absolute Blackboard name
+                    key_request=Blackboard.separator.join(
+                        [name, BlackboardKey("action_request")]
+                    ),
+                    key_response=Blackboard.separator.join(
+                        [name, BlackboardKey("action_response")]
+                    ),
+                    # Default fail if service is down
+                    wait_for_server_timeout_sec=0.0,
+                ),
+                # Get MoveIt2 Constraints
+                ComputeActionConstraints(
+                    name="ComputeActionConstraints",
+                    ns=name,
+                    inputs={
+                        "action_select_response": BlackboardKey("action_response"),
+                        # Default move_above_dist_m = 0.05
+                    },
+                    outputs={
+                        "move_above_pose": BlackboardKey("move_above_pose"),
+                    },
+                ),
+                # Move Above Food
+                MoveIt2PoseConstraint(
+                    name="MoveAbovePose",
+                    ns=name,
+                    inputs={
+                        "pose": BlackboardKey("move_above_pose"),
+                        "frame_id": "food",
+                    },
+                    outputs={
+                        "constraints": BlackboardKey("goal_constraints"),
+                    },
+                ),
+                MoveIt2Plan(
+                    name="MoveAbovePlan",
+                    ns=name,
+                    inputs={
+                        "goal_constraints": BlackboardKey("goal_constraints"),
+                        "max_velocity_scale": 0.8,
+                        "max_acceleration_scale": 0.8,
+                    },
+                    outputs={"trajectory": BlackboardKey("trajectory")},
+                ),
+                MoveIt2Execute(
+                    name="MoveAbove",
+                    ns=name,
+                    inputs={"trajectory": BlackboardKey("trajectory")},
+                    outputs={},
                 ),
             ],
         )

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -65,7 +65,7 @@ class AcquireFoodTree(ActionServerBT):
                         },
                         outputs={"action_select_request": None, "food_frame": None},
                     ),
-                )
+                ),
             ],
         )
 

--- a/ada_feeding/ada_feeding/visitors/moveto_visitor.py
+++ b/ada_feeding/ada_feeding/visitors/moveto_visitor.py
@@ -144,7 +144,7 @@ class MoveToVisitor(VisitorBase):
         # Docstring copied by @override
 
         # pylint: disable=too-many-branches
-        
+
         # We only care about leaf nodes
         if isinstance(behaviour, (Composite, Decorator)):
             return

--- a/ada_feeding/ada_feeding/visitors/moveto_visitor.py
+++ b/ada_feeding/ada_feeding/visitors/moveto_visitor.py
@@ -8,15 +8,22 @@ all actions based on MoveTo.action.
 """
 
 # Standard imports
+from copy import deepcopy
+import math
 from overrides import override
 
 # Third-party imports
 import py_trees
+from py_trees.composites import Composite
+from py_trees.decorators import Decorator
 from py_trees.visitors import VisitorBase
 from rclpy.node import Node
+from trajectory_msgs.msg import JointTrajectory
 
 # Local imports
 import ada_feeding.behaviors
+from ada_feeding.behaviors.moveit2 import MoveIt2Execute
+from ada_feeding.helpers import get_moveit2_object
 from ada_feeding_msgs.action import MoveTo
 
 
@@ -39,6 +46,10 @@ class MoveToVisitor(VisitorBase):
         self.feedback = MoveTo.Feedback()
         self.feedback.is_planning = True
 
+        # Used for get_distance_to_goal
+        self.aligned_joint_indices = None
+        self.traj_i = 0
+
     def reinit(self) -> None:
         """
         Reset all local variables.
@@ -48,9 +59,95 @@ class MoveToVisitor(VisitorBase):
         self.feedback = MoveTo.Feedback()
         self.feedback.is_planning = True
 
+    @staticmethod
+    def joint_position_dist(point1: float, point2: float) -> float:
+        """
+        Given two joint positions in radians, this function computes the
+        distance between then, accounting for rotational symmetry.
+
+        Parameters
+        ----------
+        point1: The first joint position, in radians.
+        point2: The second joint position, in radians.
+        """
+        abs_dist = abs(point1 - point2) % (2 * math.pi)
+        return min(abs_dist, 2 * math.pi - abs_dist)
+
+    def get_distance_to_goal(self, traj: JointTrajectory) -> float:
+        """
+        Returns the remaining distance to the goal.
+
+        In practice, it keeps track of what joint state along the trajectory the
+        robot is currently in, and returns the number of remaining joint states. As
+        a result, this is not technically a measure of either distance or time, but
+        should give some intuition of how much of the trajectory is left to execute.
+        """
+        # If the trajectory has not been set, something is wrong.
+        if traj is None:
+            self.node.get_logger().error(
+                "[MoveIt2Visitor::get_distance_to_goal()] Trajectory is None!"
+            )
+            return 0.0
+
+        # Get the latest joint state of the robot
+        moveit2, lock = get_moveit2_object(
+            py_trees.blackboard.Client(name="visitor", namespace="/"), self.node
+        )
+        with lock:
+            curr_joint_state = moveit2.joint_state
+
+        # Lazily align the joints between the trajectory and the joint states message
+        if self.aligned_joint_indices is None:
+            self.aligned_joint_indices = []
+            for joint_traj_i, joint_name in enumerate(traj.joint_names):
+                if joint_name in curr_joint_state.name:
+                    joint_state_i = curr_joint_state.name.index(joint_name)
+                    self.aligned_joint_indices.append(
+                        (joint_name, joint_state_i, joint_traj_i)
+                    )
+                else:
+                    self.node.get_logger().error(
+                        f"[MoveIt2Visitor::get_distance_to_goal()] Joint {joint_name} not in "
+                        "current joint state, despite being in the trajectory. Skipping this joint "
+                        "in distance to goal calculation."
+                    )
+
+        # Get the point along the trajectory closest to the robot's current joint state
+        min_dist = None
+        for i in range(self.traj_i, len(traj.points)):
+            # Compute the distance between the current joint state and the
+            # ujoint state at index i.
+            traj_joint_state = traj.points[i]
+            dist = sum(
+                MoveToVisitor.joint_position_dist(
+                    curr_joint_state.position[joint_state_i],
+                    traj_joint_state.positions[joint_traj_i],
+                )
+                for (_, joint_state_i, joint_traj_i) in self.aligned_joint_indices
+            )
+
+            # If the distance is increasing, we've found the local min.
+            if min_dist is not None:
+                if dist >= min_dist:
+                    self.traj_i = i - 1
+                    return float(len(traj.points) - self.traj_i)
+
+            min_dist = dist
+
+        # If the distance never increased, we are nearing the final waypoint.
+        # Because the robot may still have slight motion even after this point,
+        # we conservatively return 1.0.
+        return 1.0
+
     @override
     def run(self, behaviour: py_trees.behaviour.Behaviour) -> None:
         # Docstring copied by @override
+
+        # pylint: disable=too-many-branches
+        
+        # We only care about leaf nodes
+        if isinstance(behaviour, (Composite, Decorator)):
+            return
 
         # Record Start Time
         if self.start_time is None:
@@ -69,8 +166,25 @@ class MoveToVisitor(VisitorBase):
             if behaviour.tree_blackboard.is_planning != self.feedback.is_planning:
                 self.start_time = self.node.get_clock().now()
                 self.feedback.is_planning = behaviour.tree_blackboard.is_planning
+        elif (
+            isinstance(behaviour, MoveIt2Execute)
+            and behaviour.status == py_trees.common.Status.RUNNING
+        ):
+            # Flip to execute
+            if self.feedback.is_planning:
+                self.start_time = self.node.get_clock().now()
+                self.feedback.is_planning = False
+                self.traj_i = 0
+            if behaviour.blackboard_exists("trajectory"):
+                traj = behaviour.blackboard_get("trajectory")
+                if traj is not None:
+                    self.feedback.motion_initial_distance = float(len(traj.points))
+                    self.feedback.motion_curr_distance = self.get_distance_to_goal(traj)
         else:
-            # Else just update planning time
+            # Catch end of MoveIt2Execute behavior
+            if behaviour.status == py_trees.common.Status.SUCCESS:
+                self.feedback.motion_curr_distance = 0.0
+            # Switch to planning start time
             if not self.feedback.is_planning:
                 self.start_time = self.node.get_clock().now()
                 self.feedback.is_planning = True
@@ -92,4 +206,4 @@ class MoveToVisitor(VisitorBase):
         -------
         MoveTo Feedback message, see MoveTo.action for more info.
         """
-        return self.feedback
+        return deepcopy(self.feedback)

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="run_web_bridge" default="true" description="Whether to run the web bridge nodes" />
   <arg name="use_estop" default="true" description="Whether to use the e-stop. Should only be set false in sim, since we don't have a way of simulating the e-stop button." />
+  <arg name="log_level" default="info" description="Log Level to pass to create_action_servers: debug, info, warn" />
 
   <group if="$(var run_web_bridge)">
     <!-- The ROSBridge Node -->
@@ -17,7 +18,7 @@
   </node>
 
   <!-- Launch the action servers necessary to move the robot -->
-  <node pkg="ada_feeding" exec="create_action_servers.py" name="ada_feeding_action_servers" respawn="true">
+  <node pkg="ada_feeding" exec="create_action_servers.py" name="ada_feeding_action_servers" respawn="true" args="--ros-args --log-level $(var log_level) --log-level rcl:=INFO --log-level rmw_cyclonedds_cpp:=INFO">
     <param from="$(find-pkg-share ada_feeding)/config/ada_feeding_action_servers.yaml"/>
     <remap from="~/watchdog" to="/ada_watchdog/watchdog" />
     <remap from="~/toggle_watchdog_listener" to="/ada_watchdog_listener/toggle_watchdog_listener" />

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -2,6 +2,7 @@
   <arg name="run_web_bridge" default="true" description="Whether to run the web bridge nodes" />
   <arg name="use_estop" default="true" description="Whether to use the e-stop. Should only be set false in sim, since we don't have a way of simulating the e-stop button." />
   <arg name="log_level" default="info" description="Log Level to pass to create_action_servers: debug, info, warn" />
+  <arg name="default_action_select" default="true" description="Whether to use the default action select: constant policy 0" />
 
   <group if="$(var run_web_bridge)">
     <!-- The ROSBridge Node -->
@@ -26,7 +27,14 @@
     <remap from="~/set_force_gate_controller_parameters" to="/jaco_arm_controller/set_parameters" />
     <remap from="~/toggle_face_detection" to="/toggle_face_detection" />
     <remap from="~/face_detection" to="/face_detection" />
+    <remap from="~/action_select" to="/ada_feeding_action_select/action_select" />
+    <remap from="~/action_report" to="/ada_feeding_action_select/action_report" />
   </node>
+
+  <!-- Include Default Action Selection Server -->
+  <group if="$(var default_action_select)">
+    <include file="$(find-pkg-share ada_feeding_action_select)/launch/ada_feeding_action_select_launch.xml"/>
+  </group>
 
   <!-- Populate the planning scene -->
   <node pkg="ada_feeding" exec="ada_planning_scene.py" name="ada_planning_scene">

--- a/ada_feeding_msgs/srv/AcquisitionSelect.srv
+++ b/ada_feeding_msgs/srv/AcquisitionSelect.srv
@@ -18,6 +18,7 @@ ada_feeding_msgs/AcquisitionSchema[] actions
 float64[] probabilities
 
 # Status Message
+# "Success" on success
 string status
 
 # Selection ID


### PR DESCRIPTION
# Description

Adds the following functionality / overhauled behaviors:

* MoveIt2Plan: given a bunch of planning parameters returns a JointTrajectory
* * If all goal constraints are satisfied, return None and Success
* * If any path constraint is unsatisfied, return None and Failure (unless explicitly ignored)
* MoveIt2XConstraint: compile blackboard objects into the constraint kwargs dictionary expected by MoveIt2Plan
* MoveIt2Execute: Given a JointTrajectory, execute it on the robot
* Add the option for setting the debug log_level at the launch file level
* Add the default action_select policy to the ada_feeding main launch file
* Extend the AcquireFood tree to carry out MoveAbove in order to test the basic functionality of the new behaviors.

# Testing procedure

Follow the testing procedure in #102 with the following additional steps:
* Verify that the robot moves 5cm above the shown `food` frame with the tines perpendicular to the X (red) axis (i.e. constant action 0)
* Alternate between the 2 carrot images and see the robot go back and forth moving above the two foods

_Note: will be happy to take recommendations on how to test other components of the MoveIt2 behaviors, but this is sufficient for me now to continue working on the AcquireFood tree_

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
