### PR TITLE
Move From Mouth Fallback

### DIFF
--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -35,10 +35,8 @@ This code has been developed and tested with the Kinova JACO Gen2 Arm, on comput
         3. `ros2 action send_goal /MoveToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`
         4. `ros2 action send_goal /MoveToStagingConfiguration ada_feeding_msgs/action/MoveTo "{}" --feedback`
         5. `ros2 action send_goal /MoveToMouth ada_feeding_msgs/action/MoveToMouth "{}" --feedback`
-        6. `ros2 action send_goal /MoveFromMouthToRestingPosition ada_feeding_msgs/action/MoveTo "{}" --feedback`
-        7. `ros2 action send_goal /MoveFromMouthToAbovePlate ada_feeding_msgs/action/MoveTo "{}" --feedback`
-        8. `ros2 action send_goal /MoveToStowLocation ada_feeding_msgs/action/MoveTo "{}" --feedback`
-        9. `ros2 action send_goal /MoveFromMouthToStagingConfiguration ada_feeding_msgs/action/MoveTo "{}" --feedback`
+        6. `ros2 action send_goal /MoveFromMouth ada_feeding_msgs/action/MoveTo "{}" --feedback`
+        7. `ros2 action send_goal /MoveToStowLocation ada_feeding_msgs/action/MoveTo "{}" --feedback`
     2. Test the individual actions with the web app:
         1. Launch the web app ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp))
         2. Go through the web app, ensure the expected actions happen on the robot.

--- a/ada_feeding/ada_feeding/idioms/bite_transfer.py
+++ b/ada_feeding/ada_feeding/idioms/bite_transfer.py
@@ -155,7 +155,7 @@ def get_add_in_front_of_wheelchair_wall_behavior(
             "collision_object_orientation": (0.0, 0.0, 0.0, 1.0),
             "prim_type": 1,  # Box=1. See shape_msgs/SolidPrimitive.msg
             "dims": [
-                0.75,
+                0.65,
                 0.01,
                 0.4,
             ],  # Box has 3 dims: [x, y, z]

--- a/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
@@ -21,6 +21,7 @@ from rclpy.node import Node
 from ada_feeding.behaviors.moveit2 import (
     MoveIt2Plan,
     MoveIt2Execute,
+    MoveIt2PositionConstraint,
     MoveIt2JointConstraint,
     MoveIt2OrientationConstraint,
 )
@@ -54,6 +55,12 @@ class MoveFromMouthTree(MoveToTree):
         end_configuration: Optional[List[float]] = None,
         staging_configuration_tolerance_position: float = 0.02,
         end_configuration_tolerance: float = 0.001,
+        orientation_constraint_to_staging_configuration_quaternion: Optional[
+            List[float]
+        ] = None,
+        orientation_constraint_to_staging_configuration_tolerances: Optional[
+            List[float]
+        ] = None,
         orientation_constraint_to_end_configuration_quaternion: Optional[
             List[float]
         ] = None,
@@ -61,10 +68,14 @@ class MoveFromMouthTree(MoveToTree):
             List[float]
         ] = None,
         planner_id: str = "RRTstarkConfigDefault",
+        allowed_planning_time_to_staging_configuration: float = 0.5,
         allowed_planning_time_to_end_configuration: float = 0.5,
         max_linear_speed_to_staging_configuration: float = 0.1,
         max_angular_speed_to_staging_configuration: float = 0.3,
+        max_velocity_scaling_factor_to_staging_configuration: float = 0.1,
         max_velocity_scaling_factor_to_end_configuration: float = 0.1,
+        cartesian_jump_threshold_to_staging_configuration: float = 0.0,
+        cartesian_max_step_to_staging_configuration: float = 0.0025,
         wheelchair_collision_object_id: str = "wheelchair_collision",
         force_threshold_to_staging_configuration: float = 1.0,
         torque_threshold_to_staging_configuration: float = 1.0,
@@ -80,6 +91,12 @@ class MoveFromMouthTree(MoveToTree):
             configuration.
         staging_configuration_quat_xyzw: The quaternion of the staging
             configuration.
+        orientation_constraint_to_staging_configuration_quaternion: The
+            quaternion for the orientation constraint to the staging
+            configuration.
+        orientation_constraint_to_staging_configuration_tolerances: The
+            tolerances for the orientation constraint to the staging
+            configuration.
         end_configuration: The joint positions to move the robot arm to after
             going to the staging configuration.
         staging_configuration_tolerance_position: The tolerance for the joint positions.
