### PR TITLE
Add a workspace wall on the right

### DIFF
--- a/ada_feeding/config/ada_planning_scene.yaml
+++ b/ada_feeding/config/ada_planning_scene.yaml
@@ -8,6 +8,7 @@ ada_planning_scene:
       - head
       - workspace_wall_front
       - workspace_wall_left
+      - workspace_wall_right
       - workspace_wall_top
       # - food
     # For each object, specify:
@@ -57,6 +58,12 @@ ada_planning_scene:
       primitive_type: 1 # Box=1. See shape_msgs/SolidPrimitive.msg
       primitive_dims: [0.01, 1.5, 1.65] # Box has 3 dims: [x, y, z]
       position: [0.75, 0.17, 0.275]
+      quat_xyzw: [0.0, 0.0, 0.0, 1.0]
+      frame_id: root # the frame_id that the pose is relative to
+    workspace_wall_right:
+      primitive_type: 1 # Box=1. See shape_msgs/SolidPrimitive.msg
+      primitive_dims: [0.01, 1.5, 1.65] # Box has 3 dims: [x, y, z]
+      position: [-0.3, 0.17, 0.275]
       quat_xyzw: [0.0, 0.0, 0.0, 1.0]
       frame_id: root # the frame_id that the pose is relative to
     workspace_wall_top:


### PR DESCRIPTION
# Description

Although rare, we have seen one time when the robot made a needlessly large motion when "moving above" for BiteAcquisition, even when a smaller motion existed. That motion wouldn't have been possible with tighter workspace bounds. Hence, this PR adds a tight workspace wall on the right of the robot. See the below RVIZ image (the robot is in the resting configuration).

<img width="437" alt="Screenshot 2024-01-10 at 2 46 18 PM" src="https://github.com/personalrobotics/ada_feeding/assets/8277986/85f2ee63-e181-47b2-892c-e372e6e83972">

# Testing procedure

- [x] In RVIZ, visually verify that the wall is to the right of the robot and it is close but not too close to the robot's base.
- [x] Run through 5 whole bite, including acquisition, and verify that it works as expected. For one of the bites, mvoe your head to the right.
    - [x] Bite one
    - [x] Bite two
    - [x] Bite with your head moved to the right
    - [x] Bite four
    - [x] Bite five

# Future Work

As documented in #143 , we should eventually add action-specific tighter workspace walls, such as a wall above the robot for BiteAcquisition so it doesn't rise higher than it already is.

# Before opening a pull request
- [N/A] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [N/A] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
