### PR TITLE
Infra TODOs from 1/22-1/24 User Studies

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/moveit2/__init__.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/__init__.py
@@ -7,6 +7,7 @@ from .moveit2_execute import MoveIt2Execute
 from .moveit2_constraints import (
     MoveIt2JointConstraint,
     MoveIt2PositionConstraint,
+    MoveIt2PositionOffsetConstraint,
     MoveIt2OrientationConstraint,
     MoveIt2PoseConstraint,
 )

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_constraints.py
@@ -17,13 +17,18 @@ from geometry_msgs.msg import (
     Point,
     QuaternionStamped,
     Quaternion,
+    Vector3Stamped,
+    Vector3,
 )
+import numpy as np
 from overrides import override
 import py_trees
+import rclpy
+import ros2_numpy
 
 # Local imports
 from ada_feeding.behaviors.moveit2.moveit2_plan import MoveIt2ConstraintType
-from ada_feeding.helpers import BlackboardKey
+from ada_feeding.helpers import BlackboardKey, get_tf_object, get_moveit2_object
 from ada_feeding.behaviors import BlackboardBehavior
 
 
@@ -105,6 +110,186 @@ class MoveIt2JointConstraint(BlackboardBehavior):
             {
                 "joint_positions": self.blackboard_get("joint_positions"),
                 "joint_names": self.blackboard_get("joint_names"),
+                "tolerance": self.blackboard_get("tolerance"),
+                "weight": self.blackboard_get("weight"),
+            },
+        )
+
+        constraints = self.blackboard_get("constraints")
+        if constraints is None:
+            constraints = []
+        else:
+            constraints = constraints.copy()
+        constraints.append(constraint)
+        self.blackboard_set("constraints", constraints)
+        return py_trees.common.Status.SUCCESS
+
+
+class MoveIt2PositionOffsetConstraint(BlackboardBehavior):
+    """
+    Adds Position Offset Constraint to Blackboard Dictionary
+    Similar to Position Constraint + current position of target_link
+    See pymoveit2:set_position_goal() for more info
+    """
+
+    # pylint: disable=arguments-differ
+    # We *intentionally* violate Liskov Substitution Princple
+    # in that blackboard config (inputs + outputs) are not
+    # meant to be called in a generic setting.
+
+    # pylint: disable=too-many-arguments
+    # These are effectively config definitions
+    # They require a lot of arguments.
+
+    def blackboard_inputs(
+        self,
+        offset: Union[
+            BlackboardKey, Union[Vector3Stamped, Vector3, Tuple[float, float, float]]
+        ],
+        frame_id: Union[BlackboardKey, Optional[str]] = None,
+        target_link: Union[BlackboardKey, Optional[str]] = None,
+        tolerance: Union[BlackboardKey, float] = 0.001,
+        weight: Union[BlackboardKey, float] = 1.0,
+        constraints: Union[
+            BlackboardKey, Optional[List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+        ] = None,
+    ) -> None:
+        """
+        Blackboard Inputs
+
+        Docstring copied from set_position_goal():
+        Set Cartesian position goal of `target_link` with respect to `frame_id`.
+          - `frame_id` defaults to the base link
+          - `target_link` defaults to end effector
+
+        Position goal == offset + position of target_link in frame_id
+
+        Note: if position is Vector3Stamped,
+              use position.header.frame_id for frame_id (if not "")
+
+        Parameters
+        ----------
+        constraints: previous set of constraints to append to
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_inputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    def blackboard_outputs(
+        self,
+        constraints: Optional[
+            BlackboardKey
+        ],  # List[Tuple[MoveIt2ConstraintType, Dict[str, Any]]]]
+    ) -> None:
+        """
+        Blackboard Outputs
+        By convention (to avoid collisions), avoid non-None default arguments.
+
+        Parameters
+        ----------
+        constraints: list of constraints to send to MoveIt2Plan
+        """
+        # pylint: disable=unused-argument, duplicate-code
+        # Arguments are handled generically in base class.
+        super().blackboard_outputs(
+            **{key: value for key, value in locals().items() if key != "self"}
+        )
+
+    @override
+    def setup(self, **kwargs):
+        # Docstring copied from @override
+
+        # pylint: disable=attribute-defined-outside-init
+        # It is okay for attributes in behaviors to be
+        # defined in the setup / initialise functions.
+
+        # Get Node from Kwargs
+        self.node = kwargs["node"]
+
+        # Get the MoveIt2 object, don't need lock (const read only)
+        self.moveit2, _ = get_moveit2_object(
+            self.blackboard,
+            self.node,
+        )
+
+        # Get TF Listener from blackboard
+        self.tf_buffer, _, self.tf_lock = get_tf_object(self.blackboard, self.node)
+
+    @override
+    def update(self) -> py_trees.common.Status:
+        # Docstring copied from @override
+
+        if not self.blackboard_exists(
+            [
+                "offset",
+                "frame_id",
+                "target_link",
+                "tolerance",
+                "weight",
+                "constraints",
+            ]
+        ):
+            self.logger.error(
+                "MoveIt2PositionOffsetConstraint: Missing input arguments."
+            )
+            self.logger.error(str(self.blackboard))
+            return py_trees.common.Status.FAILURE
+
+        if self.tf_lock.locked():
+            return py_trees.common.Status.RUNNING
+
+        offset = self.blackboard_get("offset")
+        frame_id = (
+            offset.header.frame_id
+            if (isinstance(offset, Vector3Stamped) and len(offset.header.frame_id) > 0)
+            else self.moveit2.base_link_name
+            if self.blackboard_get("frame_id") is None
+            else self.blackboard_get("frame_id")
+        )
+        target_link = (
+            self.moveit2.end_effector_name
+            if self.blackboard_get("target_link") is None
+            else self.blackboard_get("target_link")
+        )
+
+        # Get current position
+        transform = None
+        with self.tf_lock:
+            # Check if we have the target relative to base
+            if not self.tf_buffer.can_transform(
+                frame_id,
+                target_link,
+                rclpy.time.Time(),
+            ):
+                # Not yet, wait for it
+                # Use a Timeout decorator to determine failure.
+                self.logger.warning("PositionOffsetConstraint waiting on ee/base TF...")
+                return py_trees.common.Status.RUNNING
+            transform = self.tf_buffer.lookup_transform(
+                frame_id,
+                target_link,
+                rclpy.time.Time(),
+            )
+
+        offset_np = (
+            ros2_numpy.numpify(offset.vector)
+            if isinstance(offset, Vector3Stamped)
+            else ros2_numpy.numpify(offset)
+            if isinstance(offset, Vector3)
+            else np.array(offset)
+        )
+        offset_pos = ros2_numpy.msgify(
+            Point, ros2_numpy.numpify(transform.transform.translation) + offset_np
+        )
+
+        constraint = (
+            MoveIt2ConstraintType.POSITION,
+            {
+                "position": offset_pos,
+                "frame_id": frame_id,
+                "target_link": target_link,
                 "tolerance": self.blackboard_get("tolerance"),
                 "weight": self.blackboard_get("weight"),
             },
@@ -213,7 +398,9 @@ class MoveIt2PositionConstraint(BlackboardBehavior):
             {
                 "position": position.point
                 if isinstance(position, PointStamped)
-                else position,
+                else position
+                if isinstance(position, Point)
+                else ros2_numpy.msgify(Point, np.array(position)),
                 "frame_id": position.header.frame_id
                 if (
                     isinstance(position, PointStamped)
@@ -336,7 +523,9 @@ class MoveIt2OrientationConstraint(BlackboardBehavior):
             {
                 "quat_xyzw": quat_xyzw.quaternion
                 if isinstance(quat_xyzw, QuaternionStamped)
-                else quat_xyzw,
+                else quat_xyzw
+                if isinstance(quat_xyzw, Quaternion)
+                else ros2_numpy.msgify(Quaternion, np.array(quat_xyzw)),
                 "frame_id": quat_xyzw.header.frame_id
                 if (
                     isinstance(quat_xyzw, QuaternionStamped)

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -140,7 +140,7 @@ class MoveIt2Plan(BlackboardBehavior):
             trajectory in joint space. This is useful for debugging, but should
             be disabled in production.
         max_path_len: Maximum distance in configuration space of trajectory
-            (likely radians). Default 6.0 * pi (i.e. 180 degrees ea for a 6DOF robot)
+            (likely radians). Default sqrt(6.0 * pi) (i.e. 180 degrees each for a 6DOF robot)
         max_path_len_joint: Maximum distance each joint (or subset of joints)
             is allowed to travel. As dictionary: <joint_name> -> <max_distance>
         """
@@ -503,7 +503,7 @@ class MoveIt2Plan(BlackboardBehavior):
             curr_pos = np.array(point.positions)
             seg_len = np.abs(curr_pos - prev_pos)
             total_len += np.linalg.norm(seg_len)
-            for index, name in path.joint_names:
+            for index, name in enumerate(path.joint_names):
                 joint_lens[name] += seg_len[index]
             prev_pos = curr_pos
 

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -103,7 +103,7 @@ class MoveIt2Plan(BlackboardBehavior):
             BlackboardKey, Optional[Union[JointState, List[float]]]
         ] = None,
         debug_trajectory_viz: Union[BlackboardKey, bool] = False,
