### PR TITLE
Centralize dependencies using `rosdep`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This README is the definitive source for downloading, installing, and running th
         rosdep install --from-paths src -y --ignore-src
 
 5. Install non-`rosdep` dependencies:
+    - Install SegmentAnything: `python3 -m pip install git+https://github.com/facebookresearch/segment-anything.git`
     - Upgrade `transforms3d`, since [the release on Ubuntu packages is outdated](https://github.com/matthew-brett/transforms3d/issues/65): `python3 -m pip install transforms3d -U`
     - [`pyrealsense2` is not released for ARM systems](https://github.com/IntelRealSense/librealsense/issues/6449#issuecomment-650784066), so ARM users will have to [build from source](https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/readme.md#building-from-source). You make have to add the `-DPYTHON_EXECUTABLE=/usr/bin/python3` flag to the `cmake` command. When running `sudo make install`, pay close attention to which path `pyrealsense2` is installed to and add *that path* to the `PYTHONPATH` -- it should be `/use/local/lib` but may be `/usr/local/OFF`.
 6. Install the JACO SDK (real robot only). All SDKs are listed [here](https://www.kinovarobotics.com/resources?r=79301&s); PRL currently uses the [Gen2 SDK v1.5.1](https://drive.google.com/file/d/1UEQAow0XLcVcPCeQfHK9ERBihOCclkJ9/view). Note that although the latest version of that SDK is for Ubuntu 16.04, it still works on Ubuntu 22.04 (only for x86 systems, not ARM system).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,120 @@
 # ada_feeding
 
-This repository contains all the code to run ADA's robot-asssited feeding system. Specifically, `ada_feeding_msgs` includes custom message definitions, `ada_feeding_perception` contains all the perception code, and `ada_feeding` contains all the other code (including the overall launchfile to run the robot-assisted feeding system).
+This README is the definitive source for downloading, installing, and running the Personal Robotics Lab's robot-assisted feeding software. This code has been run and tested on machines running **Ubuntu 22.04** and ROS2 Humble.
 
-See the README in each individual package for more information.
+## Setup
 
-## Launching Code
+### Setup (Robot Software)
 
-A convenience script is included in the top-level directory to load all the `screen` sessions with the appropriate code.
+1. [Install ROS2 Humble](https://docs.ros.org/en/humble/Installation.html), [configure your environment](https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html), and [create a workspace](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#).
+    1. **NOTE**: In the remainder of the instructions, replace `~\colcon_ws` with the path to your workspace.
+2. Configure [`pr-rosinstalls`](https://github.com/personalrobotics/pr-rosinstalls) in order to download all necessary repositories.
 
-To launch the real robot code, from the top-level of your colcon workspace, run `python3 src/ada_feeding/start.py`.
+        cd ~
+        git clone https://github.com/personalrobotics/pr-rosinstalls.git
 
-The script has various options: to see them, run `python3 src/ada_feeding/start.py -h`
+3. Pull all the repositories, with the correct branch. Replace `<https/ssh>` with one of the options, depending on your authentication method.
+
+        sudo apt install python3-wstool # if not already installed
+        cd ~/colcon_ws/src
+        wstool init
+        wstool merge ~/pr-rosinstalls/ada-feeding.<https/ssh>.rosinstall
+        wstool up
+
+4. Install [`rosdep`](https://docs.ros.org/en/humble/Tutorials/Intermediate/Rosdep.html) dependencies:
+
+        sudo apt install install python3-rosdep # if not already installed
+        sudo rosdep init # if this is the first time using rosdep
+        rosdep update
+        cd ~/colcon_ws
+        rosdep install --from-paths src -y --ignore-src
+
+5. Install non-`rosdep` dependencies:
+    - Upgrade `transforms3d`, since [the release on Ubuntu packages is outdated](https://github.com/matthew-brett/transforms3d/issues/65): `python3 -m pip install transforms3d -U`
+    - [`pyrealsense2` is not released for ARM systems](https://github.com/IntelRealSense/librealsense/issues/6449#issuecomment-650784066), so ARM users will have to [build from source](https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/readme.md#building-from-source). You make have to add the `-DPYTHON_EXECUTABLE=/usr/bin/python3` flag to the `cmake` command. When running `sudo make install`, pay close attention to which path `pyrealsense2` is installed to and add *that path* to the `PYTHONPATH` -- it should be `/use/local/lib` but may be `/usr/local/OFF`.
+6. Install the JACO SDK (real robot only). All SDKs are listed [here](https://www.kinovarobotics.com/resources?r=79301&s); PRL currently uses the [Gen2 SDK v1.5.1](https://drive.google.com/file/d/1UEQAow0XLcVcPCeQfHK9ERBihOCclkJ9/view). Note that although the latest version of that SDK is for Ubuntu 16.04, it still works on Ubuntu 22.04 (only for x86 systems, not ARM system).
+7. Build your workspace:
+
+        cd ~/colcon_ws
+        colcon build --symlink-install # if sim-only, add '--packages-skip ada_hardware'
+
+### Setup (Web App)
+
+1. Install the Node Version Manager (nvm): https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script
+2. Install and use NodeJS 21:
+
+        nvm install 21
+        nvm use 21
+
+3. Make Node available to all users, including root:
+
+        sudo ln -s "$NVM_DIR/versions/node/$(nvm version)/bin/node" "/usr/local/bin/node"
+        sudo ln -s "$NVM_DIR/versions/node/$(nvm version)/bin/npm" "/usr/local/bin/npm"
+        sudo ln -s "$NVM_DIR/versions/node/$(nvm version)/bin/npx" "/usr/local/bin/npx"
+
+4. Install `serve` and `pm2` globally. Root access is necessary for `serve` so it can access port 80.
+
+        sudo npm install -g serve
+        npm install -g pm2@latest
+
+5. Install the web app dependencies. (Note: there will be some vulnerabilities in dependencies. That is okay, since )
+
+        cd ~/colcon_ws/src/feeding_web_interface/feedingwebapp
+        npm install --legacy-peer-deps
+        npx playwright install
+
+6. (Optional; this should already be configured on PRL computers) To access the web app on a device other than the one hosting it, enable the desired port for HTTP access: https://www.digitalocean.com/community/tutorials/ufw-essentials-common-firewall-rules-and-commands#allow-all-incoming-http-port-80
+
+
+## Running the Software
+
+We use the convenience script `start.py` to launch the software. This script has several command-line arguements, which can be seen by passing the `-h` flag when running the script.
+
+### **Recommended** Option A: Run the Web App with the Real Robot
+
+This option starts the web app and the real robot code, and can be used to test the entire system. This will by default start the web app on port `80`, and requires `sudo` access.
+
+```
+cd ~/colcon_ws
+python3 src/ada_feeding/start.py
+```
+
+In a browser, access `127.0.0.1` (if on the same device serving the web app), or the IP address of the device hosting the web app (if on a different device connected to the same network). You should now be able to run the system! Note that upon startup, the watchdog is in a failing state until the e-stop is clicked exactly once, allowing the system to verify that it is connected and working.
+
+To close, run `python3 src/ada_feeding/start.py -c`
+
+
+### Option B: Running Web App With the Mock Robot
+
+This option starts the web app, runs dummy nodes for perception, runs the **real** robot motion code, but runs a mock robot in MoveIt. This is useful for testing robot motion code in simulation before moving onto the real robot. This will start the web app on port `3000` and does not require `sudo` access.
+
+**NOTE**: Before running `mock`, it is recommended to disable the Octomap by [changing the name of `default_sensor/image_topic` to a topic that is not published](https://github.com/personalrobotics/ada_ros2/blob/e5256bfc89c358cb71699c6be95e78bf846eed63/ada_moveit/config/sensors_3d.yaml#L7). Be sure to re-build after the change.
+
+```
+cd ~/colcon_ws
+python3 src/ada_feeding/start.py --sim mock
+```
+
+In a browser, access `127.0.0.1:3000` (if on the same device serving the web app), or the IP address of the device hosting the web app at port `3000` (if on a different device connected to the same network). You should now be able to run the system!
+
+To close, run `python3 src/ada_feeding/start.py --sim mock -c`
+
+### Option C: Running Web App With All Dummy Nodes
+
+This option starts the web app, and runs dummy nodes for all perception and robot motion code. This is useful to test the web app in isolation. This will start the web app on port `3000` and does not require `sudo` access.
+
+```
+cd ~/colcon_ws
+python3 src/ada_feeding/start.py --sim dummy
+```
+
+In a browser, access `127.0.0.1:3000` (if on the same device serving the web app), or the IP address of the device hosting the web app at port `3000` (if on a different device connected to the same network). You should now be able to run the system!
+
+To close, run `python3 src/ada_feeding/start.py --sim dummy -c`
+
+## Troubleshooting
+
+- **Something is not working, what do I do?**: All our code runs in `screen` sessions, so the first step is to attach to individual screen sessions to identify where the issue is. Run `screen -ls` to list all screens, run `screen -r <name>` to attach to a screen session, and `Ctrl-A d` to detach from the screen session. An introduction to `screen` can be found [here](https://astrobiomike.github.io/unix/screen-intro).
+- **The watchdog is not recognizing my initial e-stop click**: Verify the e-stop is plugged in, and that any other processes accessing the microphone (e.g., Sound Settings) are closed. Run `alsamixer` to see if your user account has access to it. If you do not see sound levels in the terminal, try `sudo alsamixer`. If that works, give your user account permission to access sound: `sudo setfacl -m u:$USER:rw /dev/snd/*`
+- **The watchdog is failing due to the F/T sensor**: First, check whether the force-torque sensor is publishing: `ros2 topic echo /wireless_ft/ftSensor1`. If not, the issue is in the `ft` screen (one potential issue is that the alias `ft-sensor` does not point to the right IP address for the force-torque sensor, in which case you should pass the IP address in using the `host` parameter). If so, check the timestamp of the published F/T messages compared to the current time. If it is off, the problem is that NTP got disabled on the force-torque sensor. You have to use `minicom` to re-enable NTP (see [here](https://github.com/personalrobotics/pr_docs/wiki/ADA) for PRL-specific instructions). 
+- **I get the error `cannot use destroyable because destruction was requested`**: Upgrade to the latest version of`rclpy`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ This README is the definitive source for downloading, installing, and running th
         wstool merge ~/pr-rosinstalls/ada-feeding.<https/ssh>.rosinstall
         wstool up
 
-4. Install [`rosdep`](https://docs.ros.org/en/humble/Tutorials/Intermediate/Rosdep.html) dependencies:
+4. Configure [`rosdep`](https://docs.ros.org/en/humble/Tutorials/Intermediate/Rosdep.html):
+
+        sudo apt install install python3-rosdep # if not already installed
+        sudo rosdep init # if this is the first time using rosdep
+
+5. (Temporary until [PR1](https://github.com/ros/rosdistro/pull/39905) and [PR2](https://github.com/ros/rosdistro/pull/39906) are merged in): Add the following two lines to `/etc/ros/rosdep/sources.list.d/*-default.list`:
+
+        yaml https://raw.githubusercontent.com/amalnanavati/rosdistro/patch-1/rosdep/python.yaml
+        yaml https://raw.githubusercontent.com/amalnanavati/rosdistro/skspatial/rosdep/python.yaml
+
+6. Install [`rosdep`](https://docs.ros.org/en/humble/Tutorials/Intermediate/Rosdep.html) dependencies:
 
         sudo apt install install python3-rosdep # if not already installed
         sudo rosdep init # if this is the first time using rosdep
@@ -29,12 +39,12 @@ This README is the definitive source for downloading, installing, and running th
         cd ~/colcon_ws
         rosdep install --from-paths src -y --ignore-src
 
-5. Install non-`rosdep` dependencies:
+7. Install non-`rosdep` dependencies:
     - Install SegmentAnything: `python3 -m pip install git+https://github.com/facebookresearch/segment-anything.git`
     - Upgrade `transforms3d`, since [the release on Ubuntu packages is outdated](https://github.com/matthew-brett/transforms3d/issues/65): `python3 -m pip install transforms3d -U`
     - [`pyrealsense2` is not released for ARM systems](https://github.com/IntelRealSense/librealsense/issues/6449#issuecomment-650784066), so ARM users will have to [build from source](https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/readme.md#building-from-source). You make have to add the `-DPYTHON_EXECUTABLE=/usr/bin/python3` flag to the `cmake` command. When running `sudo make install`, pay close attention to which path `pyrealsense2` is installed to and add *that path* to the `PYTHONPATH` -- it should be `/use/local/lib` but may be `/usr/local/OFF`.
-6. Install the JACO SDK (real robot only). All SDKs are listed [here](https://www.kinovarobotics.com/resources?r=79301&s); PRL currently uses the [Gen2 SDK v1.5.1](https://drive.google.com/file/d/1UEQAow0XLcVcPCeQfHK9ERBihOCclkJ9/view). Note that although the latest version of that SDK is for Ubuntu 16.04, it still works on Ubuntu 22.04 (only for x86 systems, not ARM system).
-7. Build your workspace:
+8. Install the JACO SDK (real robot only). All SDKs are listed [here](https://www.kinovarobotics.com/resources?r=79301&s); PRL currently uses the [Gen2 SDK v1.5.1](https://drive.google.com/file/d/1UEQAow0XLcVcPCeQfHK9ERBihOCclkJ9/view). Note that although the latest version of that SDK is for Ubuntu 16.04, it still works on Ubuntu 22.04 (only for x86 systems, not ARM system).
+9. Build your workspace:
 
         cd ~/colcon_ws
         colcon build --symlink-install # if sim-only, add '--packages-skip ada_hardware'

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -4,7 +4,7 @@ The `ada_feeding` package contains the overarching code to run the robot-assiste
 
 ## Setup
 
-See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md).
 
 ## Usage
 1. Build your workspace: `colcon build`

--- a/ada_feeding/README.md
+++ b/ada_feeding/README.md
@@ -2,16 +2,9 @@
 
 The `ada_feeding` package contains the overarching code to run the robot-assisted feeding system. This includes code to plan and execute motions on the robot, code to communicate with the app, and code that reasons over the results of perception. The only code this does not contain is the perception code.
 
-## Getting Started
+## Setup
 
-This code has been developed and tested with the Kinova JACO Gen2 Arm, on computers running Ubuntu 22.04. To get started:
-- Install [ROS2 Humble](https://docs.ros.org/en/humble/Installation.html)
-- Install Python dependencies: `python3 -m pip install overrides pyrealsense2 pyyaml py_trees pymongo transforms3d tornado trimesh scikit-spatial sounddevice`
-    - NOTE: [`pyrealsense2` is not released for ARM systems](https://github.com/IntelRealSense/librealsense/issues/6449#issuecomment-650784066), so ARM users will have to [build from source](https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/readme.md#building-from-source). When running `sudo make install`, pay close attention to which path `pyrealsense2` is installed to and add *that path* to the `PYTHONPATH` -- it should be `/use/local/lib` but may be `/usr/local/OFF`.
-- Install the code to command the real robot ([instructions here](https://github.com/personalrobotics/ada_ros2/blob/main/README.md))
-- Git clone the [PRL fork of pymoveit (branch: `amaln/scale_collision_meshes`)](https://github.com/personalrobotics/pymoveit2/tree/amaln/scale_collision_meshes), the [PRL fork of py_trees_ros (branch: `amaln/service_client`)](https://github.com/personalrobotics/py_trees_ros/tree/amaln/service_client), the [PRL fork of moveit2 (branch: `amaln/main`)](https://github.com/personalrobotics/moveit2/tree/amaln/main), and [ros2_numpy (branch: `humble`)](https://github.com/Box-Robotics/ros2_numpy) into your ROS2 workspace's `src` folder.
-- Install additional dependencies: `sudo apt install ros-humble-py-trees-ros-interfaces ros-humble-tf-transformations ros-humble-ament-cmake-nose`.
-- Install the web app into your workspace ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp)).
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
 
 ## Usage
 1. Build your workspace: `colcon build`

--- a/ada_feeding/package.xml
+++ b/ada_feeding/package.xml
@@ -14,18 +14,14 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
 
-  <exec_depend>rcl_interfaces</exec_depend>
-  <exec_depend>ros2launch</exec_depend>
-
   <exec_depend>moveit_msgs</exec_depend>
   <exec_depend>pymoveit2</exec_depend>
-
+  <exec_depend>python3-overrides</exec_depend>
+  <exec_depend>python-pyrealsense2-pip</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
+  <exec_depend>ros2_numpy</exec_depend>
   <exec_depend>std_srvs</exec_depend>
-
-  <!-- Extra Python Deps -->
-  <depend>pyrealsense2-pip</depend>
-  <depend>overrides-pip</depend>
-  <depend>ros2_numpy-pip</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ada_feeding/package.xml
+++ b/ada_feeding/package.xml
@@ -16,8 +16,9 @@
 
   <exec_depend>moveit_msgs</exec_depend>
   <exec_depend>pymoveit2</exec_depend>
-  <exec_depend>python3-overrides</exec_depend>
   <exec_depend>python-pyrealsense2-pip</exec_depend>
+  <exec_depend>python3-overrides</exec_depend>
+  <exec_depend>python3-sounddevice-pip</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_numpy</exec_depend>

--- a/ada_feeding/package.xml
+++ b/ada_feeding/package.xml
@@ -16,8 +16,10 @@
 
   <exec_depend>moveit_msgs</exec_depend>
   <exec_depend>pymoveit2</exec_depend>
+  <exec_depend>python3-pyaudio</exec_depend>
   <exec_depend>python-pyrealsense2-pip</exec_depend>
   <exec_depend>python3-overrides</exec_depend>
+  <exec_depend>python3-skimage</exec_depend>
   <exec_depend>python3-sounddevice-pip</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>ros2launch</exec_depend>

--- a/ada_feeding_action_select/package.xml
+++ b/ada_feeding_action_select/package.xml
@@ -11,6 +11,7 @@
   <depend>ada_feeding_msgs</depend>
 
   <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>python3-torch</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ada_feeding_action_select/package.xml
+++ b/ada_feeding_action_select/package.xml
@@ -10,6 +10,8 @@
   <depend>rclpy</depend>
   <depend>ada_feeding_msgs</depend>
 
+  <exec_depend>python3-yaml</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>

--- a/ada_feeding_perception/README.md
+++ b/ada_feeding_perception/README.md
@@ -3,7 +3,7 @@ This code performs image segmentation using the [Segment Anything](https://githu
 
 ## Setup
 
-See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md).
 
 For running SegmentAnything test scripts (below), be sure to unzip `test/food_img.zip`.
 

--- a/ada_feeding_perception/README.md
+++ b/ada_feeding_perception/README.md
@@ -1,18 +1,11 @@
 # Ada Feeding Perception
 This code performs image segmentation using the [Segment Anything](https://github.com/facebookresearch/segment-anything). It takes an input image and a point as input and generates masks for the regions of interest in the image.
 
-## Installation
-1. Clone this directory into the `src` folder of your ROS2 workspace.
-2. Install the Python dependencies:
-```
-source install.sh
-```
-3. Install the system dependencies:
-```
-sudo apt install ros-humble-image-transport ros-humble-compressed-image-transport
-```
+## Setup
 
-For testing, be sure to unzip `test/food_img.zip`.
+See the [`ada_feeding` top-level README for setup instructions](https://github.com/personalrobotics/ada_feeding/blob/amaln/rosdeps/README.md).
+
+For running SegmentAnything test scripts (below), be sure to unzip `test/food_img.zip`.
 
 ## Usage
 

--- a/ada_feeding_perception/install.sh
+++ b/ada_feeding_perception/install.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-python3 -m pip install git+https://github.com/facebookresearch/segment-anything.git
-python3 -m pip install -r requirements.txt

--- a/ada_feeding_perception/package.xml
+++ b/ada_feeding_perception/package.xml
@@ -11,7 +11,8 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>opencv-python</test_depend>
+
+  <exec_depend>python3-opencv</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ada_feeding_perception/package.xml
+++ b/ada_feeding_perception/package.xml
@@ -12,6 +12,9 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <exec_depend>compressed_image_transport</exec_depend>
+  <exec_depend>image_transport</exec_depend>
+  <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-opencv</exec_depend>

--- a/ada_feeding_perception/package.xml
+++ b/ada_feeding_perception/package.xml
@@ -13,6 +13,7 @@
   <test_depend>python3-pytest</test_depend>
 
   <exec_depend>python3-opencv</exec_depend>
+  <exec_depend>python3-scikit-spatial-pip</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ada_feeding_perception/package.xml
+++ b/ada_feeding_perception/package.xml
@@ -14,6 +14,7 @@
 
   <exec_depend>python3-opencv</exec_depend>
   <exec_depend>python3-scikit-spatial-pip</exec_depend>
+  <exec_depend>python3-shapely</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ada_feeding_perception/package.xml
+++ b/ada_feeding_perception/package.xml
@@ -12,9 +12,15 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <exec_depend>python3-matplotlib</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-opencv</exec_depend>
   <exec_depend>python3-scikit-spatial-pip</exec_depend>
+  <exec_depend>python3-scipy</exec_depend>
   <exec_depend>python3-shapely</exec_depend>
+  <exec_depend>python3-skimage</exec_depend>
+  <exec_depend>python3-torch</exec_depend>
+  <exec_depend>python3-torchvision</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ada_feeding_perception/requirements.txt
+++ b/ada_feeding_perception/requirements.txt
@@ -1,8 +1,0 @@
-numpy
-matplotlib
-opencv-python
-opencv-contrib-python
-scikit-image
-scipy
-torch
-torchvision

--- a/start.py
+++ b/start.py
@@ -11,11 +11,15 @@ import os
 import sys
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--sim", default="real", help=(
-    "`real`, `mock`, or `dummy` (default `real`). `real` executes all commands for running "
-    "the feeding code on the real robot, `mock` uses dummy perception and real motion code "
-    "with a simulated robot, and `dummy` uses dummy perception and motion code. All three "
-    "launch the web app."
+parser.add_argument(
+    "--sim",
+    default="real",
+    help=(
+        "`real`, `mock`, or `dummy` (default `real`). `real` executes all commands for running "
+        "the feeding code on the real robot, `mock` uses dummy perception and real motion code "
+        "with a simulated robot, and `dummy` uses dummy perception and motion code. All three "
+        "launch the web app."
+    ),
 )
 parser.add_argument(
     "-t",
@@ -114,21 +118,19 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
         print(
             "#     2. Your workspace should be built (e.g., `colcon build --symlink-install`)"
         )
-        if args.sim == 'real':
+        if args.sim == "real":
             print(
                 "#     3. The web app should be built (e.g., `npm run build` in "
                 "`./src/feeding_web_interface/feedingwebapp`)."
             )
     else:
-        print(
-            f"# Terminating the ada_feeding demo in **{ args.sim}**"
-        )
+        print(f"# Terminating the ada_feeding demo in **{ args.sim}**")
     print(
         "################################################################################"
     )
 
     # Determine which screen sessions to start and what commands to run
-    if args.sim == 'mock':
+    if args.sim == "mock":
         screen_sessions = {
             "web": [
                 "cd ./src/feeding_web_interface/feedingwebapp",
@@ -166,7 +168,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
             ],
         }
         close_commands = {}
-    elif args.sim == 'dummy':
+    elif args.sim == "dummy":
         screen_sessions = {
             "web": [
                 "cd ./src/feeding_web_interface/feedingwebapp",
@@ -303,7 +305,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
         print(
             "#     1. Check individual screens to verify code is working as expected."
         )
-        if args.sim == 'real':
+        if args.sim == "real":
             print("#     2. Push the e-stop button to enable the robot.")
             print("#     3. Note that this script starts the app on port 80.")
         else:
@@ -347,8 +349,10 @@ if __name__ == "__main__":
     # Get the arguments
     args = parser.parse_args()
     # Check args
-    if args.sim not in ['real', 'mock', 'dummy']:
-        raise ValueError(f"Unknown sim value {args.sim}. Must be one of ['real', 'mock', 'dummy'].")
+    if args.sim not in ["real", "mock", "dummy"]:
+        raise ValueError(
+            f"Unknown sim value {args.sim}. Must be one of ['real', 'mock', 'dummy']."
+        )
 
     # Ensure the script is not being run as sudo. Sudo has a different screen
     # server and may have different versions of libraries installed.

--- a/start.py
+++ b/start.py
@@ -11,7 +11,12 @@ import os
 import sys
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--sim", action="store_true", help="If set, run the code in sim")
+parser.add_argument("--sim", default="real", help=(
+    "`real`, `mock`, or `dummy` (default `real`). `real` executes all commands for running "
+    "the feeding code on the real robot, `mock` uses dummy perception and real motion code "
+    "with a simulated robot, and `dummy` uses dummy perception and motion code. All three "
+    "launch the web app."
+)
 parser.add_argument(
     "-t",
     "--termination_wait_secs",
@@ -103,27 +108,27 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
         "################################################################################"
     )
     if not args.close:
-        print(f"# Starting the ada_feeding demo in **{'sim' if args.sim else 'real'}**")
+        print(f"# Starting the ada_feeding demo in **{args.sim}**")
         print("# Prerequisites / Notes:")
         print("#     1. Be in the top-level of your colcon workspace")
         print(
             "#     2. Your workspace should be built (e.g., `colcon build --symlink-install`)"
         )
-        if not args.sim:
+        if args.sim == 'real':
             print(
                 "#     3. The web app should be built (e.g., `npm run build` in "
                 "`./src/feeding_web_interface/feedingwebapp`)."
             )
     else:
         print(
-            f"# Terminating the ada_feeding demo in **{'sim' if args.sim else 'real'}**"
+            f"# Terminating the ada_feeding demo in **{ args.sim}**"
         )
     print(
         "################################################################################"
     )
 
     # Determine which screen sessions to start and what commands to run
-    if args.sim:
+    if args.sim == 'mock':
         screen_sessions = {
             "web": [
                 "cd ./src/feeding_web_interface/feedingwebapp",
@@ -155,6 +160,47 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
                 "ros2 launch ada_feeding ada_feeding_launch.xml use_estop:=false"
             ],
             "moveit": ["ros2 launch ada_moveit demo.launch.py sim:=mock"],
+            "browser": [
+                "cd ./src/feeding_web_interface/feedingwebapp",
+                "node start_robot_browser.js",
+            ],
+        }
+        close_commands = {}
+    elif args.sim == 'dummy':
+        screen_sessions = {
+            "web": [
+                "cd ./src/feeding_web_interface/feedingwebapp",
+                "npm run start",
+            ],
+            "webrtc": [
+                "cd ./src/feeding_web_interface/feedingwebapp",
+                "node --env-file=.env server.js",
+            ],
+            "ft": [
+                "ros2 run ada_feeding dummy_ft_sensor.py",
+            ],
+            "perception": [
+                (
+                    "ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml "
+                    "run_motion:=false run_web_bridge:=false"
+                ),
+            ],
+            "republisher": [
+                (
+                    "ros2 run ada_feeding_perception republisher --ros-args --params-file "
+                    "src/ada_feeding/ada_feeding_perception/config/republisher.yaml"
+                ),
+            ],
+            "rosbridge": [
+                "ros2 launch rosbridge_server rosbridge_websocket_launch.xml"
+            ],
+            "feeding": [
+                (
+                    "ros2 launch feeding_web_app_ros2_test feeding_web_app_dummy_nodes_launch.xml "
+                    "run_web_bridge:=false run_food_detection:=false run_face_detection:=false "
+                    "run_real_sense:=false"
+                ),
+            ],
             "browser": [
                 "cd ./src/feeding_web_interface/feedingwebapp",
                 "node start_robot_browser.js",
@@ -257,7 +303,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
         print(
             "#     1. Check individual screens to verify code is working as expected."
         )
-        if not args.sim:
+        if args.sim == 'real':
             print("#     2. Push the e-stop button to enable the robot.")
             print("#     3. Note that this script starts the app on port 80.")
         else:
@@ -300,6 +346,9 @@ def check_pwd_is_colcon_workspace() -> str:
 if __name__ == "__main__":
     # Get the arguments
     args = parser.parse_args()
+    # Check args
+    if args.sim not in ['real', 'mock', 'dummy']:
+        raise ValueError(f"Unknown sim value {args.sim}. Must be one of ['real', 'mock', 'dummy'].")
 
     # Ensure the script is not being run as sudo. Sudo has a different screen
     # server and may have different versions of libraries installed.


### PR DESCRIPTION
## Description

Previously, dependencies were split across the `ada_feeding`, `ada_ros2`, and `feeding_web_interface` repositories, and further split across packages within those repositories.

This PR, paised with [`feeding_web_interface`#123](https://github.com/personalrobotics/feeding_web_interface/pull/123) and [`ada_ros2`#39](https://github.com/personalrobotics/ada_ros2/pull/39), centralize all the dependencies and setup instructions in the top-level of the `ada_feeding` repository.

## Testing

On a clean installation of Ubuntu 22.04, I followed the instructions in the top-level ada_feeding README step-by-step, and was succesfully able to run the robot in `--sim mock` and `--sim dummy`. I did not test with `real` since we don't have a clean installation of Ubuntu 22.04 on any of the computers that interact with the real robot.