### PR TITLE
Acquisition Recover on Failure

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -50,6 +50,7 @@ class ComputeFoodFrame(BlackboardBehavior):
         self,
         camera_info: Union[BlackboardKey, CameraInfo],
         mask: Union[BlackboardKey, Mask],
+        timestamp: Union[BlackboardKey, rclpy.time.Time] = rclpy.time.Time(),
         food_frame_id: Union[BlackboardKey, str] = "food",
         world_frame: Union[BlackboardKey, str] = "world",
     ) -> None:
@@ -60,6 +61,8 @@ class ComputeFoodFrame(BlackboardBehavior):
         ----------
         camera_info (geometry_msgs/CameraInfo): camera intrinsics matrix
         mask (ada_feeding_msgs/Mask): food context, see Mask.msg
+        timestamp (rclpy.time.Time): Timestamp for TF transformations
+                                    (default 0 for latest)
         food_frame_id (string): If len>0, TF frame to publish static transform
                                    (relative to world_frame)
         world_frame (string): ID of the TF frame to represent the food frame in
@@ -186,6 +189,7 @@ class ComputeFoodFrame(BlackboardBehavior):
 
         camera_frame = self.blackboard_get("camera_info").header.frame_id
         world_frame = self.blackboard_get("world_frame")
+        timestamp = self.blackboard_get("timestamp")
 
         # Lock TF Buffer
         if self.tf_lock.locked():
@@ -198,7 +202,7 @@ class ComputeFoodFrame(BlackboardBehavior):
             if not self.tf_buffer.can_transform(
                 world_frame,
                 camera_frame,
-                rclpy.time.Time(),
+                timestamp,
             ):
                 # Not yet, wait for it
                 # Use a Timeout decorator to determine failure.
@@ -206,7 +210,7 @@ class ComputeFoodFrame(BlackboardBehavior):
             transform = self.tf_buffer.lookup_transform(
                 world_frame,
                 camera_frame,
-                rclpy.time.Time(),
+                timestamp,
             )
 
         # Set up return objects

--- a/ada_feeding/ada_feeding/behaviors/moveit2/servo_move.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/servo_move.py
@@ -66,7 +66,7 @@ class ServoMove(BlackboardBehavior):
         duration: Union[BlackboardKey, Duration, float] = Duration(seconds=1.0),
         pub_topic: Union[BlackboardKey, str] = "~/servo_twist_cmds",
         pub_qos: Union[BlackboardKey, QoSProfile] = QoSProfile(depth=1),
-        default_frame_id: Union[BlackboardKey, str] = "world",
+        default_frame_id: Union[BlackboardKey, str] = "root",
         status_on_timeout: Union[
             BlackboardKey, py_trees.common.Status
         ] = py_trees.common.Status.SUCCESS,