-        max_path_len: Optional[Union[BlackboardKey, float]] = np.sqrt(6.0 * np.pi),
+        max_path_len: Optional[Union[BlackboardKey, float]] = 10.0, #np.sqrt(6.0) * np.pi,
         max_path_len_joint: Optional[Union[BlackboardKey, Dict[str, float]]] = None,
     ) -> None:
         """
@@ -283,6 +283,7 @@ class MoveIt2Plan(BlackboardBehavior):
                     self.blackboard_set("end_joint_state", end_joint_state)
                     # Check Path Length
                     total_len, joint_len = MoveIt2Plan.get_path_len(traj)
+                    self.logger.warning(f"Path Length of Plan: {total_len}")
                     if (
                         self.blackboard_exists("max_path_len")
                         and self.blackboard_get("max_path_len") is not None

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -139,9 +139,9 @@ class MoveIt2Plan(BlackboardBehavior):
         debug_trajectory_viz: Whether to generate and save a visualization of the
             trajectory in joint space. This is useful for debugging, but should
             be disabled in production.
-        max_path_len: Maximum distance in configuration space of trajectory 
+        max_path_len: Maximum distance in configuration space of trajectory
             (likely radians). Default 6.0 * pi (i.e. 180 degrees ea for a 6DOF robot)
-        max_path_len_joint: Maximum distance each joint (or subset of joints) 
+        max_path_len_joint: Maximum distance each joint (or subset of joints)
             is allowed to travel. As dictionary: <joint_name> -> <max_distance>
         """
         # TODO: consider cartesian parameter struct

