### PR TITLE
Improvements from 1-16-24 demo.

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -187,7 +187,6 @@ class ComputeFoodFrame(BlackboardBehavior):
             self.logger.error("Missing camera_info or world_frame")
             return py_trees.common.Status.FAILURE
 
-        self.logger.info(f"Got Frames")
         camera_frame = self.blackboard_get("camera_info").header.frame_id
         world_frame = self.blackboard_get("world_frame")
         timestamp = self.blackboard_get("timestamp")
@@ -203,16 +202,15 @@ class ComputeFoodFrame(BlackboardBehavior):
             if not self.tf_buffer.can_transform(
                 world_frame,
                 camera_frame,
-                rclpy.time.Time(),
+                timestamp,
             ):
                 # Not yet, wait for it
                 # Use a Timeout decorator to determine failure.
-                self.logger.info(f"Waiting on TF")
                 return py_trees.common.Status.RUNNING
             transform = self.tf_buffer.lookup_transform(
                 world_frame,
                 camera_frame,
-                rclpy.time.Time(),
+                timestamp,
             )
 
         # Set up return objects

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -187,6 +187,9 @@ class ComputeFoodFrame(BlackboardBehavior):
             self.logger.error("Missing camera_info or world_frame")
             return py_trees.common.Status.FAILURE
 
+        self.logger.info(
+                f"Got Frames"
+            )
         camera_frame = self.blackboard_get("camera_info").header.frame_id
         world_frame = self.blackboard_get("world_frame")
         timestamp = self.blackboard_get("timestamp")
@@ -202,15 +205,16 @@ class ComputeFoodFrame(BlackboardBehavior):
             if not self.tf_buffer.can_transform(
                 world_frame,
                 camera_frame,
-                timestamp,
+                rclpy.time.Time(),
             ):
                 # Not yet, wait for it
                 # Use a Timeout decorator to determine failure.
+                self.logger.info(f"Waiting on TF")
                 return py_trees.common.Status.RUNNING
             transform = self.tf_buffer.lookup_transform(
                 world_frame,
                 camera_frame,
-                timestamp,
+                rclpy.time.Time(),
             )
 
         # Set up return objects

--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -187,9 +187,7 @@ class ComputeFoodFrame(BlackboardBehavior):
             self.logger.error("Missing camera_info or world_frame")
             return py_trees.common.Status.FAILURE
 
-        self.logger.info(
-                f"Got Frames"
-            )
+        self.logger.info(f"Got Frames")
         camera_frame = self.blackboard_get("camera_info").header.frame_id
         world_frame = self.blackboard_get("world_frame")
         timestamp = self.blackboard_get("timestamp")

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -92,8 +92,12 @@ class AcquireFoodTree(MoveToTree):
         self.max_acceleration_scaling_move_above = max_acceleration_scaling_move_above
         self.max_velocity_scaling_move_into = max_velocity_scaling_move_into
         self.max_acceleration_scaling_move_into = max_acceleration_scaling_move_into
