### PR TITLE
Made SegmentFromPoint return the RGB image

### DIFF
--- a/ada_feeding_msgs/msg/Mask.msg
+++ b/ada_feeding_msgs/msg/Mask.msg
@@ -6,6 +6,8 @@ sensor_msgs/RegionOfInterest roi
 # The binary mask, of the same size of the bounding box, that specifies which
 # pixels in the bounding box are part of the segmented item
 sensor_msgs/CompressedImage mask
+# The RGB image that was used for segmentation, cropped to the roi.
+sensor_msgs/CompressedImage rgb_image
 
 # The average of the depth camera readings over the mask (in m)
 float64 average_depth


### PR DESCRIPTION
# Description

In service of #138, this PR expands the `Mask` message type to return an RGB image as well, so that bite acquisition no longer has to get the latest RGB image for the featurizer.

Note, I use a `CompressedImage` type because it is easier to render than on the web app side. This change will enable the web app to render one static image per mask, as opposed to three video streams.

# Testing procedure

Invoked SegmentFromPoint from the web app, received the `rgb_image` as part of the response, rendered the image in the browser (e.g., by prepending `data:image/jpeg;base64,` to the data string) and verifying that the rendered image is correct.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