--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -44,6 +44,20 @@ class MoveIt2ConstraintType(Enum):
     ORIENTATION = 2
 
 
+class MoveIt2PlanErrorCode(Enum):
+    """
+    Used to clarify reason for failure
+    """
+
+    SUCCESS = 0
+    PLANNING = 1
+    BAD_GOAL = 2
+    BAD_PATH = 3
+    INVALID_START = 4
+    PATH_LEN = 5
+    PATH_LEN_JOINT = 6
+
+
 class MoveIt2Plan(BlackboardBehavior):
     """
     Runs moveit2.py plan_async with the provided
@@ -63,6 +77,9 @@ class MoveIt2Plan(BlackboardBehavior):
     # pylint: disable=too-many-arguments
     # These are effectively config definitions
     # They require a lot of arguments.
+
+    # pylint: disable=too-many-locals
+    # Update function is long
 
     def blackboard_inputs(
         self,
@@ -86,6 +103,8 @@ class MoveIt2Plan(BlackboardBehavior):
             BlackboardKey, Optional[Union[JointState, List[float]]]
         ] = None,
         debug_trajectory_viz: Union[BlackboardKey, bool] = False,
+        max_path_len: Optional[Union[BlackboardKey, float]] = np.sqrt(6.0 * np.pi),
+        max_path_len_joint: Optional[Union[BlackboardKey, Dict[str, float]]] = None,
     ) -> None:
         """
         Blackboard Inputs
@@ -120,6 +139,10 @@ class MoveIt2Plan(BlackboardBehavior):
         debug_trajectory_viz: Whether to generate and save a visualization of the
             trajectory in joint space. This is useful for debugging, but should
             be disabled in production.
+        max_path_len: Maximum distance in configuration space of trajectory 
+            (likely radians). Default 6.0 * pi (i.e. 180 degrees ea for a 6DOF robot)
+        max_path_len_joint: Maximum distance each joint (or subset of joints) 
+            is allowed to travel. As dictionary: <joint_name> -> <max_distance>
         """
         # TODO: consider cartesian parameter struct
         # pylint: disable=unused-argument, duplicate-code
@@ -132,6 +155,7 @@ class MoveIt2Plan(BlackboardBehavior):
         self,
         trajectory: Optional[BlackboardKey],  # Optional[JointTrajectory]
         end_joint_state: Optional[BlackboardKey] = None,  # Optional[JointState]
+        error_code: Optional[BlackboardKey] = None,  # Optional[MoveIt2PlanErrorCodes]
     ) -> None:
         """
         Blackboard Outputs
@@ -143,6 +167,7 @@ class MoveIt2Plan(BlackboardBehavior):
                                       or goal is already satisfied
         end_joint_state (JointState): get the last joint state of the planned trajectoy,
                                       useful for chaining planning calls
