### PR TITLE
AcquireFood MVP (action 0 only)

### DIFF
--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -9,8 +9,8 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
 - Install Python dependencies: `python3 -m pip install overrides pyrealsense2 pyyaml py_trees pymongo tornado trimesh`
     - NOTE: [`pyrealsense2` is not released for ARM systems](https://github.com/IntelRealSense/librealsense/issues/6449#issuecomment-650784066), so ARM users will have to [build from source](https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/readme.md#building-from-source). When running `sudo make install`, pay close attention to which path `pyrealsense2` is installed to and add *that path* to the `PYTHONPATH` -- it should be `/use/local/lib` but may be `/usr/local/OFF`.
 - Install the code to command the real robot ([instructions here](https://github.com/personalrobotics/ada_ros2/blob/main/README.md))
-- Git clone the [PRL fork of pymoveit (branch: `amaln/move_collision`)](https://github.com/personalrobotics/pymoveit2/tree/amaln/move_collision) and the [PRL fork of py_trees_ros (branch: `amaln/service_client`)](https://github.com/personalrobotics/py_trees_ros/tree/amaln/service_client) into your ROS2 workspace's `src` folder.
-- Install additional dependencies: `sudo apt install ros-humble-py-trees-ros-interfaces`.
+- Git clone the [PRL fork of pymoveit (branch: `amaln/move_collision`)](https://github.com/personalrobotics/pymoveit2/tree/amaln/move_collision) the [PRL fork of py_trees_ros (branch: `amaln/service_client`)](https://github.com/personalrobotics/py_trees_ros/tree/amaln/service_client), and [ros2_numpy (branch: `humble`)](https://github.com/Box-Robotics/ros2_numpy) into your ROS2 workspace's `src` folder.
+- Install additional dependencies: `sudo apt install ros-humble-py-trees-ros-interfaces ros-humble-tf-transformations ros-humble-ament-cmake-nose`.
 - Install the web app into your workspace ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp)).
 
 ## Usage

--- a/ada_feeding/ada_feeding/behaviors/acquisition/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/__init__.py
@@ -3,4 +3,4 @@ This subpackage contains custom py_tree behaviors for Food Acquisition.
 """
 
 from .compute_food_frame import ComputeFoodFrame
-from .compute_action_constraints import ComputeActionConstraints
+from .compute_action_constraints import ComputeApproachConstraints

--- a/ada_feeding/ada_feeding/behaviors/acquisition/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/__init__.py
@@ -3,4 +3,7 @@ This subpackage contains custom py_tree behaviors for Food Acquisition.
 """
 
 from .compute_food_frame import ComputeFoodFrame
-from .compute_action_constraints import ComputeApproachConstraints
+from .compute_action_constraints import (
+    ComputeApproachConstraints,
+    ComputeExtractConstraints,
+)

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_action_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_action_constraints.py
@@ -60,6 +60,7 @@ class ComputeActionConstraints(BlackboardBehavior):
     def blackboard_outputs(
         self,
         move_above_pose: Optional[BlackboardKey],  # Pose, in Food Frame
+        move_into_pose: Optional[BlackboardKey], # Pose, in Food Frame
     ) -> None:
         """
         Blackboard Outputs
@@ -67,9 +68,8 @@ class ComputeActionConstraints(BlackboardBehavior):
 
         Parameters
         ----------
-        action_select_request (AcquisitionSelect.Request): request to send to AcquisitionSelect
-                                                           (copies mask input)
-        food_frame (geometry_msgs/TransformStamped): transform from world_frame to food_frame
+        move_above_pose: Pose constraint when moving above food
+        move_into_pose: Pose constraint when moving into food
         """
         # pylint: disable=unused-argument, duplicate-code
         # Arguments are handled generically in base class.
@@ -118,5 +118,8 @@ class ComputeActionConstraints(BlackboardBehavior):
         )
         action.pre_transform.position = ros2_numpy.msgify(Point, position)
         self.blackboard_set("move_above_pose", action.pre_transform)
+
+        # Calculate Move-Into Target
+        offset = ros2_numpy.numpify(action.pre_offset)
 
         return py_trees.common.Status.SUCCESS

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_action_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_action_constraints.py
@@ -7,22 +7,27 @@ needed to send MoveIt2Plan calls.
 """
 
 # Standard imports
+from copy import deepcopy
 from typing import Union, Optional
 
 # Third-party imports
-from geometry_msgs.msg import Point
+from geometry_msgs.msg import Point, Pose
 import numpy as np
 from overrides import override
 import py_trees
+from rcl_interfaces.srv import SetParameters
 import ros2_numpy
 
 # Local imports
 from ada_feeding_msgs.srv import AcquisitionSelect
-from ada_feeding.helpers import BlackboardKey
+from ada_feeding.helpers import (
+    BlackboardKey,
+    set_static_tf,
+)
 from ada_feeding.behaviors import BlackboardBehavior
 
 
-class ComputeActionConstraints(BlackboardBehavior):
+class ComputeApproachConstraints(BlackboardBehavior):
     """
     Checks AcquisitionSelect response, implements stochastic
     policy choice, and then decomposes into individual
@@ -60,7 +65,8 @@ class ComputeActionConstraints(BlackboardBehavior):
     def blackboard_outputs(
         self,
         move_above_pose: Optional[BlackboardKey],  # Pose, in Food Frame
-        move_into_pose: Optional[BlackboardKey], # Pose, in Food Frame
+        move_into_pose: Optional[BlackboardKey],  # Pose, in Food Frame
+        ft_thresh: Optional[BlackboardKey],  # SetParameters.Request
     ) -> None:
         """
         Blackboard Outputs
@@ -76,6 +82,40 @@ class ComputeActionConstraints(BlackboardBehavior):
         super().blackboard_outputs(
             **{key: value for key, value in locals().items() if key != "self"}
         )
+
+    @override
+    def setup(self, **kwargs):
+        # Docstring copied from @override
+
+        # pylint: disable=attribute-defined-outside-init
+        # It is okay for attributes in behaviors to be
+        # defined in the setup / initialise functions.
+
+        # Get Node from Kwargs
+        self.node = kwargs["node"]
+
+    @staticmethod
+    def create_ft_thresh_request(f_mag: float, t_mag: float) -> SetParameters.Request:
+        parameters = []
+        for key, val in [
+            ("fMag", f_mag),
+            ("fx", 0.0),
+            ("fy", 0.0),
+            ("fz", 0.0),
+            ("tMag", t_mag),
+            ("tx", 0.0),
+            ("ty", 0.0),
+            ("tz", 0.0),
+        ]:
+            parameters.append(
+                Parameter(
+                    name=f"wrench_threshold.{key}",
+                    value=ParameterValue(
+                        type=ParameterType.PARAMETER_DOUBLE, double_value=val
+                    ),
+                )
+            )
+        return SetParameters.Request(parameters=parameters)
 
     @override
     def update(self) -> py_trees.common.Status:
@@ -102,6 +142,15 @@ class ComputeActionConstraints(BlackboardBehavior):
         index = np.random.choice(np.arange(prob.size), p=prob)
         action = response.actions[index]
 
+        ### Calculate Approach Frame
+        # TODO: Calculate Approach Frame
+        identity = TransformStamped()
+        identity.transform = ros2_numpy.msgify(Transform, np.eye(4))
+        identity.header.stamp = self.node.get_clock().now()
+        identity.header.frame_id = "food"
+        identity.child_frame_id = "approach"
+        set_static_tf(identity, self.blackboard, self.node)
+
         ### Construct Constraints
 
         # Re-scale pre-transform to move_above_dist_m
@@ -119,7 +168,19 @@ class ComputeActionConstraints(BlackboardBehavior):
         action.pre_transform.position = ros2_numpy.msgify(Point, position)
         self.blackboard_set("move_above_pose", action.pre_transform)
 
-        # Calculate Move-Into Target
+        # Calculate Approach Target (in food frame)
+        move_into_pose = Pose()
+        move_into_pose.orientation = deepcopy(action.pre_transform.orientation)
         offset = ros2_numpy.numpify(action.pre_offset)
+        move_into_pose.position = ros2_numpy.msgify(Point, offset)
+        self.blackboard_set("move_into_pose", move_into_pose)
+
+        # Calculate Approach F/T Thresholds
+        self.blackboard_set(
+            "approach_ft_thresh",
+            ComputeActionConstraints.create_ft_thresh_request(
+                action.pre_force, aciton.pre_torque
+            ),
+        )
 
         return py_trees.common.Status.SUCCESS

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
@@ -211,7 +211,7 @@ class MoveIt2PositionConstraint(BlackboardBehavior):
             or not self.blackboard_exists("weight")
             or not self.blackboard_exists("constraints")
         ):
-            self.logger.error("MoveIt2Constraint: Missing input arguments.")
+            self.logger.error("MoveIt2PositionConstraint: Missing input arguments.")
             return py_trees.common.Status.FAILURE
 
         position = self.blackboard_get("position")
@@ -335,7 +335,7 @@ class MoveIt2OrientationConstraint(BlackboardBehavior):
             or not self.blackboard_exists("constraints")
             or not self.blackboard_exists("parameterization")
         ):
-            self.logger.error("MoveIt2Constraint: Missing input arguments.")
+            self.logger.error("MoveIt2OrientationConstraint: Missing input arguments.")
             return py_trees.common.Status.FAILURE
 
         quat_xyzw = self.blackboard_get("quat_xyzw")

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -301,8 +301,8 @@ class MoveIt2Plan(BlackboardBehavior):
             # If all goals are satisfied, return SUCCESS, no planning necessary
             # Skip if a start position is defined
             if (
-                self.blackboard_exists("start_joint_state")
-                and self.blackboard_get("start_joint_state") is not None
+                not self.blackboard_exists("start_joint_state")
+                or self.blackboard_get("start_joint_state") is None
             ):
                 if goals_satisfied:
                     self.blackboard_set("trajectory", None)
@@ -469,11 +469,13 @@ class MoveIt2Plan(BlackboardBehavior):
             rclpy.time.Time(),
         )
         current = ros2_numpy.numpify(t_stamped.transform.translation)
+        self.logger.info(f"Current Position: {current}")
         desired = None
         if isinstance(constraint_kwargs["position"], Point):
             desired = ros2_numpy.numpify(constraint_kwargs["position"])
         else:
             desired = np.array(constraint_kwargs["position"])
+        self.logger.info(f"Desired Position: {desired}")
 
         return np.linalg.norm(desired - current) <= tol
 

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -13,7 +13,7 @@ import time
 from typing import Any, Union, Optional, Dict, List, Tuple
 
 # Third-party imports
-from geometry_msgs.msg import Point, Quaternion
+from geometry_msgs.msg import Point, PoseStamped, Quaternion
 import numpy as np
 from overrides import override
 import py_trees
@@ -278,12 +278,18 @@ class MoveIt2Plan(BlackboardBehavior):
                             goals_satisfied
                             and self.position_constraint_satisfied(constraint_kwargs)
                         )
+                        ## If Cartesian, transform to base link frame
+                        if self.blackboard_get("cartesian"):
+                            self.transform_goal_to_base_link(constraint_kwargs)
                         self.moveit2.set_position_goal(**constraint_kwargs)
                     elif constraint_type == MoveIt2ConstraintType.ORIENTATION:
                         goals_satisfied = (
                             goals_satisfied
                             and self.orientation_constraint_satisfied(constraint_kwargs)
                         )
+                        ## If Cartesian, transform to base link frame
+                        if self.blackboard_get("cartesian"):
+                            self.transform_goal_to_base_link(constraint_kwargs)
                         self.moveit2.set_orientation_goal(**constraint_kwargs)
                 except tf2.LookupException:
                     # Wait on Frame Transform
@@ -294,8 +300,10 @@ class MoveIt2Plan(BlackboardBehavior):
                         "Waiting on TF to test constraint satisfaction", once=True
                     )
                     return py_trees.common.Status.RUNNING
-                except (IndexError, AttributeError, ValueError):
-                    self.logger.error(f"Malformed Goal Constraint: {constraint_kwargs}")
+                except (IndexError, AttributeError, ValueError) as error:
+                    self.logger.error(
+                        f"Malformed Goal Constraint: {constraint_kwargs}; Error: {error}"
+                    )
                     return py_trees.common.Status.FAILURE
 
             # If all goals are satisfied, return SUCCESS, no planning necessary
@@ -397,6 +405,45 @@ class MoveIt2Plan(BlackboardBehavior):
             self.moveit2.clear_goal_constraints()
             self.moveit2.clear_path_constraints()
 
+    def transform_goal_to_base_link(self, constraint_kwargs: Dict[str, Any]) -> None:
+        """
+        Transforms the given constraint into the base link frame.
+
+        Necessary because MoveIt2 Cartesian Planner doesn't take in frame_id.
+
+        Parameters
+        ----------
+        constraint_kwargs: MODIFIED with transformed constraint
+        """
+        if constraint_kwargs["frame_id"] is None:
+            return
+
+        cons_pose = PoseStamped()
+        cons_pose.header.frame_id = constraint_kwargs["frame_id"]
+        if "quat_xyzw" in constraint_kwargs:
+            cons_pose.pose.orientation = (
+                constraint_kwargs["quat_xyzw"]
+                if isinstance(constraint_kwargs["quat_xyzw"], Quaternion)
+                else ros2_numpy.msgify(
+                    Quaternion, np.array(constraint_kwargs["quat_xyzw"])
+                )
+            )
+            constraint_kwargs["quat_xyzw"] = self.tf_buffer.transform(
+                cons_pose, self.moveit2.base_link_name
+            ).pose.orientation
+
+        if "position" in constraint_kwargs:
+            cons_pose.pose.position = (
+                constraint_kwargs["position"]
+                if isinstance(constraint_kwargs["position"], Point)
+                else ros2_numpy.msgify(Point, np.array(constraint_kwargs["position"]))
+            )
+            constraint_kwargs["position"] = self.tf_buffer.transform(
+                cons_pose, self.moveit2.base_link_name
+            ).pose.position
+
+        constraint_kwargs["frame_id"] = self.moveit2.base_link_name
+
     def joint_constraint_satisfied(self, constraint_kwargs: Dict[str, Any]) -> bool:
         """
         Check if current joint state satisfies provided joint constraint.
@@ -421,8 +468,8 @@ class MoveIt2Plan(BlackboardBehavior):
         curr_joint_state = self.moveit2.joint_state
         tol = np.fabs(constraint_kwargs["tolerance"])
 
-        curr_positions = curr_joint_state.position.copy()
-        des_positions = constraint_kwargs["joint_positions"].copy()
+        des_positions = list(constraint_kwargs["joint_positions"])
+        curr_positions = list(curr_joint_state.position)
 
         # Remap current joints based on joint names
         joint_names = constraint_kwargs["joint_names"]
@@ -436,6 +483,7 @@ class MoveIt2Plan(BlackboardBehavior):
             raise ValueError("Joint names array should match joint positions array.")
 
         # Compare with desired joints
+        curr_positions = curr_positions[: len(des_positions)]
         diff = np.fabs(np.array(curr_positions) - np.array(des_positions))
 
         return np.all(diff < tol)
@@ -469,13 +517,11 @@ class MoveIt2Plan(BlackboardBehavior):
             rclpy.time.Time(),
         )
         current = ros2_numpy.numpify(t_stamped.transform.translation)
-        self.logger.info(f"Current Position: {current}")
         desired = None
         if isinstance(constraint_kwargs["position"], Point):
             desired = ros2_numpy.numpify(constraint_kwargs["position"])
         else:
             desired = np.array(constraint_kwargs["position"])
-        self.logger.info(f"Desired Position: {desired}")
 
         return np.linalg.norm(desired - current) <= tol
 

--- a/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
+++ b/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
@@ -173,7 +173,6 @@ def pre_moveto_config(
                 value=SetParameters.Response(),  # Unused
                 operator=set_parameter_response_all_success,
             )
-            for i in range(len(ft_threshold_request.parameters))
         ],
     )
     children.append(set_force_torque_thresholds)

