### PR TITLE
Acquisition Tweaks

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -11,6 +11,7 @@ from typing import Optional, Tuple, Union
 import cv2 as cv
 from geometry_msgs.msg import PointStamped, TransformStamped, Vector3Stamped
 import numpy as np
+import numpy.typing as npt
 from overrides import override
 import py_trees
 import pyrealsense2
@@ -141,13 +142,27 @@ class ComputeFoodFrame(BlackboardBehavior):
             )
             self.intrinsics.model = pyrealsense2.distortion.none
 
-    def get_mask_center(self, mask: Mask) -> Tuple[int, int]:
+    def get_mask_center(
+        self,
+        mask: Mask,
+        mask_img: npt.NDArray,
+        kernel_size: int = 21,
+        viz: bool = False,
+    ) -> Tuple[int, int, float]:
         """
-        Returns the center of the mask.
+        Returns the center of the mask (u,v) and the median depth in a kernel_size
+        square around the center of the mask.
+
+        Parameters
+        ----------
+        mask: the ada_feeding_msgs.msg.Mask the user selected.
+        mask_img: the mask concerted to an OpenCV Matrix
+        kernel_size: get the median depth over the kernel_size by kernel_size
+            pixels around the mask center.
+        viz: whether to visualize the mask (note, this will block the main thread).
         """
-        mask_img = cv.imdecode(
-            np.frombuffer(mask.mask.data, np.uint8), cv.IMREAD_UNCHANGED
-        )
+
+        # pylint: disable=too-many-locals
 
         # Calculate the moments of the mask
         moments = cv.moments(mask_img)
@@ -156,21 +171,44 @@ class ComputeFoodFrame(BlackboardBehavior):
         c_x = int(round(moments["m10"] / moments["m00"]))
         c_y = int(round(moments["m01"] / moments["m00"]))
 
+        # Compute the median depth around the center point
+        half_kernel_size = kernel_size // 2
+        depth_img = ros_msg_to_cv2_image(mask.depth_image)
+        depth_within_kernel = depth_img[
+            max(0, c_y - half_kernel_size) : min(
+                mask.roi.height, c_y + half_kernel_size + 1
+            ),
+            max(0, c_x - half_kernel_size) : min(
+                mask.roi.width, c_x + half_kernel_size + 1
+            ),
+        ]
+        mask_within_kernel = mask_img[
+            max(0, c_y - half_kernel_size) : min(
+                mask.roi.height, c_y + half_kernel_size + 1
+            ),
+            max(0, c_x - half_kernel_size) : min(
+                mask.roi.width, c_x + half_kernel_size + 1
+            ),
+        ]
+        masked_depth = depth_within_kernel[mask_within_kernel == 255]
+        median_depth = np.median(masked_depth[np.nonzero(masked_depth)]) / 1000.0
+
+        # Compute the center of the ROI
         roi_cx = mask.roi.width // 2
         roi_cy = mask.roi.height // 2
 