+        error_code (MoveIt2PlanErrorCode): Reason for planning failure.
         """
         # pylint: disable=unused-argument, duplicate-code
         # Arguments are handled generically in base class.
@@ -210,6 +235,8 @@ class MoveIt2Plan(BlackboardBehavior):
         # All raised exceptions map to a return statement.
         # This is the main function, it is okay for it to be long.
 
+        self.blackboard_set("error_code", MoveIt2PlanErrorCode.SUCCESS)
+
         # Lock MoveIt2 Object
         if self.moveit2_lock.locked():
             return py_trees.common.Status.RUNNING
@@ -231,6 +258,7 @@ class MoveIt2Plan(BlackboardBehavior):
                         self.logger.error(
                             f"{self.name} [MoveIt2Plan::update()] Planning Failure!"
                         )
+                        self.blackboard_set("error_code", MoveIt2PlanErrorCode.PLANNING)
                         return py_trees.common.Status.FAILURE
 
                     # MoveIt's default cartesian interpolator doesn't respect velocity
@@ -245,7 +273,7 @@ class MoveIt2Plan(BlackboardBehavior):
                     if self.blackboard_get("debug_trajectory_viz"):
                         MoveIt2Plan.visualize_trajectory(self.name, traj)
 
-                    # Write blackboard outputs and SUCCEED
+                    # Write blackboard outputs
                     self.blackboard_set("trajectory", traj)
                     end_joint_state = JointState()
                     end_joint_state.name = traj.joint_names[:]
@@ -253,6 +281,43 @@ class MoveIt2Plan(BlackboardBehavior):
                     end_joint_state.velocity = traj.points[-1].velocities[:]
                     end_joint_state.effort = traj.points[-1].effort[:]
                     self.blackboard_set("end_joint_state", end_joint_state)
+                    # Check Path Length
+                    total_len, joint_len = MoveIt2Plan.get_path_len(traj)
+                    if (
+                        self.blackboard_exists("max_path_len")
+                        and self.blackboard_get("max_path_len") is not None
+                    ):
+                        max_path_len = self.blackboard_get("max_path_len")
+                        if total_len > max_path_len:
+                            self.logger.error(
+                                f"Path length check (total): {total_len} > {max_path_len}"
+                            )
+                            self.blackboard_set(
+                                "error_code", MoveIt2PlanErrorCode.PATH_LEN
+                            )
+                            return py_trees.common.Status.FAILURE
+                    if (
+                        self.blackboard_exists("max_path_len_joint")
+                        and self.blackboard_get("max_path_len_joint") is not None
+                    ):
+                        for name, value in self.blackboard_get(
+                            "max_path_len_joint"
+                        ).items():
+                            if name not in joint_len:
+                                self.logger.warning(
+                                    f"Path length check: joint {name} not in trajectory"
+                                )
+                                continue
+                            if joint_len[name] > value:
+                                self.logger.error(
+                                    f"Path length check ({name}): {joint_len[name]} > {value}"
+                                )
+                                self.blackboard_set(
+                                    "error_code", MoveIt2PlanErrorCode.PATH_LEN_JOINT
+                                )
+                            return py_trees.common.Status.FAILURE
+
+                    # All checks passed
                     return py_trees.common.Status.SUCCESS
                 # Planning goal still running
                 return py_trees.common.Status.RUNNING
@@ -304,6 +369,7 @@ class MoveIt2Plan(BlackboardBehavior):
                     self.logger.error(
                         f"Malformed Goal Constraint: {constraint_kwargs}; Error: {error}"
                     )
+                    self.blackboard_set("error_code", MoveIt2PlanErrorCode.BAD_GOAL)
                     return py_trees.common.Status.FAILURE
 
             # If all goals are satisfied, return SUCCESS, no planning necessary
@@ -373,6 +439,7 @@ class MoveIt2Plan(BlackboardBehavior):
                         self.logger.error(
                             f"Malformed Path Constraint: {constraint_kwargs}"
                         )
+                        self.blackboard_set("error_code", MoveIt2PlanErrorCode.BAD_PATH)
                         return py_trees.common.Status.FAILURE
 
                 # If any path constraints are unsatisfied, return FAILURE
@@ -384,6 +451,9 @@ class MoveIt2Plan(BlackboardBehavior):
                     if not paths_satisfied:
                         self.blackboard_set("end_joint_state", None)
                         self.blackboard_set("trajectory", None)
+                        self.blackboard_set(
+                            "error_code", MoveIt2PlanErrorCode.INVALID_START
+                        )
                         return py_trees.common.Status.FAILURE
 
             ### Begin Planning
@@ -404,6 +474,40 @@ class MoveIt2Plan(BlackboardBehavior):
         with self.moveit2_lock:
             self.moveit2.clear_goal_constraints()
             self.moveit2.clear_path_constraints()
+
+    @staticmethod
+    def get_path_len(path: JointTrajectory) -> Tuple[float, Dict[str, float]]:
+        """
+        Get the integrated path length of a trajectory in trajectory units.
+
+        Uses only the position component of waypoints.
+
+        Note: assumes joint values are in R1 (i.e. no wrap-around)
+
+        Returns:
+        * length of the path in joint config space
+        * Dict: joint_name -> distance that joint travels
+        """
+
+        total_len = 0.0
+        joint_lens = {}
+        if path is None or len(path.joint_names) == 0:
+            return total_len, joint_lens
+        for name in path.joint_names:
+            joint_lens[name] = 0.0
+        if len(path.points) == 0:
+            return total_len, joint_lens
+
+        prev_pos = np.array(path.points[0].positions)
+        for point in path.points:
+            curr_pos = np.array(point.positions)
+            seg_len = np.abs(curr_pos - prev_pos)
+            total_len += np.linalg.norm(seg_len)
+            for index, name in path.joint_names:
+                joint_lens[name] += seg_len[index]
+            prev_pos = curr_pos
+
+        return total_len, joint_lens
 
     def transform_goal_to_base_link(self, constraint_kwargs: Dict[str, Any]) -> None:
         """

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -32,6 +32,7 @@ from ada_feeding.behaviors.acquisition import (
 from ada_feeding.behaviors.moveit2 import (
     MoveIt2JointConstraint,
     MoveIt2PoseConstraint,
+    MoveIt2PositionOffsetConstraint,
     MoveIt2Plan,
     MoveIt2Execute,
     ServoMove,
@@ -190,6 +191,16 @@ class AcquireFoodTree(MoveToTree):
                     f_mag=50.0,
                     param_service_name="~/set_servo_controller_parameters",
                 ),
+                # Clear Octomap
+                py_trees_ros.service_clients.FromConstant(
+                    name="ClearOctomap",
+                    service_name="/clear_octomap",
+                    service_type=Empty,
+                    service_request=Empty.Request(),
+                    # Default fail if service is down
+                    wait_for_server_timeout_sec=0.0,
+                ),
+                # Recovery Attempts
                 py_trees.composites.Selector(
                     name="RecoverySelector",
                     memory=True,
@@ -219,7 +230,52 @@ class AcquireFoodTree(MoveToTree):
                                 ],
                             ),
                         ),  # End Attempt 1: RecoveryServoRetry