--- a/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
+++ b/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
@@ -42,7 +42,7 @@ def set_parameter_response_all_success(
 def pre_moveto_config(
     name: str,
     re_tare: bool = True,
-    toggle_watchdog_listener: bool = True,
+    toggle_watchdog_listener: bool = False,
     f_mag: float = 4.0,
     f_x: float = 0.0,
     f_y: float = 0.0,
@@ -56,9 +56,7 @@ def pre_moveto_config(
     Returns a behavior that calls the ROS services that should be called before
     any MoveTo behavior. Specifically, it does the following, in a Sequence:
         1. Re-tare the force-torque sensor.
-            a. Toggle the Watchdog Listener off. This is necessary because re-taring
-               the force-torque sensor will briefly stop force-torque sensor readings,
-               which would cause the watchdog to fail.
+            a. Toggle the Watchdog Listener off.
             b. Re-tare the force-torque sensor.
             c. Toggle the Watchdog Listener on.
         2. Set force-torque thresholds (so the ForceGateController will trip if
@@ -68,8 +66,8 @@ def pre_moveto_config(
     ----------
     name: The name to associate with this behavior.
     re_tare: Whether to re-tare the force-torque sensor.
-    toggle_watchdog_listener: Whether to toggle the watchdog listener on and off.
-        In practice, if the watchdog listener is on, you should toggle it.
+    toggle_watchdog_listener: Whether to toggle the watchdog listener on and off
+                                during re-taring.
     f_mag: The magnitude of the overall force threshold. No threshold if 0.0.
     f_x: The magnitude of the x component of the force threshold. No threshold if 0.0.
     f_y: The magnitude of the y component of the force threshold. No threshold if 0.0.

--- a/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
+++ b/ada_feeding/ada_feeding/idioms/pre_moveto_config.py
@@ -39,6 +39,54 @@ def set_parameter_response_all_success(
     return all(result.successful for result in blackboard_value.results)
 
 
+def create_ft_thresh_request(
+    f_mag: float = 0.0,
+    f_x: float = 0.0,
+    f_y: float = 0.0,
+    f_z: float = 0.0,
+    t_mag: float = 0.0,
+    t_x: float = 0.0,
+    t_y: float = 0.0,
+    t_z: float = 0.0,
+) -> SetParameters.Request:
+    """
+    Create a SetParameters request from requested force/torque thresholds
+
+    Parameters
+    ----------
+    f_mag: Max magnitude of the force on utensil
+    t_mag: Max magnitude of torque on utensil
+
+    Returns
+    -------
+    SetParameters ROS2 service request object
+    designed to operate with `forque_sensor_hardware`
+    """
+
+    # pylint: disable=too-many-arguments
+
+    parameters = []
+    for key, val in [
+        ("fMag", f_mag),
+        ("fx", f_x),
+        ("fy", f_y),
+        ("fz", f_z),
+        ("tMag", t_mag),
+        ("tx", t_x),
+        ("ty", t_y),
+        ("tz", t_z),
+    ]:
+        parameters.append(
+            Parameter(
+                name=f"wrench_threshold.{key}",
+                value=ParameterValue(
+                    type=ParameterType.PARAMETER_DOUBLE, double_value=val
+                ),
+            )
+        )
+    return SetParameters.Request(parameters=parameters)
+
+
 def pre_moveto_config(
     name: str,
     re_tare: bool = True,
@@ -134,26 +182,9 @@ def pre_moveto_config(
             children.append(turn_watchdog_listener_on)
 
     # Set FT Thresholds
-    parameters = []
-    for key, val in [
-        ("fMag", f_mag),
-        ("fx", f_x),
-        ("fy", f_y),
-        ("fz", f_z),
-        ("tMag", t_mag),
-        ("tx", t_x),
-        ("ty", t_y),
-        ("tz", t_z),
-    ]:
-        parameters.append(
-            Parameter(
-                name=f"wrench_threshold.{key}",
-                value=ParameterValue(
-                    type=ParameterType.PARAMETER_DOUBLE, double_value=val
-                ),
-            )
-        )
-    ft_threshold_request = SetParameters.Request(parameters=parameters)
+    ft_threshold_request = create_ft_thresh_request(
+        f_mag, f_x, f_y, f_z, t_mag, t_x, t_y, t_z
+    )
     set_force_torque_thresholds_name = Blackboard.separator.join(
         [name, set_force_torque_thresholds_prefix]
     )

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -21,7 +21,9 @@ from ada_feeding.behaviors.moveit2 import (
     MoveIt2Plan,
     MoveIt2Execute,
 )
+from ada_feeding.decorators import OnPreempt
 from ada_feeding.helpers import BlackboardKey
+from ada_feeding.idioms import pre_moveto_config, scoped_behavior
 from ada_feeding.visitors import MoveToVisitor
 from ada_feeding_msgs.action import AcquireFood
 from ada_feeding_msgs.srv import AcquisitionSelect
@@ -105,7 +107,9 @@ class AcquireFoodTree(ActionServerBT):
                         "move_above_pose": BlackboardKey("move_above_pose"),
                     },
                 ),
-                # Move Above Food
+                # Re-Tare FT Sensor and default to 4N threshold
+                pre_moveto_config(),
+                ### Move Above Food
                 MoveIt2PoseConstraint(
                     name="MoveAbovePose",
                     ns=name,
@@ -132,6 +136,18 @@ class AcquireFoodTree(ActionServerBT):
                     ns=name,
                     inputs={"trajectory": BlackboardKey("trajectory")},
                     outputs={},
+                ),
+                # If Anything goes wrong, reset FT to safe levels
+                scoped_behavior(
+                    name="SafeFTPreempt",
+                    pre_behavior=py_trees.behaviours.success(),
+                    post_behavior=pre_moveto_config(re_tare=False),
+                    on_preempt_timeout=5.0,
+                    # Starts a new Sequence w/ Memory internally
+                    workers=[
+                        
+
+                    ],
                 ),
             ],
         )

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -54,6 +54,23 @@ class AcquireFoodTree(ActionServerBT):
 
     """
 
+    def __init__(
+        self,
+        node: Node,
+        resting_joint_positions: Optional[List[float]] = None,
+    ):
+        """
+        Initializes tree-specific parameters.
+
+        Parameters
+        ----------
+        resting_joint_positions: Final joint position after acquisition
+        """
+        # Initialize ActionServerBT
+        super().__init__(node)
+
+        self.resting_joint_positions = resting_joint_positions
+
     @override
     def create_tree(
         self,

--- a/ada_feeding/config/ada_feeding_action_servers.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers.yaml
@@ -43,6 +43,16 @@ ada_feeding_action_servers:
     AcquireFood: # required
       action_type: ada_feeding_msgs.action.AcquireFood # required
       tree_class: ada_feeding.trees.AcquireFoodTree # required
+      tree_kws:
+        - resting_joint_positions
+      tree_kwargs:
+        resting_joint_positions: # required
+          - -1.94672 # j2n6s200_joint_1
+          -  2.51268 # j2n6s200_joint_2
+          -  0.35653 # j2n6s200_joint_3
+          - -4.76501 # j2n6s200_joint_4
+          -  5.99991 # j2n6s200_joint_5
+          -  4.99555 # j2n6s200_joint_6
       tick_rate: 10 # Hz, optional, default: 30
 
    # Parameters for the MoveToRestingPosition action

--- a/ada_feeding_action_select/config/acquisition_library.yaml
+++ b/ada_feeding_action_select/config/acquisition_library.yaml
@@ -12,7 +12,7 @@ actions:
       grasp_duration: 0.0
       grasp_force: 15.0
       grasp_torque: 4.0
-      ext_linear: [0.0, 0.0, 1.0]
+      ext_linear: [0.0, 0.0, 0.05]
       ext_angular: [0.0, 0.0, 0.0]
       ext_duration: 1.0
       ext_force: 50.0
@@ -28,7 +28,7 @@ actions:
       grasp_duration: 0.0
       grasp_force: 15.0
       grasp_torque: 4.0
-      ext_linear: [0.0, 0.0, 1.0]
+      ext_linear: [0.0, 0.0, 0.05]
       ext_angular: [0.0, 0.0, 0.0]
       ext_duration: 1.0
       ext_force: 50.0
@@ -44,7 +44,7 @@ actions:
       grasp_duration: 0.0
       grasp_force: 15.0
       grasp_torque: 4.0
-      ext_linear: [0.0, 0.0, 1.0]
+      ext_linear: [0.0, 0.0, 0.05]
       ext_angular: [0.0, 0.0, 0.0]
       ext_duration: 1.0
       ext_force: 50.0


### PR DESCRIPTION
# Description

Pre-MVP (Action 0, straight up-and-down only) AcquireFood tree completed.

Also fixes a semantic bug where the Cartesian MoveIt2 Planner ignores the frame_id of constraints. So MoveIt2Plan now transforms position/orientation constraints into the base link frame if doing a cartesian plan.

# Testing procedure

Copied and modified from #102 :

1. Run the Mock FT Sensor: `ros2 run ada_feeding dummy_ft_sensor.py`
2. Run the action servers: `ros2 launch ada_feeding ada_feeding_launch.xml use_estop:=false`
3. Run MoveIt in sim: `ros2 launch ada_moveit demo.launch.py sim:=mock`
4. Run this code with the default dummy carrot (oriented horizontally in the camera frame): `ros2 launch feeding_web_app_ros2_test feeding_dummy_acquirefood_launch.py`
5. Verify the Goal Succeeds (status=0). Open RViz and add an Axis Frame "food"  (rescale to 0.1 for visibility), verify that +Z is against gravity and +X is horizontal relative to the camera.
6. Run this code with the dummy carrot 2 (oriented ~vertically in the camera frame): `ros2 launch feeding_web_app_ros2_test feeding_dummy_acquirefood_launch.py request:=above_plate_2_carrot_request.pkl`
7. Verify the Goal Succeeds (status=0). Open RViz and add an Axis Frame "food" (rescale to 0.1 for visibility), verify that +Z is against gravity and +X is vertical relative to the camera and to the "lower right" in the camera frame.
8. For both of the above, verify that the robot: moves above the food frame with fork tines perpendicular to the red +X axis, moves down so the center of the fork tines are located at the origin of the food frame, moves up 5cm above the food frame, and then returns to the resting position.

Testing can also follow the entire feeding demo from the app.

Currently, this has been tested only in simulation.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