@@ -89,15 +106,26 @@ class MoveFromMouthTree(MoveToTree):
         orientation_constraint_to_end_configuration_tolerances: The
             tolerances for the orientation constraint to the end configuration.
         planner_id: The planner ID to use for the MoveIt2 motion planning.
+        allowed_planning_time_to_staging_configuration: The allowed planning
+            time for the MoveIt2 motion planner to move to the staging config.
         allowed_planning_time_to_end_configuration: The allowed planning
             time for the MoveIt2 motion planner to move to the end config.
         max_linear_speed_to_staging_configuration: The maximum linear speed
             (m/s) for the motion to the staging config.
         max_angular_speed_to_staging_configuration: The maximum angular speed
             (rad/s) for the motion to the staging config.
+        max_velocity_scaling_factor_to_staging_configuration: The maximum
+            velocity scaling factor for the MoveIt2 motion planner to move to
+            the staging config.
         max_velocity_scaling_factor_to_end_configuration: The maximum
             velocity scaling factor for the MoveIt2 motion planner to move to
             the end config.
+        cartesian_jump_threshold_to_staging_configuration: The cartesian
+            jump threshold for the MoveIt2 motion planner to move to the
+            staging config.
+        cartesian_max_step_to_staging_configuration: The cartesian
+            max step for the MoveIt2 motion planner to move to the
+            staging config.
         wheelchair_collision_object_id: The ID of the wheelchair collision object
             in the MoveIt2 planning scene.
         force_threshold_to_staging_configuration: The force threshold for the
@@ -122,6 +150,12 @@ class MoveFromMouthTree(MoveToTree):
             staging_configuration_tolerance_position
         )
         self.end_configuration_tolerance = end_configuration_tolerance
+        self.orientation_constraint_to_staging_configuration_quaternion = (
+            orientation_constraint_to_staging_configuration_quaternion
+        )
+        self.orientation_constraint_to_staging_configuration_tolerances = (
+            orientation_constraint_to_staging_configuration_tolerances
+        )
         self.orientation_constraint_to_end_configuration_quaternion = (
             orientation_constraint_to_end_configuration_quaternion
         )
@@ -129,6 +163,9 @@ class MoveFromMouthTree(MoveToTree):
             orientation_constraint_to_end_configuration_tolerances
         )
         self.planner_id = planner_id
+        self.allowed_planning_time_to_staging_configuration = (
+            allowed_planning_time_to_staging_configuration
+        )
         self.allowed_planning_time_to_end_configuration = (
             allowed_planning_time_to_end_configuration
         )
@@ -138,8 +175,17 @@ class MoveFromMouthTree(MoveToTree):
         self.max_angular_speed_to_staging_configuration = (
             max_angular_speed_to_staging_configuration
         )
+        self.max_velocity_scaling_factor_to_staging_configuration = (
+            max_velocity_scaling_factor_to_staging_configuration
+        )
         self.max_velocity_scaling_factor_to_end_configuration = (
             max_velocity_scaling_factor_to_end_configuration
+        )
+        self.cartesian_jump_threshold_to_staging_configuration = (
+            cartesian_jump_threshold_to_staging_configuration
+        )
+        self.cartesian_max_step_to_staging_configuration = (
+            cartesian_max_step_to_staging_configuration
         )
         self.wheelchair_collision_object_id = wheelchair_collision_object_id
         self.force_threshold_to_staging_configuration = (
@@ -165,6 +211,30 @@ class MoveFromMouthTree(MoveToTree):
         in_front_of_wheelchair_wall_id = "in_front_of_wheelchair_wall"
         base_link = "j2n6s200_link_base"
 
+        # The tree may or may not have orientation path constraints active
+        def get_staging_path_constraints() -> py_trees.behaviour.Behaviour:
+            if self.orientation_constraint_to_staging_configuration_quaternion is None:
+                # pylint: disable=abstract-class-instantiated
+                # This is fine, not sure why pylint doesn't like it
+                return py_trees.behaviours.Success()
+            else:
+                # Orientation path constraint to keep the fork straight
+                return MoveIt2OrientationConstraint(
+                    name="KeepForkStraightPathConstraint",
+                    ns=name,
+                    inputs={
+                        "quat_xyzw": (
+                            self.orientation_constraint_to_staging_configuration_quaternion
+                        ),
+                        "tolerance": (
+                            self.orientation_constraint_to_staging_configuration_tolerances
+                        ),
+                        "parameterization": 1,  # Rotation vector
+                    },
+                    outputs={
+                        "constraints": BlackboardKey("path_constraints"),
+                    },
+                )
         if self.orientation_constraint_to_end_configuration_quaternion is None:
             # pylint: disable=abstract-class-instantiated
             # This is fine, not sure why pylint doesn't like it
@@ -187,6 +257,76 @@ class MoveFromMouthTree(MoveToTree):
                     "constraints": BlackboardKey("path_constraints"),
                 },
             )