-                        # TODO: Add other Recovery Attempts Here
+                        py_trees.composites.Sequence(
+                            name="RecoveryCartesianSequence",
+                            memory=True,
+                            children=[
+                                pre_moveto_config(
+                                    name="MaxFTRecoveryCartesian",
+                                    re_tare=False,
+                                    f_mag=50.0,
+                                ),  # Protected by scoped FTThresh in AcquireTree
+                                MoveIt2PositionOffsetConstraint(
+                                    name="RecoveryOffsetPose",
+                                    ns=name,
+                                    inputs={
+                                        "offset": Vector3(x=0.0, y=0.0, z=0.01),
+                                        # Default end effector link
+                                        # Default base link frame
+                                    },
+                                    outputs={
+                                        "constraints": BlackboardKey(
+                                            "goal_constraints"
+                                        ),
+                                    },
+                                ),
+                                MoveIt2Plan(
+                                    name="RecoveryOffsetPlan",
+                                    ns=name,
+                                    inputs={
+                                        "goal_constraints": BlackboardKey(
+                                            "goal_constraints"
+                                        ),
+                                        "max_velocity_scale": self.max_velocity_scaling_move_into,
+                                        "max_acceleration_scale": self.max_acceleration_scaling_move_into,
+                                        "cartesian": True,
+                                        "cartesian_max_step": 0.001,
+                                        "cartesian_fraction_threshold": 0.95,
+                                    },
+                                    outputs={"trajectory": BlackboardKey("trajectory")},
+                                ),
+                                MoveIt2Execute(
+                                    name="RecoveryOffset",
+                                    ns=name,
+                                    inputs={"trajectory": BlackboardKey("trajectory")},
+                                    outputs={},
+                                ),
+                            ],
+                        ),  # End Attempt 2: MoveIt2 Cartesian Planner
                     ],  # End RecoverySelector.children
                 ),  # End RecoverySelector
             ],  # End RecoverySequence.children

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -356,7 +356,7 @@ class AcquireFoodTree(MoveToTree):
                             "cartesian_fraction_threshold": 0.95,
                             "start_joint_state": BlackboardKey("test_into_joints"),
                         },
-                        outputs={"trajectory": None},
+                        outputs={"trajectory": BlackboardKey("move_into_trajectory")},
                     ),
                 ],
             )
@@ -502,24 +502,30 @@ class AcquireFoodTree(MoveToTree):
                                                 ),
                                             },
                                         ),
-                                        MoveIt2Plan(
-                                            name="MoveIntoPlan",
-                                            ns=name,
-                                            inputs={
-                                                "goal_constraints": BlackboardKey(
-                                                    "goal_constraints"
-                                                ),
-                                                "max_velocity_scale": self.max_velocity_scaling_move_into,
-                                                "max_acceleration_scale": self.max_acceleration_scaling_move_into,
-                                                "cartesian": True,
-                                                "cartesian_max_step": 0.001,
-                                                "cartesian_fraction_threshold": 0.95,
-                                            },
-                                            outputs={
-                                                "trajectory": BlackboardKey(
-                                                    "trajectory"
-                                                )
-                                            },
+                                        # If this fails
+                                        # Auto-fallback to precomputed MoveInto
+                                        # From move_above_plan()
+                                        py_trees.decorators.FailureIsSuccess(
+                                            name="MoveIntoPlanFallbackPrecomputed",
+                                            child=MoveIt2Plan(
+                                                name="MoveIntoPlan",
+                                                ns=name,
+                                                inputs={
+                                                    "goal_constraints": BlackboardKey(
+                                                        "goal_constraints"
+                                                    ),
+                                                    "max_velocity_scale": self.max_velocity_scaling_move_into,
+                                                    "max_acceleration_scale": self.max_acceleration_scaling_move_into,
+                                                    "cartesian": True,
+                                                    "cartesian_max_step": 0.001,
+                                                    "cartesian_fraction_threshold": 0.95,
+                                                },
+                                                outputs={
+                                                    "trajectory": BlackboardKey(
+                                                        "move_into_trajectory"
+                                                    )
+                                                },
+                                            ),
                                         ),
                                         # MoveInto expect F/T failure
                                         py_trees.decorators.FailureIsSuccess(
@@ -529,7 +535,7 @@ class AcquireFoodTree(MoveToTree):
                                                 ns=name,
                                                 inputs={
                                                     "trajectory": BlackboardKey(
-                                                        "trajectory"
+                                                        "move_into_trajectory"
                                                     )
                                                 },
                                                 outputs={},

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -264,7 +264,7 @@ class AcquireFoodTree(MoveToTree):
                                         "max_acceleration_scale": self.max_acceleration_scaling_move_into,
                                         "cartesian": True,
                                         "cartesian_max_step": 0.001,
-                                        "cartesian_fraction_threshold": 0.95,
+                                        "cartesian_fraction_threshold": 0.92,
                                     },
                                     outputs={"trajectory": BlackboardKey("trajectory")},
                                 ),
@@ -409,7 +409,7 @@ class AcquireFoodTree(MoveToTree):
                             "max_acceleration_scale": self.max_acceleration_scaling_move_into,
                             "cartesian": True,
                             "cartesian_max_step": 0.001,
-                            "cartesian_fraction_threshold": 0.95,
+                            "cartesian_fraction_threshold": 0.92,
                             "start_joint_state": BlackboardKey("test_into_joints"),
                         },
                         outputs={"trajectory": BlackboardKey("move_into_trajectory")},
@@ -574,7 +574,7 @@ class AcquireFoodTree(MoveToTree):
                                                     "max_acceleration_scale": self.max_acceleration_scaling_move_into,
                                                     "cartesian": True,
                                                     "cartesian_max_step": 0.001,