-        self.max_velocity_scaling_to_resting_configuration = max_velocity_scaling_to_resting_configuration
-        self.max_acceleration_scaling_to_resting_configuration = max_acceleration_scaling_to_resting_configuration
+        self.max_velocity_scaling_to_resting_configuration = (
+            max_velocity_scaling_to_resting_configuration
+        )
+        self.max_acceleration_scaling_to_resting_configuration = (
+            max_acceleration_scaling_to_resting_configuration
+        )
 
     @override
     def create_tree(

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -15,6 +15,7 @@ import py_trees
 from py_trees.blackboard import Blackboard
 import py_trees_ros
 from rcl_interfaces.srv import SetParameters
+import rclpy
 from rclpy.node import Node
 from rclpy.time import Time
 from std_msgs.msg import Header
@@ -65,6 +66,9 @@ class AcquireFoodTree(MoveToTree):
     Tree Blackboard Outputs:
 
     """
+
+    # pylint: disable=too-many-arguments
+    # The many parameters makes this tree extremely configurable.
 
     def __init__(
         self,
@@ -258,7 +262,10 @@ class AcquireFoodTree(MoveToTree):
                                 inputs={
                                     "camera_info": BlackboardKey("camera_info"),
                                     "mask": BlackboardKey("mask"),
-                                    "timestamp": BlackboardKey("timestamp"),
+                                    # NOTE: We override the goal message timestamp
+                                    # since sometimes there isn't a recent enough TF
+                                    "timestamp": rclpy.time.Time(),
+                                    # "timestamp": BlackboardKey("timestamp"),
                                     # Default food_frame_id = "food"
                                     # Default world_frame = "world"
                                 },

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -70,6 +70,12 @@ class AcquireFoodTree(MoveToTree):
         self,
         node: Node,
         resting_joint_positions: Optional[List[float]] = None,
+        max_velocity_scaling_move_above: Optional[float] = 0.8,
+        max_acceleration_scaling_move_above: Optional[float] = 0.8,
+        max_velocity_scaling_move_into: Optional[float] = 1.0,
+        max_acceleration_scaling_move_into: Optional[float] = 0.8,
+        max_velocity_scaling_to_resting_configuration: Optional[float] = 0.8,
+        max_acceleration_scaling_to_resting_configuration: Optional[float] = 0.8,
     ):
         """
         Initializes tree-specific parameters.
@@ -82,6 +88,12 @@ class AcquireFoodTree(MoveToTree):
         super().__init__(node)
 
         self.resting_joint_positions = resting_joint_positions
+        self.max_velocity_scaling_move_above = max_velocity_scaling_move_above
+        self.max_acceleration_scaling_move_above = max_acceleration_scaling_move_above
+        self.max_velocity_scaling_move_into = max_velocity_scaling_move_into
+        self.max_acceleration_scaling_move_into = max_acceleration_scaling_move_into
+        self.max_velocity_scaling_to_resting_configuration = max_velocity_scaling_to_resting_configuration
+        self.max_acceleration_scaling_to_resting_configuration = max_acceleration_scaling_to_resting_configuration
 
     @override
     def create_tree(
@@ -136,8 +148,8 @@ class AcquireFoodTree(MoveToTree):
                             ns=name,
                             inputs={
                                 "goal_constraints": BlackboardKey("goal_constraints"),
-                                "max_velocity_scale": 0.8,
-                                "max_acceleration_scale": 0.8,
+                                "max_velocity_scale": self.max_velocity_scaling_to_resting_configuration,
+                                "max_acceleration_scale": self.max_acceleration_scaling_to_resting_configuration,
                             },
                             outputs={"trajectory": BlackboardKey("trajectory")},
                         ),
@@ -319,8 +331,8 @@ class AcquireFoodTree(MoveToTree):
                             ns=name,
                             inputs={
                                 "goal_constraints": BlackboardKey("goal_constraints"),
-                                "max_velocity_scale": 0.8,
-                                "max_acceleration_scale": 0.8,
+                                "max_velocity_scale": self.max_velocity_scaling_move_above,
+                                "max_acceleration_scale": self.max_acceleration_scaling_move_above,
                                 "allowed_planning_time": 1.5,
                             },
                             outputs={"trajectory": BlackboardKey("trajectory")},
@@ -397,8 +409,8 @@ class AcquireFoodTree(MoveToTree):
                                         "goal_constraints": BlackboardKey(
                                             "goal_constraints"
                                         ),
-                                        "max_velocity_scale": 1.0,
-                                        "max_acceleration_scale": 0.8,
+                                        "max_velocity_scale": self.max_velocity_scaling_move_into,
+                                        "max_acceleration_scale": self.max_acceleration_scaling_move_into,
                                         "cartesian": True,
                                         "cartesian_max_step": 0.001,
                                         "cartesian_fraction_threshold": 0.95,

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -86,6 +86,7 @@ class MoveToMouthTree(MoveToTree):
         self,
         node: Node,
         mouth_position_tolerance: float = 0.005,
+        relaxed_mouth_position_tolerance: float = 0.025,
         head_object_id: str = "head",
         max_linear_speed: float = 0.1,
         max_angular_speed: float = 0.15,
@@ -109,6 +110,9 @@ class MoveToMouthTree(MoveToTree):
         Parameters
         ----------
         mouth_position_tolerance: The tolerance for the movement to the mouth pose.
+        relaxed_mouth_position_tolerance: Although the robot will keep moving until
+            it gets to within `mouth_position_tolerance`, if it stops early (e.g., the
+            user leaned forward), it will still return success within `relaxed_mouth_position_tolerance`.
         head_object_id: The ID of the head collision object in the MoveIt2
             planning scene.
         max_linear_speed: The maximum linear speed (m/s) for the motion.
@@ -143,6 +147,7 @@ class MoveToMouthTree(MoveToTree):
 
         # Store the parameters
         self.mouth_position_tolerance = mouth_position_tolerance
+        self.relaxed_mouth_position_tolerance = relaxed_mouth_position_tolerance
         self.head_object_id = head_object_id
         self.max_linear_speed = max_linear_speed
         self.max_angular_speed = max_angular_speed
@@ -513,6 +518,9 @@ class MoveToMouthTree(MoveToTree):
                             ns=name,
                             target_pose_stamped_key=BlackboardKey("goal_pose"),
                             tolerance_position=self.mouth_position_tolerance,
+                            tolerance_orientation=0.09,
+                            relaxed_tolerance_position=self.relaxed_mouth_position_tolerance,
+                            relaxed_tolerance_orientation=0.15,
                             duration=10.0,
                             round_decimals=3,
                             # TODO: Consider making the speed slower closer to the mouth.

--- a/ada_feeding/config/ada_feeding_action_servers_default.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_default.yaml
@@ -40,7 +40,7 @@ ada_feeding_action_servers:
             -  2.95450 # j2n6s200_joint_6
           toggle_watchdog_listener: false # optional, default: true
           f_mag: 4.0 # N
-          max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
+          max_velocity_scaling_factor: 1.0 # optional in (0.0, 1.0], default: 0.1
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the AcquireFood action
@@ -49,6 +49,9 @@ ada_feeding_action_servers:
         tree_class: ada_feeding.trees.AcquireFoodTree # required
         tree_kws:
           - resting_joint_positions
+          - max_velocity_scaling_move_above
+          - max_velocity_scaling_move_into
+          - max_velocity_scaling_to_resting_configuration
         tree_kwargs:
           resting_joint_positions: # required
             - -1.94672 # j2n6s200_joint_1
@@ -57,6 +60,9 @@ ada_feeding_action_servers:
             - -4.76501 # j2n6s200_joint_4
             -  5.99991 # j2n6s200_joint_5
             -  4.99555 # j2n6s200_joint_6
+          max_velocity_scaling_move_above: 1.0 # m/s
+          max_velocity_scaling_move_into: 1.0 # m/s
+          max_velocity_scaling_to_resting_configuration: 1.0 # m/s
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the MoveToRestingPosition action
@@ -89,7 +95,7 @@ ada_feeding_action_servers:
             - 3.14159 # y, rad
             - 0.5 # z, rad
           allowed_planning_time: 1.0 # secs
-          max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
+          max_velocity_scaling_factor: 1.0 # optional in (0.0, 1.0], default: 0.1
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the MoveToStagingConfiguration action
@@ -135,7 +141,7 @@ ada_feeding_action_servers:
             - 3.14159 # y, rad
             - 0.5 # z, rad
           allowed_planning_time: 1.0 # secs
-          max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
+          max_velocity_scaling_factor: 1.0 # optional in (0.0, 1.0], default: 0.1
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the MoveToMouth action
@@ -147,6 +153,7 @@ ada_feeding_action_servers:
           - face_detection_timeout
           - fork_target_orientation_from_mouth
           - plan_distance_from_mouth
+          - max_linear_speed
         tree_kwargs: # optional
           face_detection_msg_timeout: 10.0 # sec
           face_detection_timeout: 5.0 # sec
@@ -165,6 +172,7 @@ ada_feeding_action_servers:
             - 0.025 # m
             - 0.0 # m
             - -0.01 # m
+          max_linear_speed: 0.12 # m/s, default 0.1
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the MoveFromMouth action.
@@ -174,6 +182,7 @@ ada_feeding_action_servers:
         tree_kws: # optional
           - staging_configuration_position
           - staging_configuration_quat_xyzw
+          - max_linear_speed_to_staging_configuration
           - max_velocity_scaling_factor_to_staging_configuration
           - cartesian_jump_threshold_to_staging_configuration
           - cartesian_max_step_to_staging_configuration
@@ -187,7 +196,8 @@ ada_feeding_action_servers:
             -  0.69757 # y
             -  0.71645 # z
             - -0.00811 # w
-          max_velocity_scaling_factor_to_staging_configuration: 0.4 # optional in (0.0, 1.0], default: 0.1
+          max_linear_speed_to_staging_configuration: 0.12 # m/s, default 0.1
+          max_velocity_scaling_factor_to_staging_configuration: 0.6 # optional in (0.0, 1.0], default: 0.1. Only used for fallback cartesian motion
           cartesian_jump_threshold_to_staging_configuration: 2.0 # If a jump for a joint across consecutive IK solutions is more than this factor greater than the average, it is rejected
           cartesian_max_step_to_staging_configuration: 0.01 # m
         tick_rate: 10 # Hz, optional, default: 30
@@ -213,7 +223,7 @@ ada_feeding_action_servers:
             -  3.87886 # j2n6s200_joint_6
           toggle_watchdog_listener: false # optional, default: true
           f_mag: 4.0 # N
-          max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
+          max_velocity_scaling_factor: 1.0 # optional in (0.0, 1.0], default: 0.1
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the TestMoveToPose action. Moves to the staging location
@@ -234,7 +244,7 @@ ada_feeding_action_servers:
             -  0.69757 # y
             -  0.71645 # z
             - -0.00811 # w
-          max_velocity_scaling_factor: 0.65 # optional in (0.0, 1.0], default: 0.1
+          max_velocity_scaling_factor: 1.0 # optional in (0.0, 1.0], default: 0.1
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for the StartServo action

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -26,6 +26,7 @@
     <remap from="~/ft_topic" to="/wireless_ft/ftSensor1" />
     <remap from="~/set_force_gate_controller_parameters" to="/jaco_arm_controller/set_parameters" />
     <remap from="~/set_servo_controller_parameters" to="/jaco_arm_servo_controller/set_parameters" />
+    <remap from="~/clear_octomap" to="/clear_octomap" />
     <remap from="~/toggle_face_detection" to="/toggle_face_detection" />
     <remap from="~/face_detection" to="/face_detection" />
     <remap from="~/switch_controller" to="/controller_manager/switch_controller" />

--- a/ada_feeding_perception/ada_feeding_perception/republisher.py
+++ b/ada_feeding_perception/ada_feeding_perception/republisher.py
@@ -216,6 +216,10 @@ class Republisher(Node):
         threshold_max : int
             The maximum value to use for the threshold post-processor.
         """
+
+        # pylint: disable=too-many-locals
+        # This needs many parameters given how flexible it is intended to be.
+
         # Read the from topics
         from_topics = self.declare_parameter(
             "from_topics",


### PR DESCRIPTION
# Description

This PR contains multiple small changes from the 1-16 user study. Each change has separate testing, so we document testing right below the change.

1. Make acquisition use the most recent TF transform from the camera to the world, not the one at the mask timestamp (since sometimes that is too new).
    1. Before, compute food frame was often failing due to a TF lookup timeout. After this change, it stopped failing. (Note, this is a silent failure. We should consider logging in this case.)
2. Speed up the arm. I moved all kinematic motions from 60% to 100%, and all transfer-related servo motions from 0.1 m/2 to 0.12 m/2.
    1. Tested it, verified that it was faster and didn't feel scary.
3. Add relaxed tolerance constraints to bite transfer. If the user leans forward, the arm might get to their mouth, but think it fails due to a collision. Thus, although the robot arm will keep moving until it reaches the initial tolerance (0.5cm), it will still succeed if it is within a relaxed tolerance (2.5cm)
    1. Verified that it failed if we added a collision too far, but didn't if we added a collision close.
4. Make MoveToMouth clear octomap by default to avoid phantom collisions. It should have enough time to repopulate the octomap.
    1. Verify that MoveToMouth still works.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
