### PR TITLE
[SegmentFromPoint] Replaced Average Depth with Median

### DIFF
--- a/ada_feeding_msgs/msg/Mask.msg
+++ b/ada_feeding_msgs/msg/Mask.msg
@@ -9,7 +9,9 @@ sensor_msgs/CompressedImage mask
 # The RGB image that was used for segmentation, cropped to the roi.
 sensor_msgs/CompressedImage rgb_image
 
-# The average of the depth camera readings over the mask (in m)
+# The mean or median of the depth camera readings over the mask (in m)
+# (NOTE: SegmentFromPoint returns median. The name is "average" for legacy
+# purposes)
 float64 average_depth
 
 # An arbitrary ID that defines the segmented item

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -445,7 +445,8 @@ class SegmentFromPointNode(Node):
         #       Erosion/dilation could be useful here.
         cleaned_mask = get_connected_component(mask, seed_point)
         # Get the **median** depth over the mask
-        average_depth_mm = np.median(depth_img[cleaned_mask])
+        masked_depth = depth_img[cleaned_mask]
+        average_depth_mm = np.median(masked_depth[np.nonzero(masked_depth)])
         # Compute the bounding box
         bbox = bbox_from_mask(cleaned_mask)
         # Crop the image and the mask

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -444,10 +444,8 @@ class SegmentFromPointNode(Node):
         # TODO: Thoroughly test this, in case we need to add more mask cleaning!
         #       Erosion/dilation could be useful here.
         cleaned_mask = get_connected_component(mask, seed_point)
-        # Get the average depth over the mask
-        average_depth_mm = np.sum(np.where(cleaned_mask, depth_img, 0)) / np.sum(
-            cleaned_mask
-        )
+        # Get the **median** depth over the mask
+        average_depth_mm = np.median(depth_img[cleaned_mask])
         # Compute the bounding box
         bbox = bbox_from_mask(cleaned_mask)
         # Crop the image and the mask


### PR DESCRIPTION
# Description

In the 1/16 user study, we saw some cases where the deepest point of the fork's "into" motion was around 1 inch from the top of the food. Our hypothesis is that part of the fork (and/or its shadow) was in the segmented mask, skewing the average depth. Thus, this PR does two things:

1. Replaces average depth with median depth.
2. Removes points of depth 0 from the mask (indicative of a shadow in the depth camera)

# Testing procedure

In-person:

- [x] Test with several food items, in several different locations around the plate. For some of them, have them close to and/or overlapping with the fork. Verify that it acquires the food correctly.
- [x] Also, verify that the perceived depth is correct (easiest way to do so imo is with the web browser's console logs).

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