-                                                    "cartesian_fraction_threshold": 0.95,
+                                                    "cartesian_fraction_threshold": 0.92,
                                                 },
                                                 outputs={
                                                     "trajectory": BlackboardKey(

--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -75,19 +75,15 @@ class EStopCondition(WatchdogCondition):
         self.last_recv_data_time_lock = Lock()
         self.last_recv_data_time = None
         self.prev_data_arr = None
-        self.prev_data_arr_std = None
-        self.prev_data_arr_std_lock = Lock()
         self.prev_button_click_start_time = None
         self.num_clicks = 0
         self.num_clicks_lock = Lock()
         self.is_mic_unplugged = False
         self.is_mic_unplugged_lock = Lock()
 
-        # Initialize STD EMA
-        # TODO: Make these parameters to pass in
-        self.std_ema = 2.0
-        self.std_ema_alpha = 0.1
-        self.std_thresh = 0.95
+        # Initialize STD Exponential Moving Average
+        self.std_ema = None
+        self.std_ema_lock = Lock()
 
         # Start listening for ACPI events on a separate thread
         self.acpi_thread = Thread(target=self.__acpi_listener, daemon=True)
@@ -105,6 +101,9 @@ class EStopCondition(WatchdogCondition):
         """
         Load the parameters for this watchdog condition.
         """
+
+        # pylint: disable=too-many-locals
+
         rate = self._node.declare_parameter(
             "rate",
             48000,
@@ -315,6 +314,65 @@ class EStopCondition(WatchdogCondition):
             "amixer_mic_control_names": amixer_mic_control_names.value,
             "amixer_mic_control_percentages": amixer_mic_control_percentages.value,
         }
+
+        std_ema_min_thresh = self._node.declare_parameter(
+            "std_ema_min_thresh",
+            5.0,
+            ParameterDescriptor(
+                name="std_ema_min_thresh",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "If the exponential moving average of the standard deviation of microphone "
+                    "readings is less than this value, fail the e-stop condition"
+                ),
+                read_only=True,
+            ),
+        )
+        self.std_ema_min_thresh = std_ema_min_thresh.value
+
+        std_ema_max_thresh = self._node.declare_parameter(
+            "std_ema_max_thresh",
+            15.0,
+            ParameterDescriptor(
+                name="std_ema_max_thresh",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "If the exponential moving average of the standard deviation of microphone "
+                    "readings is lmoreess than this value, fail the e-stop condition"
+                ),
+                read_only=True,
+            ),
+        )
+        self.std_ema_max_thresh = std_ema_max_thresh.value
+
+        std_ema_alpha = self._node.declare_parameter(
+            "std_ema_alpha",
+            0.5,
+            ParameterDescriptor(
+                name="std_ema_alpha",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "The alpha value to use when computing the exponential moving average "
+                    "of the standard deviation. Should be in [0, 1]"
+                ),
+                read_only=True,
+            ),
+        )
+        self.std_ema_alpha = std_ema_alpha.value
+
+        num_secs_threshold = self._node.declare_parameter(
+            "num_secs_threshold",
+            1.0,
+            ParameterDescriptor(
+                name="num_secs_threshold",
+                type=ParameterType.PARAMETER_DOUBLE,
+                description=(
+                    "If the e-stop button has not sent data for these many secs, fail."
+                ),
+                read_only=True,
+            ),
+        )
+        self.num_secs_threshold = num_secs_threshold.value
 
     def __set_system_volume(self) -> None:
         """
@@ -578,8 +636,14 @@ class EStopCondition(WatchdogCondition):
 
         # Return the data
         self.prev_data_arr = data_arr
-        with self.prev_data_arr_std_lock:
-            self.prev_data_arr_std = np.std(self.prev_data_arr)
+        with self.std_ema_lock:
+            prev_data_arr_std = np.std(self.prev_data_arr)
+            if self.std_ema is None:
+                self.std_ema = prev_data_arr_std
+            else:
+                self.std_ema = self.std_ema * (
+                    self.std_ema_alpha
+                ) + prev_data_arr_std * (1.0 - self.std_ema_alpha)
         return (data, pyaudio.paContinue)
 
     def check_startup(self) -> List[Tuple[bool, str, str]]:
@@ -617,6 +681,14 @@ class EStopCondition(WatchdogCondition):
             status_2 = self.num_clicks > 0
         condition_2 = "E-stop button must be clicked at least once"
 
+        # Print the std_ema, which can help with debugging
+        if not (status_1 and status_2):
+            with self.std_ema_lock:
+                self._node.get_logger().warning(
+                    f"At least one e-stop startup condition failed. std_ema {self.std_ema}",
+                    throttle_duration_sec=1,
+                )
+
         return [(status_1, name_1, condition_1), (status_2, name_2, condition_2)]
 
     def check_status(self) -> List[Tuple[bool, str, str]]:
@@ -649,29 +721,36 @@ class EStopCondition(WatchdogCondition):
         condition_2 = f"E-stop button has {'not ' if status_2 else ''}been unplugged"
 
         name_3 = "E-Stop Button Streaming Data"
-        num_secs_threshold = 1.0
         with self.last_recv_data_time_lock:
             if self.last_recv_data_time is None:
                 status_3 = False
             else:
                 status_3 = (
                     self._node.get_clock().now() - self.last_recv_data_time
-                ).nanoseconds <= num_secs_threshold * 10**9.0
-        condition_3 = f"E-stop button has {'not ' if status_3 else ''}sent data for {num_secs_threshold} secs"
+                ).nanoseconds <= self.num_secs_threshold * 10**9.0
+        condition_3 = f"E-stop button has {'' if status_3 else 'not '}sent data within {self.num_secs_threshold} secs"
 
         name_4 = "E-Stop Standard Deviation"
-        with self.prev_data_arr_std_lock:
-            if self.prev_data_arr_std is None:
-                status_4 = None
+        with self.std_ema_lock:
+            if self.std_ema is None:
+                status_4 = False
             else:
-                if self.std_ema < self.std_thresh:
-                    status_4 = False
-                else:
-                    self.std_ema = self.std_ema * (
-                        self.std_ema_alpha
-                    ) + self.prev_data_arr_std * (1.0 - self.std_ema_alpha)
-                    status_4 = self.std_ema > self.std_thresh
-            condition_4 = f"E-stop button experienced small standard deviation ({self.std_ema} < {self.std_thresh})"
+                status_4 = (
+                    self.std_ema_min_thresh <= self.std_ema
+                    and self.std_ema <= self.std_ema_max_thresh
+                )
+            condition_4 = (
+                f"E-stop button's standard deviation {self.std_ema} is {'' if status_4 else 'not '}"
+                f"within expected range [{self.std_ema_min_thresh}, {self.std_ema_max_thresh}]"
+            )
+
+        # Print the std_ema, which can help with debugging
+        if not (status_1 and status_2 and status_3 and status_4):
+            with self.std_ema_lock:
+                self._node.get_logger().warning(
+                    f"At least one e-stop condition failed. std_ema {self.std_ema}",
+                    throttle_duration_sec=1,
+                )
 
         return [
             (status_1, name_1, condition_1),

--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -6,6 +6,7 @@ e-stop button either being clicked or being unplugged and fails if so.
 """
 
 # Standard imports
