### PR TITLE
Scale the `wheelchair_collision` object based on detected face

### DIFF
--- a/ada_feeding/CMakeLists.txt
+++ b/ada_feeding/CMakeLists.txt
@@ -36,6 +36,7 @@ install(PROGRAMS
   scripts/ada_watchdog.py
   scripts/ada_planning_scene.py
   scripts/dummy_ft_sensor.py
+  scripts/joint_state_latency.py
   scripts/save_image.py
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -217,6 +217,9 @@ class ComputeFoodFrame(BlackboardBehavior):
 
         # De-project center of ROI
         mask = self.blackboard_get("mask")
+        if mask.average_depth == 0.0:
+            self.logger.error("Invalid mask: average depth is zero.")
+            return py_trees.common.Status.FAILURE
         center_list = pyrealsense2.rs2_deproject_pixel_to_point(
             self.intrinsics,
             self.get_mask_center(mask),

--- a/ada_feeding/ada_feeding/behaviors/moveit2/modify_collision_object.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/modify_collision_object.py
@@ -66,6 +66,7 @@ class ModifyCollisionObject(BlackboardBehavior):
             0.0,
             0.0,
         ),
+        mesh_scale: Union[BlackboardKey, float, Tuple[float, float, float]] = 1.0,
     ) -> None:
         """
         Blackboard Inputs
@@ -90,6 +91,7 @@ class ModifyCollisionObject(BlackboardBehavior):
             ADD or MOVE and the collision object position/orientation do not have a frame_id.
         position_offset: The offset to apply to the collision object position. Only used if
             the operation is ADD or MOVE.
+        mesh_scale: The scale to apply to the mesh. Only used if the operation is ADD.
         """
         # pylint: disable=unused-argument, duplicate-code, too-many-arguments
         # Arguments are handled generically in base class.
@@ -188,6 +190,7 @@ class ModifyCollisionObject(BlackboardBehavior):
                     "prim_type",
                     "dims",
                     "position_offset",