--- a/ada_feeding/ada_feeding/idioms/__init__.py
+++ b/ada_feeding/ada_feeding/idioms/__init__.py
@@ -3,6 +3,7 @@ This package contains custom idioms that are used in the Ada Feeding
 project.
 """
 from .eventually_swiss import eventually_swiss
+from .ft_thresh_utils import ft_thresh_satisfied
 from .pre_moveto_config import pre_moveto_config
 from .retry_call_ros_service import retry_call_ros_service
 from .scoped_behavior import scoped_behavior

--- a/ada_feeding/ada_feeding/idioms/ft_thresh_utils.py
+++ b/ada_feeding/ada_feeding/idioms/ft_thresh_utils.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module defines the ft_thresh_satisifed idiom.
+Which subscribes to the FT sensor and detects whether
+a given FT threshold is satisfied at the point of execution.
+"""
+
+# Standard imports
+
+# Third-part_y imports
+import py_trees
+from py_trees.blackboard import Blackboard
+import py_trees_ros
+from geometry_msgs.msg import WrenchStamped
+
+# Local imports
+
+
+def ft_thresh_satisfied(
+    name: str,
+    f_mag: float = 4.0,
+    f_x: float = 0.0,
+    f_y: float = 0.0,
+    f_z: float = 0.0,
+    t_mag: float = 0.0,
+    t_x: float = 0.0,
+    t_y: float = 0.0,
+    t_z: float = 0.0,
+    ft_topic: str = "~/ft_topic",
+) -> py_trees.behaviour.Behaviour:
+    """
+    Returns a behavior that subscribes to the FT sensor and checks whether threshold
+    is immediately satisifed. FAILURE if not, SUCCESS if so. RUNNING while waiting
+    for force/torque message.
+
+    Parameters
+    ----------
+    name: The name to associate with this behavior.
+    ft_topic: FT topic to subscribe to
+    f_mag: The magnitude of the overall force threshold. No threshold if 0.0.
+    f_x: The magnitude of the x component of the force threshold. No threshold if 0.0.
+    f_y: The magnitude of the y component of the force threshold. No threshold if 0.0.
+    f_z: The magnitude of the z component of the force threshold. No threshold if 0.0.
+    t_mag: The magnitude of the overall torque threshold. No threshold if 0.0.
+    t_x: The magnitude of the x component of the torque threshold. No threshold if 0.0.
+    t_y: The magnitude of the y component of the torque threshold. No threshold if 0.0.
+    t_z: The magnitude of the z component of the torque threshold. No threshold if 0.0.
+    """
+    # pylint: disable=too-many-arguments
+
+    def is_satisfied(wrench: WrenchStamped, _: WrenchStamped):
+        """
+        Inner function to test threshold. The many Ifs / Returns
+        make it easiest to read.
+        """
+        # pylint: disable=too-many-arguments, too-many-return-statements, too-many-branches
+
+        if f_x > 0.0:
+            if wrench.force.x > f_x:
+                return False
+        if f_y > 0.0:
+            if wrench.force.y > f_y:
+                return False
+        if f_z > 0.0:
+            if wrench.force.z > f_z:
+                return False
+        if f_mag > 0.0:
+            if (
+                wrench.force.x * wrench.force.x
+                + wrench.force.y * wrench.force.y
+                + wrench.force.z * wrench.force.z
+                > f_mag * f_mag
+            ):
+                return False
+        if t_x > 0.0:
+            if wrench.torque.x > t_x:
+                return False
+        if t_y > 0.0:
+            if wrench.torque.y > t_y:
+                return False
+        if t_z > 0.0:
+            if wrench.torque.z > t_z:
+                return False
+        if t_mag > 0.0:
+            if (
+                wrench.torque.x * wrench.torque.x
+                + wrench.torque.y * wrench.torque.y
+                + wrench.torque.z * wrench.torque.z
+                > t_mag * t_mag
+            ):
+                return False
+        return True
+
+    ft_absolute_key = Blackboard.separator.join([name, "ft_wrench"])
+
+    return py_trees.composites.Sequence(
+        name=name,
+        memory=True,
+        children=[
+            py_trees_ros.subscribers.ToBlackboard(
+                name=name + " FTSubscriber",
+                topic_name=ft_topic,
+                topic_type=WrenchStamped,
+                qos_profile=(py_trees_ros.utilities.qos_profile_unlatched()),
+                blackboard_variables={
+                    ft_absolute_key: None,
+                },
+                initialise_variables={
+                    ft_absolute_key: WrenchStamped(),
+                },
+            ),
+            py_trees.behaviours.CheckBlackboardVariableValue(
+                name=name + " CheckFTThresholdSatisfied",
+                check=py_trees.common.ComparisonExpression(
+                    variable=ft_absolute_key,
+                    value=WrenchStamped(),
+                    operator=is_satisfied,
+                ),
+            ),
+        ],
+    )

