### PR TITLE
Fix perception race conditions, web app streaming, and F/T QoS

### DIFF
--- a/ada_feeding/ada_feeding/idioms/ft_thresh_utils.py
+++ b/ada_feeding/ada_feeding/idioms/ft_thresh_utils.py
@@ -9,10 +9,11 @@ a given FT threshold is satisfied at the point of execution.
 # Standard imports
 
 # Third-part_y imports
+from geometry_msgs.msg import WrenchStamped
 import py_trees
 from py_trees.blackboard import Blackboard
 import py_trees_ros
-from geometry_msgs.msg import WrenchStamped
+import rclpy
 
 # Local imports
 
@@ -103,7 +104,7 @@ def ft_thresh_satisfied(
                 name=name + " FTSubscriber",
                 topic_name=ft_topic,
                 topic_type=WrenchStamped,
-                qos_profile=(py_trees_ros.utilities.qos_profile_unlatched()),
+                qos_profile=rclpy.qos.QoSPresetProfiles.SENSOR_DATA.value,
                 blackboard_variables={
                     ft_absolute_key: None,
                 },

--- a/ada_feeding_perception/ada_feeding_perception/face_detection.py
+++ b/ada_feeding_perception/ada_feeding_perception/face_detection.py
@@ -145,8 +145,15 @@ class FaceDetectionNode(Node):
         self.latest_img_msg = None
         self.latest_img_msg_lock = threading.Lock()
         image_topic = "~/image"
+        try:
+            image_type = get_img_msg_type(image_topic, self)
+        except ValueError as err:
+            self.get_logger().error(
+                f"Error getting type of image topic. Defaulting to CompressedImage. {err}"
+            )
+            image_type = CompressedImage
         self.img_subscription = self.create_subscription(
-            get_img_msg_type(image_topic, self),
+            image_type,
             image_topic,
             self.camera_callback,
             1,
@@ -157,9 +164,16 @@ class FaceDetectionNode(Node):
         self.depth_buffer = collections.deque(maxlen=depth_buffer_size)
         self.depth_buffer_lock = threading.Lock()
         aligned_depth_topic = "~/aligned_depth"
+        try:
+            aligned_depth_type = get_img_msg_type(aligned_depth_topic, self)
+        except ValueError as err:
+            self.get_logger().error(
+                f"Error getting type of depth image topic. Defaulting to Image. {err}"
+            )
+            aligned_depth_type = Image
         # Subscribe to the depth image
         self.depth_subscription = self.create_subscription(
-            get_img_msg_type(aligned_depth_topic, self),
+            aligned_depth_type,
             aligned_depth_topic,
             self.depth_callback,
             1,

--- a/ada_feeding_perception/ada_feeding_perception/face_detection.py
+++ b/ada_feeding_perception/ada_feeding_perception/face_detection.py
@@ -130,7 +130,9 @@ class FaceDetectionNode(Node):
         # Currently, RVIZ2 doesn't support visualization of CompressedImage
         # (other than as part of a Camera). Hence, for vizualization purposes
         # this must be an Image. https://github.com/ros2/rviz/issues/738
-        self.publisher_image = self.create_publisher(Image, "~/face_detection_img", 1)
+        self.publisher_image = self.create_publisher(
+            CompressedImage, "~/face_detection_img/compressed", 1
+        )
 
         # Create an instance of the Face Detection Cascade Classifier
         self.detector = cv2.CascadeClassifier(self.face_model_path)
@@ -667,7 +669,7 @@ class FaceDetectionNode(Node):
 
             # Publish the face detection image
             self.publisher_image.publish(
-                cv2_image_to_ros_msg(image_bgr, compress=False, encoding="bgr8")
+                cv2_image_to_ros_msg(image_bgr, compress=True, encoding="bgr8")
             )
 
             # Publish 3d point

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -100,8 +100,15 @@ class SegmentFromPointNode(Node):
         self.latest_depth_img_msg = None
         self.latest_depth_img_msg_lock = threading.Lock()
         aligned_depth_topic = "~/aligned_depth"
+        try:
+            aligned_depth_type = get_img_msg_type(aligned_depth_topic, self)
+        except ValueError as err:
+            self.get_logger().error(
+                f"Error getting type of depth image topic. Defaulting to Image. {err}"
+            )
+            aligned_depth_type = Image
         self.depth_image_subscriber = self.create_subscription(
-            get_img_msg_type(aligned_depth_topic, self),
+            aligned_depth_type,
             aligned_depth_topic,
             self.depth_image_callback,
             1,
@@ -112,8 +119,15 @@ class SegmentFromPointNode(Node):
         self.latest_img_msg = None
         self.latest_img_msg_lock = threading.Lock()
         image_topic = "~/image"
+        try:
+            image_type = get_img_msg_type(image_topic, self)
+        except ValueError as err:
+            self.get_logger().error(
+                f"Error getting type of image topic. Defaulting to CompressedImage. {err}"
+            )
+            image_type = CompressedImage
         self.image_subscriber = self.create_subscription(
-            get_img_msg_type(image_topic, self),
+            image_type,
             image_topic,
             self.image_callback,
             1,

--- a/ada_feeding_perception/config/republisher.yaml
+++ b/ada_feeding_perception/config/republisher.yaml
@@ -4,26 +4,43 @@ republisher:
     # The name of the topics to republish from
     from_topics:
       - /camera/color/image_raw/compressed
+      - /local/camera/color/image_raw/compressed
       - /camera/color/camera_info
       - /camera/aligned_depth_to_color/image_raw
       - /camera/aligned_depth_to_color/camera_info
       - /local/camera/aligned_depth_to_color/image_raw
+      - /face_detection_img/compressed
 
     # The types of topics to republish from
     topic_types:
+      - sensor_msgs.msg.CompressedImage
       - sensor_msgs.msg.CompressedImage
       - sensor_msgs.msg.CameraInfo
       - sensor_msgs.msg.Image
       - sensor_msgs.msg.CameraInfo
       - sensor_msgs.msg.Image
+      - sensor_msgs.msg.CompressedImage
 
     # The name of the topics to republish to
     to_topics:
       - /local/camera/color/image_raw/compressed
+      - /local/camera/color/image_raw/compressed/low_hz
       - /local/camera/color/camera_info
       - /local/camera/aligned_depth_to_color/image_raw
       - /local/camera/aligned_depth_to_color/camera_info
       - /local/camera/aligned_depth_to_color/depth_octomap
+      - /face_detection_img/compressed/low_hz
+
+    # The target rates (Hz) for the republished topics. Rates <= 0 will publish
+    # every message.
+    target_rates:
+      - 0
+      - 3
+      - 0
+      - 0
+      - 0
+      - 0
+      - 3
 
     # The names of a post-processing functions to apply to the message before
     # republishing it. Current options are:
@@ -42,7 +59,9 @@ republisher:
       - ""
       - ""
       - ""
+      - ""
       - threshold,mask,temporal,spatial # Apply filters to the depth image for the Octomap
+      - ""
     # The binary mask used for "mask" post-processing. This mask will get scaled,
     # possibly disproportionately, to the same of the image.
     mask_relative_path: model/fork_handle_mask.png

--- a/ada_feeding_perception/launch/ada_feeding_perception.launch.py
+++ b/ada_feeding_perception/launch/ada_feeding_perception.launch.py
@@ -123,7 +123,7 @@ def generate_launch_description():
     # points have been set to 0.
     face_detection_remappings = [
         ("~/face_detection", "/face_detection"),
-        ("~/face_detection_img", "/face_detection_img"),
+        ("~/face_detection_img/compressed", "/face_detection_img/compressed"),
         ("~/toggle_face_detection", "/toggle_face_detection"),
         (
             "~/aligned_depth",


### PR DESCRIPTION
# Description

This PR addresses miscellaneous bugs in the system:

1. The F/T thresh idiom subscribed to the F/T readings with a QoS including `RELIABILITY`, which is incompatible with the F/T sensor's publication of `BEST_EFFORT`. This PR addresses that.
2. Both SegmentFromPoint and FaceDetection had a race condition where sometimes they attempt to get the type of message being sent on an image topic before republisher has advertised that topic, throwing a `ValueError`. Since we have mostly converged to the message types we will be using, this PR adds a fallback to a hardcoded message type if publishers for those topics are not yet alive.
3. Since [`feeding_web_interface`#106](https://github.com/personalrobotics/feeding_web_interface/pull/106), the web app expects the face detection image to be a `CompressedImage`, which this PR addresses.
4. As documented in [`feeding_web_interface`#111](https://github.com/personalrobotics/feeding_web_interface/pull/111), to avoid latency the web app needs a rate-limited publication of video streams. This PR extends `republisher` to rate-limit streams, and rate-limits the streams rendered on the web app to 3Hz (can be tuned).

# Testing procedure

- [x] Pull this code and the affiliated [`feeding_web_interface`#111](https://github.com/personalrobotics/feeding_web_interface/pull/111) and re-build the workspace.
- [x] Run the read robot code and the web app.
- [x] Verify that the robot code is receiving F/T messages (i.e., the watchdog is not tripping)
- [x] Go to bite selection in the web app, move your hand in and out of the camera, verify that the latency is not more than 1-2 secs.
- [x] Go to the `DetectingFace` page in the web app, move your head around in front of the camera, verify that the latency is not more than 1-2 secs.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
