### PR TITLE
Remove `web_video_server`

### DIFF
--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -7,8 +7,6 @@
   <group if="$(var run_web_bridge)">
     <!-- The ROSBridge Node -->
     <include file="$(find-pkg-share rosbridge_server)/launch/rosbridge_websocket_launch.xml"/>
-    <!-- The ROS web_video_server -->
-    <node pkg="web_video_server" exec="web_video_server" name="web_video_server"/>
   </group>
 
   <!-- Launch the watchdog -->


### PR DESCRIPTION
# Description

As of [`feeding_web_interface`#106](https://github.com/personalrobotics/feeding_web_interface/pull/106), we no longer use `web_video_server`. This PR removes it from the `ada_feeding` launchfile.

# Testing procedure

This was tested in sim.

- [x] Launch the code and web app as documented in the README.
- [x] Verify that the web app runs as expected and the video shows up.

# Before opening a pull request
- [N/A] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [N/A] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