--- a/ada_feeding/ada_feeding/idioms/ft_thresh_utils.py
+++ b/ada_feeding/ada_feeding/idioms/ft_thresh_utils.py
@@ -49,13 +49,14 @@ def ft_thresh_satisfied(
     """
     # pylint: disable=too-many-arguments
 
-    def is_satisfied(wrench: WrenchStamped, _: WrenchStamped):
+    def is_satisfied(stamped: WrenchStamped, _: WrenchStamped):
         """
         Inner function to test threshold. The many Ifs / Returns
         make it easiest to read.
         """
         # pylint: disable=too-many-arguments, too-many-return-statements, too-many-branches
 
+        wrench = stamped.wrench
         if f_x > 0.0:
             if wrench.force.x > f_x:
                 return False

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -16,6 +16,7 @@ from py_trees.blackboard import Blackboard
 import py_trees_ros
 from rcl_interfaces.srv import SetParameters
 from rclpy.node import Node
+from rclpy.time import Time
 from std_msgs.msg import Header
 from std_srvs.srv import Empty
 
@@ -59,6 +60,7 @@ class AcquireFoodTree(MoveToTree):
     Tree Blackboard Inputs:
     - camera_info: See ComputeFoodFrame
     - mask: See ComputeFoodFrame
+    - timestamp: See ComputeFoodFrame
 
     Tree Blackboard Outputs:
 
@@ -239,7 +241,8 @@ class AcquireFoodTree(MoveToTree):
                                 ns=name,
                                 inputs={
                                     "camera_info": BlackboardKey("camera_info"),
-                                    "mask": BlackboardKey("mask")
+                                    "mask": BlackboardKey("mask"),
+                                    "timestamp": BlackboardKey("timestamp"),
                                     # Default food_frame_id = "food"
                                     # Default world_frame = "world"
                                 },
@@ -630,6 +633,8 @@ class AcquireFoodTree(MoveToTree):
         blackboard.mask = goal.detected_food
         blackboard.register_key(key="camera_info", access=py_trees.common.Access.WRITE)
         blackboard.camera_info = goal.camera_info
+        blackboard.register_key(key="timestamp", access=py_trees.common.Access.WRITE)
+        blackboard.timestamp = Time.from_msg(goal.header.stamp)
 
         # Adds MoveToVisitor for Feedback
         return super().send_goal(tree, goal)

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -9,7 +9,7 @@ wrap that behavior tree in a ROS2 action server.
 from typing import List, Optional
 
 # Third-party imports
-from geometry_msgs.msg import Twist, TwistStamped
+from geometry_msgs.msg import Twist, TwistStamped, Vector3
 from overrides import override
 import py_trees
 from py_trees.blackboard import Blackboard
@@ -45,6 +45,7 @@ from ada_feeding.idioms.bite_transfer import (
     get_add_in_front_of_wheelchair_wall_behavior,
     get_remove_in_front_of_wheelchair_wall_behavior,
 )
+from ada_feeding.idioms.ft_thresh_utils import ft_thresh_satisfied
 from ada_feeding.idioms.pre_moveto_config import set_parameter_response_all_success
 from ada_feeding.trees import MoveToTree, StartServoTree, StopServoTree
 
@@ -147,6 +148,48 @@ class AcquireFoodTree(MoveToTree):
                     ],
                 ),
             )
+
+        ### Define Recovery Tree (if failure in Grasp/Extract)
+        recovery_tree = py_trees.composites.Sequence(
+            name="RecoverySequence",
+            memory=True,
+            children=[
+                pre_moveto_config(
+                    name="MaxFTRecoveryRetare",
+                    re_tare=False,
+                    f_mag=50.0,
+                    param_service_name="~/set_servo_controller_parameters",
+                ),
+                py_trees.composites.Selector(
+                    name="RecoverySelector",
+                    memory=True,
+                    children=[
+                        py_trees.decorators.Retry(
+                            name="RecoveryServoRetry",
+                            num_failures=3,
+                            child=py_trees.composites.Sequence(
+                                name="RecoveryServoSequence",
+                                memory=True,
+                                children=[
+                                    ServoMove(
+                                        name="RecoveryServo",
+                                        ns=name,
+                                        inputs={
+                                            "twist": Twist(
+                                                linear=Vector3(x=0.0, y=0.0, z=0.03),
+                                                angular=Vector3(),
+                                            ),  # Default 1s duration
+                                        },
+                                    ),  # Auto Zero-Twist on terminate()
+                                    ft_thresh_satisfied(name="FTThreshSatisfied"),
+                                ],
+                            ),
+                        ),  # End Attempt 1: RecoveryServoRetry
+                        # TODO: Add other Recovery Attempts Here
+                    ],  # End RecoverySelector.children
+                ),  # End RecoverySelector
+            ],  # End RecoverySequence.children
+        )  # End RecoverySequence
 
         ### Define Tree Logic
         # NOTE: If octomap clearing ends up being an issue, we should
@@ -403,104 +446,160 @@ class AcquireFoodTree(MoveToTree):
                                     on_preempt_timeout=5.0,
                                     # Starts a new Sequence w/ Memory internally
                                     workers=[
-                                        ### Grasp
-                                        retry_call_ros_service(
-                                            name="GraspFTThresh",
-                                            service_type=SetParameters,
-                                            service_name="~/set_servo_controller_parameters",
-                                            # Blackboard, not Constant
-                                            request=None,
-                                            # Need absolute Blackboard name
-                                            key_request=Blackboard.separator.join(
-                                                [name, BlackboardKey("grasp_thresh")]
-                                            ),
-                                            key_response=Blackboard.separator.join(
-                                                [name, BlackboardKey("ft_response")]
-                                            ),
-                                            response_checks=[
-                                                py_trees.common.ComparisonExpression(
-                                                    variable=Blackboard.separator.join(
-                                                        [
-                                                            name,
-                                                            BlackboardKey(
-                                                                "ft_response"
+                                        py_trees.composites.Selector(
+                                            name="InFoodErrorSelector",
+                                            memory=True,
+                                            children=[
+                                                py_trees.composites.Sequence(
+                                                    name="InFoodGraspExtract",
+                                                    memory=True,
+                                                    children=[
+                                                        ### Grasp
+                                                        retry_call_ros_service(
+                                                            name="GraspFTThresh",
+                                                            service_type=SetParameters,
+                                                            service_name="~/set_servo_controller_parameters",
+                                                            # Blackboard, not Constant
+                                                            request=None,
+                                                            # Need absolute Blackboard name
+                                                            key_request=Blackboard.separator.join(
+                                                                [
+                                                                    name,
+                                                                    BlackboardKey(
+                                                                        "grasp_thresh"
+                                                                    ),
+                                                                ]
                                                             ),
-                                                        ]
-                                                    ),
-                                                    value=SetParameters.Response(),  # Unused
-                                                    operator=set_parameter_response_all_success,
-                                                )
-                                            ],
-                                        ),
-                                        ComputeActionTwist(
-                                            name="ComputeGrasp",
-                                            ns=name,
-                                            inputs={
-                                                "action": BlackboardKey("action"),
-                                                "is_grasp": True,
-                                            },
-                                            outputs={
-                                                "twist": BlackboardKey("twist"),
-                                                "duration": BlackboardKey("duration"),
-                                            },
-                                        ),
-                                        ServoMove(
-                                            name="GraspServo",
-                                            ns=name,
-                                            inputs={
-                                                "twist": BlackboardKey("twist"),
-                                                "duration": BlackboardKey("duration"),
-                                            },
-                                        ),  # Auto Zero-Twist on terminate()
-                                        ### Extraction
-                                        ComputeActionTwist(
-                                            name="ComputeExtract",
-                                            ns=name,
-                                            inputs={
-                                                "action": BlackboardKey("action"),
-                                                "is_grasp": False,
-                                            },
-                                            outputs={
-                                                "twist": BlackboardKey("twist"),
-                                                "duration": BlackboardKey("duration"),
-                                            },
-                                        ),
-                                        retry_call_ros_service(
-                                            name="ExtractionFTThresh",
-                                            service_type=SetParameters,
-                                            service_name="~/set_servo_controller_parameters",
-                                            # Blackboard, not Constant
-                                            request=None,
-                                            # Need absolute Blackboard name
-                                            key_request=Blackboard.separator.join(
-                                                [name, BlackboardKey("ext_thresh")]
-                                            ),
-                                            key_response=Blackboard.separator.join(
-                                                [name, BlackboardKey("ft_response")]
-                                            ),
-                                            response_checks=[
-                                                py_trees.common.ComparisonExpression(
-                                                    variable=Blackboard.separator.join(
-                                                        [
-                                                            name,
-                                                            BlackboardKey(
-                                                                "ft_response"
+                                                            key_response=Blackboard.separator.join(
+                                                                [
+                                                                    name,
+                                                                    BlackboardKey(
+                                                                        "ft_response"
+                                                                    ),
+                                                                ]
                                                             ),
-                                                        ]
-                                                    ),
-                                                    value=SetParameters.Response(),  # Unused
-                                                    operator=set_parameter_response_all_success,
-                                                )
-                                            ],
-                                        ),
-                                        ServoMove(
-                                            name="ExtractServo",
-                                            ns=name,
-                                            inputs={
-                                                "twist": BlackboardKey("twist"),
-                                                "duration": BlackboardKey("duration"),
-                                            },
-                                        ),  # Auto Zero-Twist on terminate()
+                                                            response_checks=[
+                                                                py_trees.common.ComparisonExpression(
+                                                                    variable=Blackboard.separator.join(
+                                                                        [
+                                                                            name,
+                                                                            BlackboardKey(
+                                                                                "ft_response"
+                                                                            ),
+                                                                        ]
+                                                                    ),
+                                                                    value=SetParameters.Response(),  # Unused
+                                                                    operator=set_parameter_response_all_success,
+                                                                )
+                                                            ],
+                                                        ),
+                                                        ComputeActionTwist(
+                                                            name="ComputeGrasp",
+                                                            ns=name,
+                                                            inputs={
+                                                                "action": BlackboardKey(
+                                                                    "action"
+                                                                ),
+                                                                "is_grasp": True,
+                                                            },
+                                                            outputs={
+                                                                "twist": BlackboardKey(
+                                                                    "twist"
+                                                                ),
+                                                                "duration": BlackboardKey(
+                                                                    "duration"
+                                                                ),
+                                                            },
+                                                        ),
+                                                        ServoMove(
+                                                            name="GraspServo",
+                                                            ns=name,
+                                                            inputs={
+                                                                "twist": BlackboardKey(
+                                                                    "twist"
+                                                                ),
+                                                                "duration": BlackboardKey(
+                                                                    "duration"
+                                                                ),
+                                                            },
+                                                        ),  # Auto Zero-Twist on terminate()
+                                                        ### Extraction
+                                                        ComputeActionTwist(
+                                                            name="ComputeExtract",
+                                                            ns=name,
+                                                            inputs={
+                                                                "action": BlackboardKey(
+                                                                    "action"
+                                                                ),
+                                                                "is_grasp": False,
+                                                            },
+                                                            outputs={
+                                                                "twist": BlackboardKey(
+                                                                    "twist"
+                                                                ),
+                                                                "duration": BlackboardKey(
+                                                                    "duration"
+                                                                ),
+                                                            },
+                                                        ),
+                                                        retry_call_ros_service(
+                                                            name="ExtractionFTThresh",
+                                                            service_type=SetParameters,
+                                                            service_name="~/set_servo_controller_parameters",
+                                                            # Blackboard, not Constant
+                                                            request=None,
+                                                            # Need absolute Blackboard name
+                                                            key_request=Blackboard.separator.join(
+                                                                [
+                                                                    name,
+                                                                    BlackboardKey(
+                                                                        "ext_thresh"
+                                                                    ),
+                                                                ]
+                                                            ),
+                                                            key_response=Blackboard.separator.join(
+                                                                [
+                                                                    name,
+                                                                    BlackboardKey(
+                                                                        "ft_response"
+                                                                    ),
+                                                                ]
+                                                            ),
+                                                            response_checks=[
+                                                                py_trees.common.ComparisonExpression(
+                                                                    variable=Blackboard.separator.join(
+                                                                        [
+                                                                            name,
+                                                                            BlackboardKey(
+                                                                                "ft_response"
+                                                                            ),
+                                                                        ]
+                                                                    ),
+                                                                    value=SetParameters.Response(),  # Unused
+                                                                    operator=set_parameter_response_all_success,
+                                                                )
+                                                            ],
+                                                        ),
+                                                        ServoMove(
+                                                            name="ExtractServo",
+                                                            ns=name,
+                                                            inputs={
+                                                                "twist": BlackboardKey(
+                                                                    "twist"
+                                                                ),
+                                                                "duration": BlackboardKey(
+                                                                    "duration"
+                                                                ),
+                                                            },
+                                                        ),  # Auto Zero-Twist on terminate()
+                                                        ft_thresh_satisfied(
+                                                            name="CheckFTForkOffPlate"
+                                                        ),
+                                                    ],  # End InFoodGraspExtract.children
+                                                ),  # End InFoodGraspExtract
+                                                recovery_tree,
+                                            ],  # End InFoodErrorSelector.children
+                                        ),  # End InFoodErrorSelector
                                     ],  # End MoveIt2Servo.workers
                                 ),  # End MoveIt2Servo
                             ],  # End SafeFTPreempt.workers

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -23,6 +23,7 @@
     <remap from="~/watchdog" to="/ada_watchdog/watchdog" />
     <remap from="~/toggle_watchdog_listener" to="/ada_watchdog_listener/toggle_watchdog_listener" />
     <remap from="~/re_tare_ft" to="/wireless_ft/set_bias" />
+    <remap from="~/ft_topic" to="/wireless_ft/ftSensor1" />
     <remap from="~/set_force_gate_controller_parameters" to="/jaco_arm_controller/set_parameters" />
     <remap from="~/set_servo_controller_parameters" to="/jaco_arm_servo_controller/set_parameters" />
     <remap from="~/toggle_face_detection" to="/toggle_face_detection" />

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="run_web_bridge" default="true" description="Whether to run the web bridge nodes" />
+  <arg name="run_web_bridge" default="false" description="Whether to run the web bridge nodes" />
   <arg name="use_estop" default="true" description="Whether to use the e-stop. Should only be set false in sim, since we don't have a way of simulating the e-stop button." />
   <arg name="log_level" default="info" description="Log Level to pass to create_action_servers: debug, info, warn" />
   <arg name="default_action_select" default="true" description="Whether to use the default action select: constant policy 0" />


### PR DESCRIPTION
# Description

This PR does 2 things:

(1) If Grasp/Extract fails OR it finishes and the Resting Pose / Above Plate movement would fail due to a F/T trip, we execute a Recovery Procedure.

The Recovery Procedure first sets the F/T threshold to max (50N) an then does a Selector to loop through recovery attempts.

Currently, this procedure only makes 1 recovery attempt: Servo up 3cm and re-check the F/T trip (attempt 3 times)

Tested in sim with manual insertions of Failure right before Extraction (and verification of 3x retry by setting the FT test to 0.01N instead of the default 4N)


(2) Calculate the TF of the food frame using the timestamp from the header.

Solves #126 

Tested in sim by refreshing the webapp during food acquisition. Whenever the new goal wasn't rejected (which happened if the previous goal didn't finish terminating), the food frame did not move despite the robot camera frame having moved.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