-        self.node.get_logger().warn(
-            f"c_x {c_x}, c_y {c_y}, roi_cx {roi_cx}, roi_cy {roi_cy}"
+        self.node.get_logger().debug(
+            f"get_mask_center c_x {c_x}, c_y {c_y}, median_depth {median_depth}, roi_cx {roi_cx}, roi_cy {roi_cy}"
         )
 
-        mask_img_color = cv.cvtColor(mask_img, cv.COLOR_GRAY2BGR)
-        cv.circle(mask_img_color, (c_x, c_y), 2, (0, 0, 255), -1)
-        cv.circle(mask_img_color, (roi_cx, roi_cy), 2, (255, 0, 0), -1)
+        if viz:
+            mask_img_color = cv.cvtColor(mask_img, cv.COLOR_GRAY2BGR)
+            cv.circle(mask_img_color, (c_x, c_y), 2, (0, 0, 255), -1)
+            cv.circle(mask_img_color, (roi_cx, roi_cy), 2, (255, 0, 0), -1)
+            cv.imshow("mask_img", mask_img_color)
+            cv.waitKey(0)
 
-        # cv.imshow("mask_img", mask_img_color)
-        # cv.waitKey(0)
-
-        return (mask.roi.x_offset + c_x, mask.roi.y_offset + c_y)
+        return (mask.roi.x_offset + c_x, mask.roi.y_offset + c_y, median_depth)
 
     @override
     def update(self) -> py_trees.common.Status:
@@ -222,15 +260,19 @@ class ComputeFoodFrame(BlackboardBehavior):
         world_to_food_transform.header.frame_id = world_frame
         world_to_food_transform.child_frame_id = self.blackboard_get("food_frame_id")
 
-        # De-project center of ROI
+        # Get Mask
         mask = self.blackboard_get("mask")
-        if mask.average_depth == 0.0:
-            self.logger.error("Invalid mask: average depth is zero.")
+        mask_cv = ros_msg_to_cv2_image(mask.mask)
+
+        # De-project center of ROI
+        c_x, c_y, median_depth = self.get_mask_center(mask, mask_cv)
+        if median_depth == 0.0:
+            self.logger.error("Invalid mask: median_depth is zero.")
             return py_trees.common.Status.FAILURE
         center_list = pyrealsense2.rs2_deproject_pixel_to_point(
             self.intrinsics,
-            self.get_mask_center(mask),
-            mask.average_depth,
+            (c_x, c_y),
+            median_depth,
         )
         center = PointStamped()
         center.header.frame_id = camera_frame
@@ -242,8 +284,6 @@ class ComputeFoodFrame(BlackboardBehavior):
         # Get angle from mask bounded ellipse
         # See: https://stackoverflow.com/questions/15956124/minarearect-angles-unsure-
         #      about-the-angle-returned
-        # Get Mask
-        mask_cv = ros_msg_to_cv2_image(mask.mask)
         # Threshold and get contours
         _, mask_thresh = cv.threshold(mask_cv, 127, 255, 0)
         contours, _ = cv.findContours(mask_thresh, 1, 2)
@@ -262,10 +302,10 @@ class ComputeFoodFrame(BlackboardBehavior):
             point2 = points[2]
         # Get vector in camera frame
         point1 = pyrealsense2.rs2_deproject_pixel_to_point(
-            self.intrinsics, [point1[0], point1[1]], mask.average_depth
+            self.intrinsics, [point1[0], point1[1]], median_depth
         )
         point2 = pyrealsense2.rs2_deproject_pixel_to_point(
-            self.intrinsics, [point2[0], point2[1]], mask.average_depth
+            self.intrinsics, [point2[0], point2[1]], median_depth
         )
         # Flip X if requested
         if self.blackboard_get("flip_food_frame"):

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -354,8 +354,6 @@ class AcquireFoodTree(MoveToTree):
             )
 
         ### Define Tree Logic