+
+        # Generate the fallback MoveIt2 behaviors to get to the staging configuration
+        def moveit2_move_to_staging_pose(
+            cartesian: bool,
+        ) -> py_trees.behaviour.Behaviour:
+            return py_trees.composites.Sequence(
+                name=name + "MoveToStagingConfigurationViaMoveIt2Cartesian",
+                memory=True,
+                children=[
+                    # Goal configuration: target position
+                    MoveIt2PositionConstraint(
+                        name="MoveToStagingPoseCartesianPositionGoalConstraint",
+                        ns=name,
+                        inputs={
+                            "position": self.staging_configuration_position,
+                            "tolerance": self.staging_configuration_tolerance_position,
+                        },
+                        outputs={
+                            "constraints": BlackboardKey("goal_constraints"),
+                        },
+                    ),
+                    # Goal configuration: target orientation
+                    MoveIt2OrientationConstraint(
+                        name="MoveToStagingPoseCartesianOrientationGoalConstraint",
+                        ns=name,
+                        inputs={
+                            "quat_xyzw": self.staging_configuration_quat_xyzw,
+                            "tolerance": (0.6, 0.5, 0.5),
+                            "parameterization": 1,  # Rotation vector
+                            "constraints": BlackboardKey("goal_constraints"),
+                        },
+                        outputs={
+                            "constraints": BlackboardKey("goal_constraints"),
+                        },
+                    ),
+                    get_staging_path_constraints(),
+                    # Plan
+                    MoveIt2Plan(
+                        name="MoveToStagingPoseCartesianPlan",
+                        ns=name,
+                        inputs={
+                            "goal_constraints": BlackboardKey("goal_constraints"),
+                            "path_constraints": BlackboardKey("path_constraints"),
+                            "planner_id": self.planner_id,
+                            "allowed_planning_time": (
+                                self.allowed_planning_time_to_staging_configuration
+                            ),
+                            "max_velocity_scale": (
+                                self.max_velocity_scaling_factor_to_staging_configuration
+                            ),
+                            "cartesian": cartesian,
+                            "cartesian_jump_threshold": (
+                                self.cartesian_jump_threshold_to_staging_configuration
+                            ),
+                            "cartesian_fraction_threshold": 0.60,  # Fine if its low since the user can retry
+                            "cartesian_max_step": (
+                                self.cartesian_max_step_to_staging_configuration
+                            ),
+                        },
+                        outputs={"trajectory": BlackboardKey("trajectory")},
+                    ),
+                    # Execute
+                    MoveIt2Execute(
+                        name="MoveToStagingPoseCartesianExecute",
+                        ns=name,
+                        inputs={"trajectory": BlackboardKey("trajectory")},
+                        outputs={},
+                    ),
+                ],  # End MoveToStagingConfigurationViaMoveIt2Cartesian.children
+            )  # End MoveToStagingConfigurationViaMoveIt2Cartesian
 
         # Use a custom speed profile to do angular motions at the end.
         max_pose_distance = 0.0
@@ -253,34 +393,57 @@ class MoveFromMouthTree(MoveToTree):
                             f_mag=self.force_threshold_to_staging_configuration,
                             t_mag=self.torque_threshold_to_staging_configuration,
                         ),