+                    "mesh_scale",
                 ]
             ):
                 self.logger.error(
@@ -205,6 +208,7 @@ class ModifyCollisionObject(BlackboardBehavior):
             prim_type = self.blackboard_get("prim_type")
             dims = self.blackboard_get("dims")
             position_offset = self.blackboard_get("position_offset")
+            mesh_scale = self.blackboard_get("mesh_scale")
 
             # Update types
             if isinstance(collision_object_position, PointStamped):
@@ -233,6 +237,7 @@ class ModifyCollisionObject(BlackboardBehavior):
                         collision_object_position,
                         collision_object_orientation,
                         frame_id=frame_id,
+                        scale=mesh_scale,
                     )
                 else:
                     self.moveit2.add_collision_primitive(

--- a/ada_feeding/ada_feeding/behaviors/moveit2/servo_move.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/servo_move.py
@@ -174,9 +174,8 @@ class ServoMove(BlackboardBehavior):
         msg: The servo status message.
         """
         with self.latest_servo_status_lock:
-            self.latest_servo_status = (
-                msg.data
-            )  # pylint: disable=attribute-defined-outside-init
+            # pylint: disable=attribute-defined-outside-init
+            self.latest_servo_status = msg.data
 
     @override
     def update(self) -> py_trees.common.Status:

--- a/ada_feeding/ada_feeding/behaviors/moveit2/servo_move.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/servo_move.py
@@ -218,7 +218,10 @@ class ServoMove(BlackboardBehavior):
         if duration.nanoseconds >= 0 and self.node.get_clock().now() > (
             self.start_time + duration
         ):
-            return self.blackboard_get("status_on_timeout")
+            status = self.blackboard_get("status_on_timeout")
+            if status == py_trees.common.Status.FAILURE:
+                self.logger.error("ServoMove timed out.")
+            return status
 
         # Servo is still executing
         return py_trees.common.Status.RUNNING

--- a/ada_feeding/ada_feeding/behaviors/transfer/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/transfer/__init__.py
@@ -1,0 +1,4 @@
+"""
+This package contains custom py_tree behaviors for bite transfer.
+"""
+from .planning_scene import ComputeWheelchairCollisionTransform

--- a/ada_feeding/ada_feeding/behaviors/transfer/planning_scene.py
+++ b/ada_feeding/ada_feeding/behaviors/transfer/planning_scene.py
@@ -35,7 +35,7 @@ class ComputeWheelchairCollisionTransform(BlackboardBehavior):
     NOTE: Although this class is in theory rich enough to compute arbitrary
     updates to the wheelchair collision object, e.g., moving its x and y to be
     centered on the face, currently we don't translate it at all and only scale
-    z in (0.0, inf). This is because incorporating translations may bring the 
+    z in (0.0, inf). This is because incorporating translations may bring the
     wheelchair collision object into collision with the robot base, which is not desirable.
     """
 

--- a/ada_feeding/ada_feeding/behaviors/transfer/planning_scene.py
+++ b/ada_feeding/ada_feeding/behaviors/transfer/planning_scene.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines behaviors that manipulate the planning scene during bite
+transfer.
+"""
+
+# Standard imports
+from typing import Optional, Union
+
+# Third-party imports
+from geometry_msgs.msg import (
+    Point,
+    PointStamped,
+    Pose,
+    PoseStamped,
+    Quaternion,
+    QuaternionStamped,
+)
+from overrides import override
+import py_trees
+from std_msgs.msg import Header
+
+# Local imports
+from ada_feeding.behaviors import BlackboardBehavior
+from ada_feeding.helpers import BlackboardKey
+
+
+class ComputeWheelchairCollisionTransform(BlackboardBehavior):
+    """
+    A behavior that takes in the detected head pose, the original head pose,
+    and the original wheelchair_collision pose, and computes the new
+    wheelchair_collision pose and scale.
+
+    NOTE: Although this class is in theory rich enough to compute arbitrary
+    updates to the wheelchair collision object, e.g., moving its x and y to be
+    centered on the face, currently we don't translate it at all and only scale
+    z in (0.0, 1.0]. This is because incorporating translations or scaling z > 1
+    may bring the wheelchair collision object into collision with the robot base,
+    which is not desirable.
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    def blackboard_inputs(
+        self,
+        detected_head_pose: Union[BlackboardKey, PoseStamped],
+        # NOTE: The below parameters must match the ones in `ada_planning_scene.yaml`
+        original_head_pose: Union[BlackboardKey, PoseStamped] = PoseStamped(
+            header=Header(frame_id="j2n6s200_link_base"),
+            pose=Pose(
+                position=Point(x=0.29, y=0.35, z=0.85),
+                orientation=Quaternion(
+                    x=-0.0616284, y=-0.0616284, z=-0.704416, w=0.704416
+                ),
+            ),
+        ),
+        original_wheelchair_collision_pose: Union[
+            BlackboardKey, PoseStamped
+        ] = PoseStamped(
+            header=Header(frame_id="j2n6s200_link_base"),
+            pose=Pose(
+                position=Point(x=0.02, y=-0.02, z=-0.05),
+                orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+            ),
+        ),
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Parameters
+        ----------
+        detected_head_pose: The detected head pose in the planning scene.
+        original_head_pose: The initial head pose in the planning scene.
+        original_wheelchair_collision_pose: The initial wheelchair_collision
+            pose in the planning scene.
+        """
+        # pylint: disable=unused-argument, duplicate-code, too-many-arguments
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        wheelchair_position: Optional[BlackboardKey] = None,  # PointStamped
+        wheelchair_orientation: Optional[BlackboardKey] = None,  # QuaternionStamped
+        wheelchair_scale: Optional[BlackboardKey] = None,  # Tuple[float, float, float]
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        wheelchair_position: The new position of the wheelchair collision object.
+        wheelchair_orientation: The new orientation of the wheelchair collision object.
+        wheelchair_scale: The new scale of the wheelchair collision object.
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        self.logger.debug(
+            f"{self.name} [ComputeWheelchairCollisionTransform::update()]"
+        )
+
+        # Validate inputs
+        if not self.blackboard_exists(
+            [
+                "detected_head_pose",
+                "original_head_pose",
+                "original_wheelchair_collision_pose",
+            ]
+        ):
+            self.logger.error("Missing input arguments")
+            return py_trees.common.Status.FAILURE
+
+        # Get the inputs
+        detected_head_pose = self.blackboard_get("detected_head_pose")
+        original_head_pose = self.blackboard_get("original_head_pose")
+        original_wheelchair_collision_pose = self.blackboard_get(
+            "original_wheelchair_collision_pose"
+        )
+
+        # Verify that they all have the same frame_id
+        if not (
+            detected_head_pose.header.frame_id
+            == original_head_pose.header.frame_id
+            == original_wheelchair_collision_pose.header.frame_id
+        ):
+            self.logger.error("All input poses must have the same frame_id")
+            return py_trees.common.Status.FAILURE
+
+        # Compute the new wheelchair collision pose
+        wheelchair_position = PointStamped(
+            header=detected_head_pose.header,
+            point=original_wheelchair_collision_pose.pose.position,
+        )
+        wheelchair_orientation = QuaternionStamped(
+            header=detected_head_pose.header,
+            quaternion=original_wheelchair_collision_pose.pose.orientation,
+        )
+        wheelchair_scale = (
+            1.0,
+            1.0,
+            min(
+                1.0,
+                (
+                    detected_head_pose.pose.position.z
+                    - original_wheelchair_collision_pose.pose.position.z
+                )
+                / (
+                    original_head_pose.pose.position.z
+                    - original_wheelchair_collision_pose.pose.position.z
+                ),
+            ),
+        )
+
+        # Set the outputs
+        self.blackboard_set("wheelchair_position", wheelchair_position)
+        self.blackboard_set("wheelchair_orientation", wheelchair_orientation)
+        self.blackboard_set("wheelchair_scale", wheelchair_scale)
+
+        # Return success
+        return py_trees.common.Status.SUCCESS

--- a/ada_feeding/ada_feeding/behaviors/transfer/planning_scene.py
+++ b/ada_feeding/ada_feeding/behaviors/transfer/planning_scene.py
@@ -35,9 +35,8 @@ class ComputeWheelchairCollisionTransform(BlackboardBehavior):
     NOTE: Although this class is in theory rich enough to compute arbitrary
     updates to the wheelchair collision object, e.g., moving its x and y to be
     centered on the face, currently we don't translate it at all and only scale
-    z in (0.0, 1.0]. This is because incorporating translations or scaling z > 1
-    may bring the wheelchair collision object into collision with the robot base,
-    which is not desirable.
+    z in (0.0, inf). This is because incorporating translations may bring the 
+    wheelchair collision object into collision with the robot base, which is not desirable.
     """
 
     # pylint: disable=arguments-differ
@@ -153,16 +152,13 @@ class ComputeWheelchairCollisionTransform(BlackboardBehavior):
         wheelchair_scale = (
             1.0,
             1.0,
-            min(
-                1.0,
-                (
-                    detected_head_pose.pose.position.z
-                    - original_wheelchair_collision_pose.pose.position.z
-                )
-                / (
-                    original_head_pose.pose.position.z
-                    - original_wheelchair_collision_pose.pose.position.z
-                ),
+            (
+                detected_head_pose.pose.position.z
+                - original_wheelchair_collision_pose.pose.position.z
+            )
+            / (
+                original_head_pose.pose.position.z
+                - original_wheelchair_collision_pose.pose.position.z
             ),
         )
 

--- a/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
@@ -29,7 +29,6 @@ from ada_feeding.helpers import BlackboardKey
 from ada_feeding.idioms import pre_moveto_config, scoped_behavior, servo_until_pose
 from ada_feeding.idioms.bite_transfer import (
     get_add_in_front_of_wheelchair_wall_behavior,
-    get_toggle_collision_object_behavior,
     get_remove_in_front_of_wheelchair_wall_behavior,
 )
 from ada_feeding.trees import MoveToTree
@@ -226,11 +225,6 @@ class MoveFromMouthTree(MoveToTree):
                         name=name,
                         memory=True,
                         children=[
-                            get_toggle_collision_object_behavior(
-                                name + "AllowWheelchairCollisionScopePre",
-                                [self.wheelchair_collision_object_id],
-                                True,
-                            ),
                             StartServoTree(self._node)
                             .create_tree(name=name + "StartServoScopePre")
                             .root,
@@ -243,11 +237,6 @@ class MoveFromMouthTree(MoveToTree):
                             StopServoTree(self._node)
                             .create_tree(name=name + "StopServoScopePost")
                             .root,
-                            get_toggle_collision_object_behavior(
-                                name + "DisallowWheelchairCollisionScopePost",
-                                [self.wheelchair_collision_object_id],
-                                False,
-                            ),
                             pre_moveto_config(
                                 name=name + "PreMoveToConfigScopePost",
                                 re_tare=False,

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -198,6 +198,9 @@ class MoveToMouthTree(MoveToTree):
     ) -> py_trees.trees.BehaviourTree:
         # Docstring copied from @override
 
+        # TODO: Consider moving move head and scale wheelchair_collision logic into
+        # ada_planning_scene.py, to consolidate all planning scene updates.
+
         ### Define Tree Logic
 
         face_detection_absolute_key = Blackboard.separator.join(

--- a/ada_feeding/ada_feeding/visitors/moveto_visitor.py
+++ b/ada_feeding/ada_feeding/visitors/moveto_visitor.py
@@ -152,7 +152,7 @@ class MoveToVisitor(VisitorBase):
     def run(self, behaviour: py_trees.behaviour.Behaviour) -> None:
         # Docstring copied by @override
 
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches, too-many-statements
 
         # We only care about leaf nodes
         if isinstance(behaviour, (Composite, Decorator)):

--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -19,7 +19,7 @@ from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 import rclpy
 from rclpy.duration import Duration
 from rclpy.node import Node
-import sounddevice # pylint: disable=unused-import
+import sounddevice  # pylint: disable=unused-import
 
 # Local imports
 from ada_feeding.watchdog import WatchdogCondition

--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -19,6 +19,7 @@ from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 import rclpy
 from rclpy.duration import Duration
 from rclpy.node import Node
+import sounddevice # pylint: disable=unused-import
 
 # Local imports
 from ada_feeding.watchdog import WatchdogCondition

--- a/ada_feeding/config/ada_planning_scene.yaml
+++ b/ada_feeding/config/ada_planning_scene.yaml
@@ -26,6 +26,8 @@ ada_planning_scene:
       quat_xyzw: [0.0, 0.0, 0.0, 1.0]
       frame_id: root # the frame_id that the pose is relative to
     # an expanded mesh around the wheelchair to account for a user sitting in it
+    # NOTE: If you change this you must also change the hardcoded initial pose in
+    # btie transfer.
     wheelchair_collision: 
       filename: wheelchair_collision.stl
       position: [0.02, -0.02, -0.05] # should match the wheelchair position
@@ -36,6 +38,8 @@ ada_planning_scene:
       position: [0.08, -0.5, -0.48]
       quat_xyzw: [0.0, 0.0, 0.0, 1.0]
       frame_id: root # the frame_id that the pose is relative to
+    # NOTE: If you change this you must also change the hardcoded initial pose in
+    # btie transfer.
     head: # the head mesh
       filename: tom.stl
       # This is an initial guess of head position; it will be updated as the


### PR DESCRIPTION
# Description

Paired with [`ada_ros2`#34](https://github.com/personalrobotics/ada_ros2/pull/34).

## Issue

Currently, we make the `wheelchair_collision` object---meant to represent the user's body in the wheelchair---extremely large to encompass diverse body types. As a result of that, for people who are shorter, their actual head position overlaps with the `wheelchair_collision` object. This has a few consequences:

1. The Octomap doesn't register obstacles (e.g., assistive technology) around the user's face, because it thinks those obstacles are part of the `wheelchair_collision` object.
2. We have to allow collisions with the `wheelchair_collision` object during transfer.

## Fix

This PR scales the `wheelchair_collision` object based on the user's detected head pose, so it always ends around their neck. In other words, we are encoding the assumption that people whose head is lower in the wheelchair have shorter bodies than people whose heads are higher in the wheelchair. This solution means that, the area around users' perceived head will be empty, meaning:
1. Obstacles in that area will be perceived in the Octomap.
2. We no longer need to (dis)allow collisions with `wheelchair_collision` during bite transfer.

# Testing procedure

Pull the [branch `amaln/scale_collision_meshes` from our fork of `pymoveit2`](https://github.com/personalrobotics/pymoveit2/tree/amaln/scale_collision_meshes) and the branch from [`ada_ros2`#34](https://github.com/personalrobotics/ada_ros2/pull/34). Start the code as documented in the README.

- [x] Sim: 
    - [x] Run bite transfer (move to mouth and then back above the plate) 3 times. For each time, verify that the `wheelchair_collision` object shrinks/expands based on the detected head pose, and that it is never in collision with the base link of the robot.
- [x] Real: Try the below bite transfers, verify that it works as expected.
    - [x] Head in a "normal" position for you
    - [x] Head lower than "normal" for you
    - [x] Head higher than "normal" for you
    - [x] Head to the left of "normal" for you
    - [x] Head to the right of "normal" for you
    - [x] For multiple of the above, put an obstacle to the side of your face and verify it gets added to the Octomap.
        - [x] In particular, try this out when your head pose is initially within the `wheelchair_collision` in the planning scene (e.g., the previous planning attempt had your head higher and now it is lower). This will test whether the Octomap updates fast enough to add dynamic obstacles around your face for the first transfer, if your face is lower than the large `wheelchair_collision` object.
    - [x] For multiple of the above, put an obstacle in front of your face, verify it gets added to the Octomap, and servo stops before colliding with it.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