-        # NOTE: If octomap clearing ends up being an issue, we should
-        # consider adding a call to the /clear_octomap service to this tree.
         # Root Sequence
         root_seq = py_trees.composites.Sequence(
             name=name,
@@ -365,208 +363,237 @@ class AcquireFoodTree(MoveToTree):
                     name="TableCollision",
                     # Set Approach F/T Thresh
                     pre_behavior=ToggleCollisionObject(
-                        name="AllowTableAndOctomap",
+                        name="AllowTable",
                         ns=name,
                         inputs={
-                            "collision_object_ids": ["table", "<octomap>"],
+                            "collision_object_ids": ["table"],
                             "allow": True,
                         },
                     ),
                     post_behavior=ToggleCollisionObject(
-                        name="DisallowTableAndOctomap",
+                        name="DisallowTable",
                         ns=name,
                         inputs={
-                            "collision_object_ids": ["table", "<octomap>"],
+                            "collision_object_ids": ["table"],
                             "allow": False,
                         },
                     ),
                     on_preempt_timeout=5.0,
                     # Starts a new Sequence w/ Memory internally
                     workers=[
-                        # Clear Octomap
-                        py_trees_ros.service_clients.FromConstant(
-                            name="ClearOctomap",
-                            service_name="/clear_octomap",
-                            service_type=Empty,
-                            service_request=Empty.Request(),
-                            # Default fail if service is down
-                            wait_for_server_timeout_sec=0.0,
-                        ),
-                        py_trees.composites.Selector(
-                            name="BackupFlipFoodFrameSel",
-                            memory=True,
-                            children=[
-                                move_above_plan(True),
-                                move_above_plan(False),
-                            ],
-                        ),
-                        MoveIt2Execute(
-                            name="MoveAbove",
-                            ns=name,
-                            inputs={"trajectory": BlackboardKey("trajectory")},
-                            outputs={},
-                        ),
-                        # If Anything goes wrong, reset FT to safe levels
                         scoped_behavior(
-                            name="SafeFTPreempt",
+                            name="OctomapCollision",
                             # Set Approach F/T Thresh
-                            pre_behavior=py_trees.composites.Sequence(
-                                name=name,
-                                memory=True,
-                                children=[
-                                    retry_call_ros_service(
-                                        name="ApproachFTThresh",
-                                        service_type=SetParameters,
-                                        service_name="~/set_force_gate_controller_parameters",
-                                        # Blackboard, not Constant
-                                        request=None,
-                                        # Need absolute Blackboard name
-                                        key_request=Blackboard.separator.join(
-                                            [name, BlackboardKey("approach_thresh")]
-                                        ),
-                                        key_response=Blackboard.separator.join(
-                                            [name, BlackboardKey("ft_response")]
-                                        ),
-                                        response_checks=[
-                                            py_trees.common.ComparisonExpression(
-                                                variable=Blackboard.separator.join(
-                                                    [name, BlackboardKey("ft_response")]
-                                                ),
-                                                value=SetParameters.Response(),  # Unused
-                                                operator=set_parameter_response_all_success,
-                                            )
-                                        ],
-                                    ),
-                                ],
+                            pre_behavior=ToggleCollisionObject(
+                                name="AllowOctomap",
+                                ns=name,
+                                inputs={
+                                    "collision_object_ids": ["<octomap>"],
+                                    "allow": True,
+                                },
                             ),
-                            post_behavior=py_trees.composites.Sequence(
-                                name=name,
-                                memory=True,
-                                children=[
-                                    pre_moveto_config(
-                                        name="PostAcquireFTSet", re_tare=False
-                                    ),
-                                ],
+                            post_behavior=ToggleCollisionObject(
+                                name="DisallowOctomap",
+                                ns=name,
+                                inputs={
+                                    "collision_object_ids": ["<octomap>"],
+                                    "allow": False,
+                                },
                             ),
                             on_preempt_timeout=5.0,
-                            # Starts a new Sequence w/ Memory internally
                             workers=[
-                                ### Move Into Food
-                                MoveIt2PoseConstraint(
-                                    name="MoveIntoPose",
+                                # Clear Octomap
+                                py_trees_ros.service_clients.FromConstant(
+                                    name="ClearOctomap",
+                                    service_name="/clear_octomap",
+                                    service_type=Empty,
+                                    service_request=Empty.Request(),
+                                    # Default fail if service is down
+                                    wait_for_server_timeout_sec=0.0,
+                                ),
+                                py_trees.composites.Selector(
+                                    name="BackupFlipFoodFrameSel",
+                                    memory=True,
+                                    children=[
+                                        move_above_plan(True),
+                                        move_above_plan(False),
+                                    ],
+                                ),
+                                MoveIt2Execute(
+                                    name="MoveAbove",
                                     ns=name,
-                                    inputs={
-                                        "pose": BlackboardKey("move_into_pose"),
-                                        "frame_id": "food",
-                                    },
-                                    outputs={
-                                        "constraints": BlackboardKey(
-                                            "goal_constraints"
-                                        ),
-                                    },
+                                    inputs={"trajectory": BlackboardKey("trajectory")},
+                                    outputs={},
                                 ),
-                                MoveIt2Plan(
-                                    name="MoveIntoPlan",
-                                    ns=name,
-                                    inputs={
-                                        "goal_constraints": BlackboardKey(
-                                            "goal_constraints"
-                                        ),
-                                        "max_velocity_scale": self.max_velocity_scaling_move_into,
-                                        "max_acceleration_scale": self.max_acceleration_scaling_move_into,
-                                        "cartesian": True,
-                                        "cartesian_max_step": 0.001,
-                                        "cartesian_fraction_threshold": 0.95,
-                                    },
-                                    outputs={"trajectory": BlackboardKey("trajectory")},
-                                ),
-                                # MoveInto expect F/T failure
-                                py_trees.decorators.FailureIsSuccess(
-                                    name="MoveIntoExecuteSucceed",
-                                    child=MoveIt2Execute(
-                                        name="MoveInto",
-                                        ns=name,
-                                        inputs={
-                                            "trajectory": BlackboardKey("trajectory")
-                                        },
-                                        outputs={},
-                                    ),
-                                ),
-                                ### Scoped Behavior for Moveit2_Servo
+                                # If Anything goes wrong, reset FT to safe levels
                                 scoped_behavior(
-                                    name="MoveIt2Servo",
+                                    name="SafeFTPreempt",
                                     # Set Approach F/T Thresh
                                     pre_behavior=py_trees.composites.Sequence(
                                         name=name,
                                         memory=True,
                                         children=[
-                                            StartServoTree(
-                                                self._node,
-                                                servo_controller_name="jaco_arm_cartesian_controller",
-                                                start_moveit_servo=False,
-                                            )
-                                            .create_tree(name="StartServoScoped")
-                                            .root,
+                                            retry_call_ros_service(
+                                                name="ApproachFTThresh",
+                                                service_type=SetParameters,
+                                                service_name="~/set_force_gate_controller_parameters",
+                                                # Blackboard, not Constant
+                                                request=None,
+                                                # Need absolute Blackboard name
+                                                key_request=Blackboard.separator.join(
+                                                    [
+                                                        name,
+                                                        BlackboardKey(
+                                                            "approach_thresh"
+                                                        ),
+                                                    ]
+                                                ),
+                                                key_response=Blackboard.separator.join(
+                                                    [name, BlackboardKey("ft_response")]
+                                                ),
+                                                response_checks=[
+                                                    py_trees.common.ComparisonExpression(
+                                                        variable=Blackboard.separator.join(
+                                                            [
+                                                                name,
+                                                                BlackboardKey(
+                                                                    "ft_response"
+                                                                ),
+                                                            ]
+                                                        ),
+                                                        value=SetParameters.Response(),  # Unused
+                                                        operator=set_parameter_response_all_success,
+                                                    )
+                                                ],
+                                            ),
                                         ],
                                     ),
-                                    # Reset FT and Stop Servo
                                     post_behavior=py_trees.composites.Sequence(
                                         name=name,
                                         memory=True,
                                         children=[
                                             pre_moveto_config(
-                                                name="PostServoFTSet",
-                                                re_tare=False,
-                                                f_mag=1.0,
-                                                param_service_name="~/set_servo_controller_parameters",
+                                                name="PostAcquireFTSet", re_tare=False
                                             ),
-                                            StopServoTree(
-                                                self._node,
-                                                servo_controller_name="jaco_arm_cartesian_controller",
-                                                stop_moveit_servo=False,
-                                            )
-                                            .create_tree(name="StopServoScoped")
-                                            .root,
                                         ],
                                     ),
                                     on_preempt_timeout=5.0,
                                     # Starts a new Sequence w/ Memory internally
                                     workers=[
-                                        py_trees.composites.Selector(
-                                            name="InFoodErrorSelector",
-                                            memory=True,
-                                            children=[
-                                                py_trees.composites.Sequence(
-                                                    name="InFoodGraspExtract",
+                                        ### Move Into Food
+                                        MoveIt2PoseConstraint(
+                                            name="MoveIntoPose",
+                                            ns=name,
+                                            inputs={
+                                                "pose": BlackboardKey("move_into_pose"),
+                                                "frame_id": "food",
+                                            },
+                                            outputs={
+                                                "constraints": BlackboardKey(
+                                                    "goal_constraints"
+                                                ),
+                                            },
+                                        ),
+                                        MoveIt2Plan(
+                                            name="MoveIntoPlan",
+                                            ns=name,
+                                            inputs={
+                                                "goal_constraints": BlackboardKey(
+                                                    "goal_constraints"
+                                                ),
+                                                "max_velocity_scale": self.max_velocity_scaling_move_into,
+                                                "max_acceleration_scale": self.max_acceleration_scaling_move_into,
+                                                "cartesian": True,
+                                                "cartesian_max_step": 0.001,
+                                                "cartesian_fraction_threshold": 0.95,
+                                            },
+                                            outputs={
+                                                "trajectory": BlackboardKey(
+                                                    "trajectory"
+                                                )
+                                            },
+                                        ),
+                                        # MoveInto expect F/T failure
+                                        py_trees.decorators.FailureIsSuccess(
+                                            name="MoveIntoExecuteSucceed",
+                                            child=MoveIt2Execute(
+                                                name="MoveInto",
+                                                ns=name,
+                                                inputs={
+                                                    "trajectory": BlackboardKey(
+                                                        "trajectory"
+                                                    )
+                                                },
+                                                outputs={},
+                                            ),
+                                        ),
+                                        ### Scoped Behavior for Moveit2_Servo
+                                        scoped_behavior(
+                                            name="MoveIt2Servo",
+                                            # Set Approach F/T Thresh
+                                            pre_behavior=py_trees.composites.Sequence(
+                                                name=name,
+                                                memory=True,
+                                                children=[
+                                                    StartServoTree(
+                                                        self._node,
+                                                        servo_controller_name="jaco_arm_cartesian_controller",
+                                                        start_moveit_servo=False,
+                                                    )
+                                                    .create_tree(
+                                                        name="StartServoScoped"
+                                                    )
+                                                    .root,
+                                                ],
+                                            ),
+                                            # Reset FT and Stop Servo
+                                            post_behavior=py_trees.composites.Sequence(
+                                                name=name,
+                                                memory=True,
+                                                children=[
+                                                    pre_moveto_config(
+                                                        name="PostServoFTSet",
+                                                        re_tare=False,
+                                                        f_mag=1.0,
+                                                        param_service_name="~/set_servo_controller_parameters",
+                                                    ),
+                                                    StopServoTree(
+                                                        self._node,
+                                                        servo_controller_name="jaco_arm_cartesian_controller",
+                                                        stop_moveit_servo=False,
+                                                    )
+                                                    .create_tree(name="StopServoScoped")
+                                                    .root,
+                                                ],
+                                            ),
+                                            on_preempt_timeout=5.0,
+                                            # Starts a new Sequence w/ Memory internally
+                                            workers=[
+                                                py_trees.composites.Selector(
+                                                    name="InFoodErrorSelector",
                                                     memory=True,
                                                     children=[
-                                                        ### Grasp
-                                                        retry_call_ros_service(
-                                                            name="GraspFTThresh",
-                                                            service_type=SetParameters,
-                                                            service_name="~/set_cartesian_controller_parameters",
-                                                            # Blackboard, not Constant
-                                                            request=None,
-                                                            # Need absolute Blackboard name
-                                                            key_request=Blackboard.separator.join(
-                                                                [
-                                                                    name,
-                                                                    BlackboardKey(
-                                                                        "grasp_thresh"
+                                                        py_trees.composites.Sequence(
+                                                            name="InFoodGraspExtract",
+                                                            memory=True,
+                                                            children=[
+                                                                ### Grasp
+                                                                retry_call_ros_service(
+                                                                    name="GraspFTThresh",
+                                                                    service_type=SetParameters,
+                                                                    service_name="~/set_cartesian_controller_parameters",
+                                                                    # Blackboard, not Constant
+                                                                    request=None,
+                                                                    # Need absolute Blackboard name
+                                                                    key_request=Blackboard.separator.join(
+                                                                        [
+                                                                            name,
+                                                                            BlackboardKey(
+                                                                                "grasp_thresh"
+                                                                            ),
+                                                                        ]
                                                                     ),
-                                                                ]
-                                                            ),
-                                                            key_response=Blackboard.separator.join(
-                                                                [
-                                                                    name,
-                                                                    BlackboardKey(
-                                                                        "ft_response"
-                                                                    ),
-                                                                ]
-                                                            ),
-                                                            response_checks=[
-                                                                py_trees.common.ComparisonExpression(
-                                                                    variable=Blackboard.separator.join(
+                                                                    key_response=Blackboard.separator.join(
                                                                         [
                                                                             name,
                                                                             BlackboardKey(
@@ -574,90 +601,90 @@ class AcquireFoodTree(MoveToTree):
                                                                             ),
                                                                         ]
                                                                     ),
-                                                                    value=SetParameters.Response(),  # Unused
-                                                                    operator=set_parameter_response_all_success,
-                                                                )
-                                                            ],
-                                                        ),
-                                                        ComputeActionTwist(
-                                                            name="ComputeGrasp",
-                                                            ns=name,
-                                                            inputs={
-                                                                "action": BlackboardKey(
-                                                                    "action"
+                                                                    response_checks=[
+                                                                        py_trees.common.ComparisonExpression(
+                                                                            variable=Blackboard.separator.join(
+                                                                                [
+                                                                                    name,
+                                                                                    BlackboardKey(
+                                                                                        "ft_response"
+                                                                                    ),
+                                                                                ]
+                                                                            ),
+                                                                            value=SetParameters.Response(),  # Unused
+                                                                            operator=set_parameter_response_all_success,
+                                                                        )
+                                                                    ],
                                                                 ),
-                                                                "is_grasp": True,
-                                                            },
-                                                            outputs={
-                                                                "twist": BlackboardKey(
-                                                                    "twist"
+                                                                ComputeActionTwist(
+                                                                    name="ComputeGrasp",
+                                                                    ns=name,
+                                                                    inputs={
+                                                                        "action": BlackboardKey(
+                                                                            "action"
+                                                                        ),
+                                                                        "is_grasp": True,
+                                                                    },
+                                                                    outputs={
+                                                                        "twist": BlackboardKey(
+                                                                            "twist"
+                                                                        ),
+                                                                        "duration": BlackboardKey(
+                                                                            "duration"
+                                                                        ),
+                                                                    },
                                                                 ),
-                                                                "duration": BlackboardKey(
-                                                                    "duration"
+                                                                ServoMove(
+                                                                    name="GraspServo",
+                                                                    ns=name,
+                                                                    inputs={
+                                                                        "twist": BlackboardKey(
+                                                                            "twist"
+                                                                        ),
+                                                                        "duration": BlackboardKey(
+                                                                            "duration"
+                                                                        ),
+                                                                        "pub_topic": "~/cartesian_twist_cmds",
+                                                                        "fail_near_collision": False,
+                                                                        "fail_on_collision": False,
+                                                                        "fail_on_singularity": False,
+                                                                    },
+                                                                ),  # Auto Zero-Twist on terminate()
+                                                                ### Extraction
+                                                                ComputeActionTwist(
+                                                                    name="ComputeExtract",
+                                                                    ns=name,
+                                                                    inputs={
+                                                                        "action": BlackboardKey(
+                                                                            "action"
+                                                                        ),
+                                                                        "is_grasp": False,
+                                                                    },
+                                                                    outputs={
+                                                                        "twist": BlackboardKey(
+                                                                            "twist"
+                                                                        ),
+                                                                        "duration": BlackboardKey(
+                                                                            "duration"
+                                                                        ),
+                                                                    },
                                                                 ),
-                                                            },
-                                                        ),
-                                                        ServoMove(
-                                                            name="GraspServo",
-                                                            ns=name,
-                                                            inputs={
-                                                                "twist": BlackboardKey(
-                                                                    "twist"
-                                                                ),
-                                                                "duration": BlackboardKey(
-                                                                    "duration"
-                                                                ),
-                                                                "pub_topic": "~/cartesian_twist_cmds",
-                                                                "fail_near_collision": False,
-                                                                "fail_on_collision": False,
-                                                                "fail_on_singularity": False,
-                                                            },
-                                                        ),  # Auto Zero-Twist on terminate()
-                                                        ### Extraction
-                                                        ComputeActionTwist(
-                                                            name="ComputeExtract",
-                                                            ns=name,
-                                                            inputs={
-                                                                "action": BlackboardKey(
-                                                                    "action"
-                                                                ),
-                                                                "is_grasp": False,
-                                                            },
-                                                            outputs={
-                                                                "twist": BlackboardKey(
-                                                                    "twist"
-                                                                ),
-                                                                "duration": BlackboardKey(
-                                                                    "duration"
-                                                                ),
-                                                            },
-                                                        ),
-                                                        retry_call_ros_service(
-                                                            name="ExtractionFTThresh",
-                                                            service_type=SetParameters,
-                                                            service_name="~/set_cartesian_controller_parameters",
-                                                            # Blackboard, not Constant
-                                                            request=None,
-                                                            # Need absolute Blackboard name
-                                                            key_request=Blackboard.separator.join(
-                                                                [
-                                                                    name,
-                                                                    BlackboardKey(
-                                                                        "ext_thresh"
+                                                                retry_call_ros_service(
+                                                                    name="ExtractionFTThresh",
+                                                                    service_type=SetParameters,
+                                                                    service_name="~/set_cartesian_controller_parameters",
+                                                                    # Blackboard, not Constant
+                                                                    request=None,
+                                                                    # Need absolute Blackboard name
+                                                                    key_request=Blackboard.separator.join(
+                                                                        [
+                                                                            name,
+                                                                            BlackboardKey(
+                                                                                "ext_thresh"
+                                                                            ),
+                                                                        ]
                                                                     ),
-                                                                ]
-                                                            ),
-                                                            key_response=Blackboard.separator.join(
-                                                                [
-                                                                    name,
-                                                                    BlackboardKey(
-                                                                        "ft_response"
-                                                                    ),
-                                                                ]
-                                                            ),
-                                                            response_checks=[
-                                                                py_trees.common.ComparisonExpression(
-                                                                    variable=Blackboard.separator.join(
+                                                                    key_response=Blackboard.separator.join(
                                                                         [
                                                                             name,
                                                                             BlackboardKey(
@@ -665,39 +692,51 @@ class AcquireFoodTree(MoveToTree):
                                                                             ),
                                                                         ]
                                                                     ),
-                                                                    value=SetParameters.Response(),  # Unused
-                                                                    operator=set_parameter_response_all_success,
-                                                                )
-                                                            ],
-                                                        ),
-                                                        ServoMove(
-                                                            name="ExtractServo",
-                                                            ns=name,
-                                                            inputs={
-                                                                "twist": BlackboardKey(
-                                                                    "twist"
+                                                                    response_checks=[
+                                                                        py_trees.common.ComparisonExpression(
+                                                                            variable=Blackboard.separator.join(
+                                                                                [
+                                                                                    name,
+                                                                                    BlackboardKey(
+                                                                                        "ft_response"
+                                                                                    ),
+                                                                                ]
+                                                                            ),
+                                                                            value=SetParameters.Response(),  # Unused
+                                                                            operator=set_parameter_response_all_success,
+                                                                        )
+                                                                    ],
                                                                 ),
-                                                                "duration": BlackboardKey(
-                                                                    "duration"
+                                                                ServoMove(
+                                                                    name="ExtractServo",
+                                                                    ns=name,
+                                                                    inputs={
+                                                                        "twist": BlackboardKey(
+                                                                            "twist"
+                                                                        ),
+                                                                        "duration": BlackboardKey(
+                                                                            "duration"
+                                                                        ),
+                                                                        "pub_topic": "~/cartesian_twist_cmds",
+                                                                        "fail_near_collision": False,
+                                                                        "fail_on_collision": False,
+                                                                        "fail_on_singularity": False,
+                                                                    },
+                                                                ),  # Auto Zero-Twist on terminate()
+                                                                ft_thresh_satisfied(
+                                                                    name="CheckFTForkOffPlate"
                                                                 ),
-                                                                "pub_topic": "~/cartesian_twist_cmds",
-                                                                "fail_near_collision": False,
-                                                                "fail_on_collision": False,
-                                                                "fail_on_singularity": False,
-                                                            },
-                                                        ),  # Auto Zero-Twist on terminate()
-                                                        ft_thresh_satisfied(
-                                                            name="CheckFTForkOffPlate"
-                                                        ),
-                                                    ],  # End InFoodGraspExtract.children
-                                                ),  # End InFoodGraspExtract
-                                                recovery_tree,
-                                            ],  # End InFoodErrorSelector.children
-                                        ),  # End InFoodErrorSelector
-                                    ],  # End MoveIt2Servo.workers
-                                ),  # End MoveIt2Servo
-                            ],  # End SafeFTPreempt.workers
-                        ),  # End SafeFTPreempt
+                                                            ],  # End InFoodGraspExtract.children
+                                                        ),  # End InFoodGraspExtract
+                                                        recovery_tree,
+                                                    ],  # End InFoodErrorSelector.children
+                                                ),  # End InFoodErrorSelector
+                                            ],  # End MoveIt2Servo.workers
+                                        ),  # End MoveIt2Servo
+                                    ],  # End SafeFTPreempt.workers
+                                ),  # End SafeFTPreempt
+                            ],  # End OctomapCollision.workers
+                        ),  # OctomapCollision
                     ]
                     + resting_position_behaviors,  # End TableCollision.workers
                 ),  # End TableCollision


### PR DESCRIPTION
1. Change `compute_food_frame` to use the median depth around the center of the mask, instead of the median depth across the whole mask (which is what is contained in `Mask.msg`). This is because if the mask is a large blob (e.g., burrito bowl), the depth might not be consistent across the whole blob, so the median depth across the whole mask may be off (e.g., if the edges of the mask are higher than the center).
2. Re-enable Octomap for the motion to the Resting Configuration.