-                        # Create the goal pose
-                        CreatePoseStamped(
-                            name=name + "CreateStagingPose",
-                            ns=name,
-                            inputs={
-                                "position": self.staging_configuration_position,
-                                "quaternion": self.staging_configuration_quat_xyzw,
-                                "frame_id": base_link,
-                            },
-                            outputs={
-                                "pose_stamped": BlackboardKey("goal_pose"),
-                            },
-                        ),
-                        # Servo until the goal pose
-                        servo_until_pose(
-                            name=name + " MoveToStagingPose",
-                            ns=name,
-                            target_pose_stamped_key=BlackboardKey("goal_pose"),
-                            tolerance_position=self.staging_configuration_tolerance_position,
-                            tolerance_orientation=(0.6, 0.5, 0.5),
-                            duration=10.0,
-                            round_decimals=3,
-                            speed=speed,
-                        ),
-                    ],
-                ),
-            ],
-        )
+                        py_trees.composites.Selector(
+                            name=name + "MoveToStagingConfigurationSelector",
+                            memory=True,
+                            children=[
+                                # First, try to move to the staging configuration with Servo
+                                py_trees.composites.Sequence(
+                                    name=name + "MoveToStagingConfigurationViaServo",
+                                    memory=True,
+                                    children=[
+                                        # Create the goal pose
+                                        CreatePoseStamped(
+                                            name=name + "CreateStagingPose",
+                                            ns=name,
+                                            inputs={
+                                                "position": self.staging_configuration_position,
+                                                "quaternion": self.staging_configuration_quat_xyzw,
+                                                "frame_id": base_link,
+                                            },
+                                            outputs={
+                                                "pose_stamped": BlackboardKey(
+                                                    "goal_pose"
+                                                ),
+                                            },
+                                        ),
+                                        # Servo until the goal pose
+                                        servo_until_pose(
+                                            name=name + " MoveToStagingPoseServo",
+                                            ns=name,
+                                            target_pose_stamped_key=BlackboardKey(
+                                                "goal_pose"
+                                            ),
+                                            tolerance_position=self.staging_configuration_tolerance_position,
+                                            tolerance_orientation=(0.6, 0.5, 0.5),
+                                            duration=10.0,
+                                            round_decimals=3,
+                                            speed=speed,
+                                        ),
+                                    ],  # End MoveToStagingConfigurationViaServo.children
+                                ),  # End MoveToStagingConfigurationViaServo
+                                # If that fails, try to move to the staging configuration with a
+                                # MoveIt2 cartesian path
+                                moveit2_move_to_staging_pose(cartesian=True),
+                                # If that fails, try to move to the staging configuration with a
+                                # MoveIt2 kinematic path
+                                moveit2_move_to_staging_pose(cartesian=False),
+                            ],  # End MoveToStagingConfigurationSelector.children
+                        ),  # End MoveToStagingConfigurationSelector
+                    ],  # End AllowWheelchairCollisionScope.workers
+                ),  # End AllowWheelchairCollisionScope
+            ],  # End root_seq.children
+        )  # End root_seq
 
         # Move to the end configuration if it is provided
         if self.end_configuration is not None:
@@ -342,9 +505,9 @@ class MoveFromMouthTree(MoveToTree):
                             inputs={"trajectory": BlackboardKey("trajectory")},
                             outputs={},
                         ),
-                    ],
-                ),
-            )
+                    ],  # End AddInFrontOfWheelchairWallScope.workers
+                ),  # End AddInFrontOfWheelchairWallScope
+            )  # End root_seq.children.append
 
         ### Return tree
         return py_trees.trees.BehaviourTree(root_seq)

--- a/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
@@ -217,24 +217,24 @@ class MoveFromMouthTree(MoveToTree):
                 # pylint: disable=abstract-class-instantiated
                 # This is fine, not sure why pylint doesn't like it
                 return py_trees.behaviours.Success()
-            else:
-                # Orientation path constraint to keep the fork straight
-                return MoveIt2OrientationConstraint(
-                    name="KeepForkStraightPathConstraint",
-                    ns=name,
-                    inputs={
-                        "quat_xyzw": (
-                            self.orientation_constraint_to_staging_configuration_quaternion
-                        ),
-                        "tolerance": (
-                            self.orientation_constraint_to_staging_configuration_tolerances
-                        ),
-                        "parameterization": 1,  # Rotation vector
-                    },
-                    outputs={
-                        "constraints": BlackboardKey("path_constraints"),
-                    },
-                )
+            # Orientation path constraint to keep the fork straight
+            return MoveIt2OrientationConstraint(
+                name="KeepForkStraightPathConstraint",
+                ns=name,
+                inputs={
+                    "quat_xyzw": (
+                        self.orientation_constraint_to_staging_configuration_quaternion
+                    ),
+                    "tolerance": (
+                        self.orientation_constraint_to_staging_configuration_tolerances
+                    ),
+                    "parameterization": 1,  # Rotation vector
+                },
+                outputs={
+                    "constraints": BlackboardKey("path_constraints"),
+                },
+            )
+
         if self.orientation_constraint_to_end_configuration_quaternion is None:
             # pylint: disable=abstract-class-instantiated
             # This is fine, not sure why pylint doesn't like it