+import math
 import socket
 import subprocess
 from threading import Lock, Thread
@@ -317,7 +318,7 @@ class EStopCondition(WatchdogCondition):
 
         std_ema_min_thresh = self._node.declare_parameter(
             "std_ema_min_thresh",
-            5.0,
+            0.0,
             ParameterDescriptor(
                 name="std_ema_min_thresh",
                 type=ParameterType.PARAMETER_DOUBLE,
@@ -332,7 +333,7 @@ class EStopCondition(WatchdogCondition):
 
         std_ema_max_thresh = self._node.declare_parameter(
             "std_ema_max_thresh",
-            15.0,
+            math.inf,
             ParameterDescriptor(
                 name="std_ema_max_thresh",
                 type=ParameterType.PARAMETER_DOUBLE,

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -515,8 +515,8 @@ class CreateActionServers(Node):
             goal_uuid = "".join(format(x, "02x") for x in goal_handle.goal_id.uuid)
             self.get_logger().info(
                 f"{server_name}: "
-                f"Executing goal {goal_uuid} "
-                f"with request {goal_handle.request}"
+                f"Executing goal {goal_uuid}"
+                # f" with request {goal_handle.request}"
             )
 
             # pylint: disable=broad-exception-caught

--- a/ada_feeding_action_select/config/acquisition_library.yaml
+++ b/ada_feeding_action_select/config/acquisition_library.yaml
@@ -1,7 +1,7 @@
 # This file was modifed by modify_ac_library.py
 actions:
 - ext_angular:
-  - 0.0
+  - -0.4
   - 0.0
   - 0.0
   ext_duration: 1.0
@@ -26,7 +26,7 @@ actions:
   pre_offset:
   - 0.0
   - 0.0
-  - -0.02
+  - -0.025
   pre_pos:
   - 0.0
   - 0.0

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -101,6 +101,7 @@ class SegmentFromPointNode(Node):
         # NOTE: We assume this is in the same frame as the RGB image
         self.latest_depth_img_msg = None
         self.latest_depth_img_msg_lock = threading.Lock()
+        # TODO: make the min/max depth mm parameters
         self.min_depth_mm = 330
         self.max_depth_mm = 1500
         aligned_depth_topic = "~/aligned_depth"

--- a/start.py
+++ b/start.py
@@ -54,15 +54,35 @@ async def get_existing_screens():
     return existing_screens
 
 
-async def terminate_code_in_screen(screen_name: str) -> bool:
+async def execute_command(
+    screen_name: str, command: str, args: argparse.Namespace, indent: int = 8
+) -> None:
     """
-    Send Ctrl+C to the screen session.
+    Execute a command in a screen.
     """
-    proc = await asyncio.create_subprocess_shell(
-        f"screen -S {screen_name} -X stuff $'\003'"
+    global sudo_password
+    indentation = " " * indent
+    printable_command = command.replace("\003", "SIGINT")
+    print(f"# {indentation}`{printable_command}`")
+    await asyncio.create_subprocess_shell(
+        f"screen -S {screen_name} -X stuff '{command}\n'"
     )
-    await proc.communicate()
-    return proc.returncode == 0
+    await asyncio.sleep(args.launch_wait_secs)
+    if command.startswith("sudo"):
+        if sudo_password is None:
+            sudo_password = getpass.getpass(
+                prompt=f"# {indentation}Enter sudo password: "
+            )
+        await asyncio.create_subprocess_shell(
+            f"screen -S {screen_name} -X stuff '{sudo_password}\n'"
+        )
+        await asyncio.sleep(args.launch_wait_secs)
+    elif command.startswith("ssh"):
+        ssh_password = getpass.getpass(prompt=f"# {indentation}Enter ssh password: ")
+        await asyncio.create_subprocess_shell(
+            f"screen -S {screen_name} -X stuff '{ssh_password}\n'"
+        )
+        await asyncio.sleep(args.launch_wait_secs)
 
 
 async def main(args: argparse.Namespace, pwd: str) -> None:
@@ -103,7 +123,6 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
     )
 
     # Determine which screen sessions to start and what commands to run
-    sudo_password = None
     if args.sim:
         screen_sessions = {
             "web": [
@@ -141,6 +160,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
                 "node start_robot_browser.js",
             ],
         }
+        close_commands = {}
     else:
         screen_sessions = {
             "web": [
@@ -149,8 +169,8 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
             ],
             "webrtc": [
                 "cd ./src/feeding_web_interface/feedingwebapp",
-                "pm2 delete server",
                 "pm2 start server.js",
+                "pm2 log server",
             ],
             "camera": [
                 "ssh nano './run_camera.sh'",
@@ -177,12 +197,23 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
                 "node start_robot_browser.js --port=80",
             ],
         }
-    initial_commands = [
+        close_commands = {
+            "webrtc": [
+                "pm2 delete server",
+            ]
+        }
+    initial_close_commands = ["\003"]
+    initial_start_commands = [
         f"cd {pwd}",
         "source install/setup.bash",
     ]
     for screen_name, commands in screen_sessions.items():
-        screen_sessions[screen_name] = initial_commands + commands
+        screen_sessions[screen_name] = initial_start_commands + commands
+        if screen_name not in close_commands:
+            close_commands[screen_name] = []
+        close_commands[screen_name] = (
+            initial_close_commands + close_commands[screen_name]
+        )
 
     # Determine which screens are already running
     print("# Checking for existing screen sessions")
@@ -190,11 +221,9 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
     existing_screens = await get_existing_screens()
     for screen_name in screen_sessions:
         if screen_name in existing_screens:
-            print(f"#    Found session `{screen_name}`: ", end="")
-            await asyncio.create_subprocess_shell(
-                f"screen -S {screen_name} -X stuff $'\003'"
-            )
-            print("Sent SIGINT")
+            print(f"#    Found session `{screen_name}`: ")
+            for command in close_commands[screen_name]:
+                await execute_command(screen_name, command, args)
             terminated_screen = True
         elif not args.close:
             print(f"#    Creating session `{screen_name}`")
@@ -219,29 +248,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
         for screen_name, commands in screen_sessions.items():
             print(f"#     `{screen_name}`")
             for command in commands:
-                print(f"#         `{command}`")
-                await asyncio.create_subprocess_shell(
-                    f"screen -S {screen_name} -X stuff '{command}\n'"
-                )
-                await asyncio.sleep(args.launch_wait_secs)
-                if command.startswith("sudo"):
-                    if sudo_password is None:
-                        sudo_password = getpass.getpass(
-                            prompt="#         Enter sudo password: "
-                        )
-                    await asyncio.create_subprocess_shell(
-                        f"screen -S {screen_name} -X stuff '{sudo_password}\n'"
-                    )
-                    await asyncio.sleep(args.launch_wait_secs)
-                elif command.startswith("ssh"):
-                    ssh_password = getpass.getpass(
-                        prompt="#         Enter ssh password: "
-                    )
-                    await asyncio.create_subprocess_shell(
-                        f"screen -S {screen_name} -X stuff '{ssh_password}\n'"
-                    )
-                    await asyncio.sleep(args.launch_wait_secs)
-
+                await execute_command(screen_name, command, args)
         print(
             "################################################################################"
         )
@@ -307,6 +314,7 @@ if __name__ == "__main__":
     pwd = check_pwd_is_colcon_workspace()
 
     # Run the main function
+    sudo_password = None
     asyncio.run(main(args, pwd))
 
     # Return success

--- a/start.py
+++ b/start.py
@@ -149,7 +149,8 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
             ],
             "webrtc": [
                 "cd ./src/feeding_web_interface/feedingwebapp",
-                "node --env-file=.env server.js",
+                "pm2 delete server",
+                "pm2 start server.js",
             ],
             "camera": [
                 "ssh nano './run_camera.sh'",

--- a/start.py
+++ b/start.py
@@ -145,7 +145,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
             "republisher": [
                 (
                     "ros2 run ada_feeding_perception republisher --ros-args --params-file "
-                    "src/ada_feeding/ada_feeding_perception/config/republisher.yaml",
+                    "src/ada_feeding/ada_feeding_perception/config/republisher.yaml"
                 ),
             ],
             "rosbridge": [


### PR DESCRIPTION
# Description
1. Add a recovery behavior to raise 1cm if extraction fails.
    1. As part of this, added MoveIt2PositionOffsetConstraint
2. Reject path whose path length (L2 norm over the 6D trajectory) exceeds a threshold.
3. If MoveInto fails, auto-fallback to pre-computed MoveInto
4. Added a standard deviation condition for the e-stop (although we have disabled it, by setting min and max to [0, inf] since it was unreliable)
5. Make SegmentFromPoint only consider depth points within the expected range.
6. Make `start.py` launch the WebRTC signaling server within pm2, for auto-restart.

# Testing

Tested through the 1/22-1/24 user studies

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
