### PR TITLE
Addressed rare case where perception blocks

### DIFF
--- a/ada_feeding_perception/ada_feeding_perception/helpers.py
+++ b/ada_feeding_perception/ada_feeding_perception/helpers.py
@@ -82,7 +82,9 @@ def cv2_image_to_ros_msg(
     return bridge.cv2_to_imgmsg(image, encoding="passthrough")
 
 
-def get_img_msg_type(topic: str, node: Node) -> type:
+def get_img_msg_type(
+    topic: str, node: Node, timeout_sec: Optional[float] = 1.0
+) -> type:
     """
     Get the type of the image message on the given topic.
 
@@ -90,13 +92,15 @@ def get_img_msg_type(topic: str, node: Node) -> type:
     ----------
     topic: the topic to get the image message type for
     node: the node to use to get the topic type
+    timeout_sec: the timeout to use when getting the topic type. If None, this
+        will wait forever.
 
     Returns
     -------
     the type of the image message on the given topic, either Image or CompressedImage
     """
     # Spin the node once to get the publishers list
-    rclpy.spin_once(node)
+    rclpy.spin_once(node, timeout_sec=timeout_sec)
 
     # Resolve the topic name (e.g., handle remappings)
     final_topic = node.resolve_topic_name(topic)

--- a/ada_feeding_perception/ada_feeding_perception/helpers.py
+++ b/ada_feeding_perception/ada_feeding_perception/helpers.py
@@ -93,7 +93,7 @@ def get_img_msg_type(
     topic: the topic to get the image message type for
     node: the node to use to get the topic type
     timeout_sec: the timeout to use when getting the topic type. If None, this
-        will wait forever.
+        will wait forever. If 0.0, this is non-blocking.
 
     Returns
     -------


### PR DESCRIPTION
# Description

This PR addresses two bugs:

- Although spinning once may be necessary in `get_img_msg_type(...)` to get the latest types that are being registered on topics, is may also block if there are no units of work available (e.g., if all topics have already been advertised, and no new messages are being published). This PR adds a timeout to avoid that.
- Some of the initializations in SegmentFromPoint happened in an unintuitive order (e.g., a callback that needs a variable would be initialized before that variable is). This PR addresses that.

# Testing procedure

Launch the perception nodes, motion nodes, and web app. Ensure SegmentFromPoint works.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