@@ -264,12 +264,12 @@ class MoveFromMouthTree(MoveToTree):
         ) -> py_trees.behaviour.Behaviour:
             suffix = "Cartesian" if cartesian else "Kinematic"
             return py_trees.composites.Sequence(
-                name=name + "MoveToStagingConfigurationViaMoveIt2"+suffix,
+                name=name + "MoveToStagingConfigurationViaMoveIt2" + suffix,
                 memory=True,
                 children=[
                     # Goal configuration: target position
                     MoveIt2PositionConstraint(
-                        name="MoveToStagingPosePositionGoalConstraint"+suffix,
+                        name="MoveToStagingPosePositionGoalConstraint" + suffix,
                         ns=name,
                         inputs={
                             "position": self.staging_configuration_position,
@@ -281,7 +281,7 @@ class MoveFromMouthTree(MoveToTree):
                     ),
                     # Goal configuration: target orientation
                     MoveIt2OrientationConstraint(
-                        name="MoveToStagingPoseOrientationGoalConstraint"+suffix,
+                        name="MoveToStagingPoseOrientationGoalConstraint" + suffix,
                         ns=name,
                         inputs={
                             "quat_xyzw": self.staging_configuration_quat_xyzw,
@@ -296,7 +296,7 @@ class MoveFromMouthTree(MoveToTree):
                     get_staging_path_constraints(),
                     # Plan
                     MoveIt2Plan(
-                        name="MoveToStagingPosePlan"+suffix,
+                        name="MoveToStagingPosePlan" + suffix,
                         ns=name,
                         inputs={
                             "goal_constraints": BlackboardKey("goal_constraints"),
@@ -321,7 +321,7 @@ class MoveFromMouthTree(MoveToTree):
                     ),
                     # Execute
                     MoveIt2Execute(
-                        name="MoveToStagingPoseExecute"+suffix,
+                        name="MoveToStagingPoseExecute" + suffix,
                         ns=name,
                         inputs={"trajectory": BlackboardKey("trajectory")},
                         outputs={},

--- a/ada_feeding/config/ada_feeding_action_servers_default.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_default.yaml
@@ -159,6 +159,9 @@ ada_feeding_action_servers:
         tree_kws: # optional
           - staging_configuration_position
           - staging_configuration_quat_xyzw
+          - max_velocity_scaling_factor_to_staging_configuration
+          - cartesian_jump_threshold_to_staging_configuration
+          - cartesian_max_step_to_staging_configuration
         tree_kwargs: # optional
           staging_configuration_position:
             -  0.28323 # x
@@ -169,6 +172,9 @@ ada_feeding_action_servers:
             -  0.69757 # y
             -  0.71645 # z
             - -0.00811 # w
+          max_velocity_scaling_factor_to_staging_configuration: 0.4 # optional in (0.0, 1.0], default: 0.1
+          cartesian_jump_threshold_to_staging_configuration: 2.0 # If a jump for a joint across consecutive IK solutions is more than this factor greater than the average, it is rejected
+          cartesian_max_step_to_staging_configuration: 0.01 # m
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the MoveFromMouthToAbovePlate action.
@@ -182,6 +188,9 @@ ada_feeding_action_servers:
           - staging_configuration_quat_xyzw
           - end_configuration
           - max_velocity_scaling_factor_to_end_configuration
+          - max_velocity_scaling_factor_to_staging_configuration
+          - cartesian_jump_threshold_to_staging_configuration
+          - cartesian_max_step_to_staging_configuration
         tree_kwargs: # optional
           staging_configuration_position:
             -  0.28323 # x
@@ -200,6 +209,9 @@ ada_feeding_action_servers:
             - -2.34026 # j2n6s200_joint_5
             -  2.95450 # j2n6s200_joint_6
           max_velocity_scaling_factor_to_end_configuration: 0.65 # optional in (0.0, 1.0], default: 0.1
+          max_velocity_scaling_factor_to_staging_configuration: 0.4 # optional in (0.0, 1.0], default: 0.1
+          cartesian_jump_threshold_to_staging_configuration: 2.0 # If a jump for a joint across consecutive IK solutions is more than this factor greater than the average, it is rejected
+          cartesian_max_step_to_staging_configuration: 0.01 # m
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the MoveFromMouthToRestingPosition action.
@@ -216,6 +228,9 @@ ada_feeding_action_servers:
           # - orientation_constraint_to_end_configuration_tolerances
           - allowed_planning_time_to_end_configuration
           - max_velocity_scaling_factor_to_end_configuration
+          - max_velocity_scaling_factor_to_staging_configuration
+          - cartesian_jump_threshold_to_staging_configuration
+          - cartesian_max_step_to_staging_configuration
         tree_kwargs: # optional
           staging_configuration_position:
             -  0.28323 # x
@@ -243,6 +258,9 @@ ada_feeding_action_servers:
             - 3.14159 # y, rad
             - 0.5 # z, rad
           max_velocity_scaling_factor_to_end_configuration: 0.65 # optional in (0.0, 1.0], default: 0.1
+          max_velocity_scaling_factor_to_staging_configuration: 0.4 # optional in (0.0, 1.0], default: 0.1
+          cartesian_jump_threshold_to_staging_configuration: 2.0 # If a jump for a joint across consecutive IK solutions is more than this factor greater than the average, it is rejected
+          cartesian_max_step_to_staging_configuration: 0.01 # m
           allowed_planning_time_to_end_configuration: 1.0 # secs
         tick_rate: 10 # Hz, optional, default: 30
 

--- a/ada_feeding/config/ada_feeding_action_servers_default.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_default.yaml
@@ -10,18 +10,18 @@ ada_feeding_action_servers:
       server_names:
         - MoveAbovePlate
         - AcquireFood
+        - MoveToRestingPosition
         - MoveToStagingConfiguration
         - MoveToMouth
-        - MoveFromMouthToStagingConfiguration
-        - MoveFromMouthToAbovePlate
-        - MoveFromMouthToRestingPosition
-        - MoveToRestingPosition
+        - MoveFromMouth
         - MoveToStowLocation
         - TestMoveToPose
         - StartServo
         - StopServo
 
       # Parameters for the MoveAbovePlate action
+      # TODO: Consider whether to make a version of this with a wheelchair wall
+      # for when moving away from the mouth.
       MoveAbovePlate: # required
         action_type: ada_feeding_msgs.action.MoveTo # required
         tree_class: ada_feeding.trees.MoveToConfigurationWithFTThresholdsTree # required
@@ -59,25 +59,36 @@ ada_feeding_action_servers:
             -  4.99555 # j2n6s200_joint_6
         tick_rate: 10 # Hz, optional, default: 30
 
-    # Parameters for the MoveToRestingPosition action
+      # Parameters for the MoveToRestingPosition action
+      # TODO: Consider whether to make a version of this with a wheelchair wall
+      # for when moving away from the mouth.
       MoveToRestingPosition: # required
         action_type: ada_feeding_msgs.action.MoveTo # required
-        tree_class: ada_feeding.trees.MoveToConfigurationWithFTThresholdsTree # required
+        tree_class: ada_feeding.trees.MoveToConfigurationWithWheelchairWallTree # required
         tree_kws: # optional
-          - joint_positions
-          - toggle_watchdog_listener
-          - f_mag
+          - goal_configuration
+          # - orientation_constraint_quaternion
+          # - orientation_constraint_tolerances
+          - allowed_planning_time
           - max_velocity_scaling_factor
         tree_kwargs: # optional
-          joint_positions: # required
+          goal_configuration: # required
             - -1.94672 # j2n6s200_joint_1
             -  2.51268 # j2n6s200_joint_2
             -  0.35653 # j2n6s200_joint_3
             - -4.76501 # j2n6s200_joint_4
             -  5.99991 # j2n6s200_joint_5
             -  4.99555 # j2n6s200_joint_6
-          toggle_watchdog_listener: false # optional, default: true
-          f_mag: 4.0 # N
+          orientation_constraint_quaternion: # perpendicular to the base link
+            - 0.707168 # x
+            - 0.0 # y
+            - 0.0 # z
+            - 0.707168 # w
+          orientation_constraint_tolerances: # Note that tolerances are w.r.t. the axes in quat_xyzw_path
+            - 0.6 # x, rad
+            - 3.14159 # y, rad
+            - 0.5 # z, rad
+          allowed_planning_time: 1.0 # secs
           max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
         tick_rate: 10 # Hz, optional, default: 30
 
@@ -156,10 +167,8 @@ ada_feeding_action_servers:
             - -0.01 # m
         tick_rate: 10 # Hz, optional, default: 30
 
-      # Parameters for the MoveFromMouthToStagingConfiguration action.
-      # No need for orientation path constraints when moving above the plate
-      # because presumably there is no food on the fork.
-      MoveFromMouthToStagingConfiguration: # required
+      # Parameters for the MoveFromMouth action.
+      MoveFromMouth: # required
         action_type: ada_feeding_msgs.action.MoveTo # required
         tree_class: ada_feeding.trees.MoveFromMouthTree # required
         tree_kws: # optional
@@ -181,93 +190,6 @@ ada_feeding_action_servers:
           max_velocity_scaling_factor_to_staging_configuration: 0.4 # optional in (0.0, 1.0], default: 0.1
           cartesian_jump_threshold_to_staging_configuration: 2.0 # If a jump for a joint across consecutive IK solutions is more than this factor greater than the average, it is rejected
           cartesian_max_step_to_staging_configuration: 0.01 # m
-        tick_rate: 10 # Hz, optional, default: 30
-
-      # Parameters for the MoveFromMouthToAbovePlate action.
-      # No need for orientation path constraints when moving above the plate
-      # because presumably there is no food on the fork.
-      MoveFromMouthToAbovePlate: # required
-        action_type: ada_feeding_msgs.action.MoveTo # required
-        tree_class: ada_feeding.trees.MoveFromMouthTree # required
-        tree_kws: # optional
-          - staging_configuration_position
-          - staging_configuration_quat_xyzw
-          - end_configuration
-          - max_velocity_scaling_factor_to_end_configuration
-          - max_velocity_scaling_factor_to_staging_configuration
-          - cartesian_jump_threshold_to_staging_configuration
-          - cartesian_max_step_to_staging_configuration
-        tree_kwargs: # optional
-          staging_configuration_position:
-            -  0.28323 # x
-            -  0.07289 # y
-            -  0.69509 # z
-          staging_configuration_quat_xyzw:
-            -  0.00472 # x
-            -  0.69757 # y
-            -  0.71645 # z
-            - -0.00811 # w
-          end_configuration:
-            - -2.11666 # j2n6s200_joint_1
-            -  3.34967 # j2n6s200_joint_2
-            -  2.04129 # j2n6s200_joint_3
-            - -2.30031 # j2n6s200_joint_4
-            - -2.34026 # j2n6s200_joint_5
-            -  2.95450 # j2n6s200_joint_6
-          max_velocity_scaling_factor_to_end_configuration: 0.65 # optional in (0.0, 1.0], default: 0.1
-          max_velocity_scaling_factor_to_staging_configuration: 0.4 # optional in (0.0, 1.0], default: 0.1
-          cartesian_jump_threshold_to_staging_configuration: 2.0 # If a jump for a joint across consecutive IK solutions is more than this factor greater than the average, it is rejected
-          cartesian_max_step_to_staging_configuration: 0.01 # m
-        tick_rate: 10 # Hz, optional, default: 30
-
-      # Parameters for the MoveFromMouthToRestingPosition action.
-      # Need orientation path constraints to end config because
-      # presumably there is still food on the fork.
-      MoveFromMouthToRestingPosition: # required
-        action_type: ada_feeding_msgs.action.MoveTo # required
-        tree_class: ada_feeding.trees.MoveFromMouthTree # required
-        tree_kws: # optional
-          - staging_configuration_position
-          - staging_configuration_quat_xyzw
-          - end_configuration
-          # - orientation_constraint_to_end_configuration_quaternion
-          # - orientation_constraint_to_end_configuration_tolerances
-          - allowed_planning_time_to_end_configuration
-          - max_velocity_scaling_factor_to_end_configuration
-          - max_velocity_scaling_factor_to_staging_configuration
-          - cartesian_jump_threshold_to_staging_configuration
-          - cartesian_max_step_to_staging_configuration
-        tree_kwargs: # optional
-          staging_configuration_position:
-            -  0.28323 # x
-            -  0.07289 # y
-            -  0.69509 # z
-          staging_configuration_quat_xyzw:
-            -  0.00472 # x
-            -  0.69757 # y
-            -  0.71645 # z
-            - -0.00811 # w
-          end_configuration:
-            - -1.94672 # j2n6s200_joint_1
-            -  2.51268 # j2n6s200_joint_2
-            -  0.35653 # j2n6s200_joint_3
-            - -4.76501 # j2n6s200_joint_4
-            -  5.99991 # j2n6s200_joint_5
-            -  4.99555 # j2n6s200_joint_6
-          orientation_constraint_to_end_configuration_quaternion: # perpendicular to the base link
-            - 0.707168 # x
-            - 0.0 # y
-            - 0.0 # z
-            - 0.707168 # w
-          orientation_constraint_to_end_configuration_tolerances: # Note that tolerances are w.r.t. the axes in quat_xyzw_path
-            - 0.6 # x, rad
-            - 3.14159 # y, rad
-            - 0.5 # z, rad
-          max_velocity_scaling_factor_to_end_configuration: 0.65 # optional in (0.0, 1.0], default: 0.1
-          max_velocity_scaling_factor_to_staging_configuration: 0.4 # optional in (0.0, 1.0], default: 0.1
-          cartesian_jump_threshold_to_staging_configuration: 2.0 # If a jump for a joint across consecutive IK solutions is more than this factor greater than the average, it is rejected
-          cartesian_max_step_to_staging_configuration: 0.01 # m
-          allowed_planning_time_to_end_configuration: 1.0 # secs
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the MoveToStowLocation action

--- a/ada_feeding/config/ada_feeding_action_servers_default.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_default.yaml
@@ -139,11 +139,17 @@ ada_feeding_action_servers:
         tree_kwargs: # optional
           face_detection_msg_timeout: 10.0 # sec
           face_detection_timeout: 5.0 # sec
+          # The below has the fork slightly tilted at the mouth
+          # fork_target_orientation_from_mouth: # In mouth frame, +x out of mouth, +z towards top of head
+          #   - 0.5751716
+          #   - -0.5751716
+          #   - -0.4113121
+          #   - 0.4113121
           fork_target_orientation_from_mouth: # In mouth frame, +x out of mouth, +z towards top of head
-            - 0.5751716
-            - -0.5751716
-            - -0.4113121
-            - 0.4113121
+            - 0.5
+            - -0.5
+            - -0.5
+            - 0.5
           plan_distance_from_mouth:
             - 0.025 # m
             - 0.0 # m

--- a/ada_feeding/config/ada_planning_scene.yaml
+++ b/ada_feeding/config/ada_planning_scene.yaml
@@ -4,7 +4,7 @@ ada_planning_scene:
     object_ids: # list of objects to add to the planning scene
       - wheelchair
       - wheelchair_collision
-      - table
+      # - table
       - head
       - workspace_wall_front
       - workspace_wall_left

--- a/ada_feeding_perception/ada_feeding_perception/republisher.py
+++ b/ada_feeding_perception/ada_feeding_perception/republisher.py
@@ -118,7 +118,12 @@ class Republisher(Node):
             self.topic_types.append(import_from_string(topic_type_str))
 
         # For each topic, create a callback, publisher, and subscriber
-        num_topics = min(len(self.from_topics), len(self.topic_types), len(to_topics), len(target_rates))
+        num_topics = min(
+            len(self.from_topics),
+            len(self.topic_types),
+            len(to_topics),
+            len(target_rates),
+        )
         self.callbacks = []
         self.pubs = []
         self.subs = []
@@ -175,7 +180,16 @@ class Republisher(Node):
     def load_parameters(
         self,
     ) -> Tuple[
-        List[str], List[str], List[str], List[str], List[List[str]], str, int, int, int, int
+        List[str],
+        List[str],
+        List[str],
+        List[str],
+        List[List[str]],
+        str,
+        int,
+        int,
+        int,
+        int,
     ]:
         """
         Load the parameters for the republisher.
@@ -376,7 +390,10 @@ class Republisher(Node):
         )
 
     def create_callback(
-        self, i: int, post_processors: List[Callable[[Any], Any]], target_rate: float,
+        self,
+        i: int,
+        post_processors: List[Callable[[Any], Any]],
+        target_rate: float,
     ) -> Callable:
         """
         Create the callback for the subscriber.
@@ -399,7 +416,7 @@ class Republisher(Node):
         if target_rate <= 0:
             interval = -math.inf
         else:
-            interval = 1.0/target_rate
+            interval = 1.0 / target_rate
         last_published_time = None
 
         def callback(msg: Any):
@@ -417,7 +434,10 @@ class Republisher(Node):
             # )
             for post_processor in post_processors:
                 msg = post_processor(msg)
-            if (last_published_time is None or time.time() - last_published_time >= interval):
+            if (
+                last_published_time is None
+                or time.time() - last_published_time >= interval
+            ):
                 self.pubs[i].publish(msg)
                 last_published_time = time.time()
 


### PR DESCRIPTION
# Description

Motivated by [`feeding_web_interface`#113](https://github.com/personalrobotics/feeding_web_interface/pull/113). 

If MoveToMouth fails due to approaching a singularity, MoveFromMouth will also fail. This PR addresses that by adding cartesian motion as a fallback to MoveFromMouth.

Further, since cartesian motion tends to fail if the arm is tilted, this PR also removes the arm tilt at the mouth.

Finally, to help streamline the app and improve retrying actions, this PR removes the combo actions of `MoveFromMouthToAbovePlate` and `MoveFromMouthToRestingPosition`. Instead, the app will achieve the desired behavior by calling `MoveFromMouth` followed by either `MoveAbovePlate` or `MoveToRestingPosition`

# Testing procedure

- [x] Tested with [`feeding_web_interface`#113](https://github.com/personalrobotics/feeding_web_interface/pull/113). Do many MoveToMouth / MoveFromMouth with different distances, verify it works.
- [x] Comment out the servo part of the fallback (equivalent to it failing), repeat the above, and verify that cartesian tends to succeed.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
