### PR TITLE
SegmentFromPoint: Speed Up (EfficientSAM) & Return Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ This README is the definitive source for downloading, installing, and running th
         rosdep install --from-paths src -y --ignore-src
 
 7. Install non-`rosdep` dependencies:
-    - Install SegmentAnything: `python3 -m pip install git+https://github.com/facebookresearch/segment-anything.git`
+    - Install SegmentAnythingModel: `python3 -m pip install git+https://github.com/facebookresearch/segment-anything.git`
+    - Install EfficientSAM: `python3 -m pip install git+https://github.com/yformer/EfficientSAM.git`
     - Upgrade `transforms3d`, since [the release on Ubuntu packages is outdated](https://github.com/matthew-brett/transforms3d/issues/65): `python3 -m pip install transforms3d -U`
     - [`pyrealsense2` is not released for ARM systems](https://github.com/IntelRealSense/librealsense/issues/6449#issuecomment-650784066), so ARM users will have to [build from source](https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/readme.md#building-from-source). You make have to add the `-DPYTHON_EXECUTABLE=/usr/bin/python3` flag to the `cmake` command. When running `sudo make install`, pay close attention to which path `pyrealsense2` is installed to and add *that path* to the `PYTHONPATH` -- it should be `/use/local/lib` but may be `/usr/local/OFF`.
 8. Install the JACO SDK (real robot only). All SDKs are listed [here](https://www.kinovarobotics.com/resources?r=79301&s); PRL currently uses the [Gen2 SDK v1.5.1](https://drive.google.com/file/d/1UEQAow0XLcVcPCeQfHK9ERBihOCclkJ9/view). Note that although the latest version of that SDK is for Ubuntu 16.04, it still works on Ubuntu 22.04 (only for x86 systems, not ARM system).

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -179,8 +179,10 @@ class SegmentFromPointNode(Node):
         max_depth_mm: The maximum depth in mm to consider for a mask.
         """
         (
-            model_name,
-            model_base_url,
+            sam_model_name,
+            sam_model_base_url,
+            efficient_sam_model_name,
+            efficient_sam_model_base_url,
             model_dir,
             use_efficient_sam,
             n_contender_masks,
@@ -191,24 +193,47 @@ class SegmentFromPointNode(Node):
             "",
             [
                 (
-                    "model_name",
+                    "sam_model_name",
                     None,
                     ParameterDescriptor(
-                        name="model_name",
+                        name="sam_model_name",
                         type=ParameterType.PARAMETER_STRING,
-                        description="The name of the model checkpoint to use",
+                        description="The name of the model checkpoint to use for SAM",
                         read_only=True,
                     ),
                 ),
                 (
-                    "model_base_url",
+                    "sam_model_base_url",
                     None,
                     ParameterDescriptor(
-                        name="model_base_url",
+                        name="sam_model_base_url",
                         type=ParameterType.PARAMETER_STRING,
                         description=(
                             "The URL to download the model checkpoint from if "
-                            "it is not already downloaded"
+                            "it is not already downloaded for SAM"
+                        ),
+                        read_only=True,
+                    ),
+                ),
+                (
+                    "efficient_sam_model_name",
+                    None,
+                    ParameterDescriptor(
+                        name="efficient_sam_model_name",
+                        type=ParameterType.PARAMETER_STRING,
+                        description="The name of the model checkpoint to use for EfficientSAM",
+                        read_only=True,
+                    ),
+                ),
+                (
+                    "efficient_sam_model_base_url",
+                    None,
+                    ParameterDescriptor(
+                        name="efficient_sam_model_base_url",
+                        type=ParameterType.PARAMETER_STRING,
+                        description=(
+                            "The URL to download the model checkpoint from if "
+                            "it is not already downloaded for EfficientSAM"
                         ),
                         read_only=True,
                     ),
@@ -278,9 +303,17 @@ class SegmentFromPointNode(Node):
                 ),
             ],
         )
+
+        if use_efficient_sam.value:
+            model_name = efficient_sam_model_name.value
+            model_base_url = efficient_sam_model_base_url.value
+        else:
+            model_name = sam_model_name.value
+            model_base_url = sam_model_base_url.value
+
         return (
-            model_name.value,
-            model_base_url.value,
+            model_name,
+            model_base_url,
             model_dir.value,
             use_efficient_sam.value,
             n_contender_masks.value,

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -72,6 +72,8 @@ class SegmentFromPointNode(Node):
             model_dir,
             self.use_efficient_sam,
             self.n_contender_masks,
+            self.min_depth_mm,
+            self.max_depth_mm,
         ) = self.read_params()
 
         # Download the checkpoint if it doesn't exist
@@ -101,9 +103,6 @@ class SegmentFromPointNode(Node):
         # NOTE: We assume this is in the same frame as the RGB image
         self.latest_depth_img_msg = None
         self.latest_depth_img_msg_lock = threading.Lock()
-        # TODO: make the min/max depth mm parameters
-        self.min_depth_mm = 330
-        self.max_depth_mm = 1500
         aligned_depth_topic = "~/aligned_depth"
         try:
             aligned_depth_type = get_img_msg_type(aligned_depth_topic, self)
@@ -173,6 +172,8 @@ class SegmentFromPointNode(Node):
         model_dir: The location of the directory where the model checkpoint is / should be stored
         use_efficient_sam: Whether to use EfficientSAM or SAM
         n_contender_masks: The number of contender masks to return per point.
+        min_depth_mm: The minimum depth in mm to consider for a mask.
+        max_depth_mm: The maximum depth in mm to consider for a mask.
         """
         (
             model_name,
@@ -180,6 +181,8 @@ class SegmentFromPointNode(Node):
             model_dir,
             use_efficient_sam,
             n_contender_masks,
+            min_depth_mm,
+            max_depth_mm,
         ) = self.declare_parameters(
             "",
             [
@@ -239,6 +242,26 @@ class SegmentFromPointNode(Node):
                         read_only=True,
                     ),
                 ),
+                (
+                    "min_depth_mm",
+                    330,
+                    ParameterDescriptor(
+                        name="min_depth_mm",
+                        type=ParameterType.PARAMETER_INTEGER,
+                        description="The minimum depth in mm to consider in a mask.",
+                        read_only=True,
+                    ),
+                ),
+                (
+                    "max_depth_mm",
+                    10150000,
+                    ParameterDescriptor(
+                        name="max_depth_mm",
+                        type=ParameterType.PARAMETER_INTEGER,
+                        description="The maximum depth in mm to consider in a mask.",
+                        read_only=True,
+                    ),
+                ),
             ],
         )
         return (
@@ -247,6 +270,8 @@ class SegmentFromPointNode(Node):
             model_dir.value,
             use_efficient_sam.value,
             n_contender_masks.value,
+            min_depth_mm.value,
+            max_depth_mm.value,
         )
 
     def initialize_sam(self, model_name: str, model_path: str) -> None:

--- a/ada_feeding_perception/config/segment_from_point.yaml
+++ b/ada_feeding_perception/config/segment_from_point.yaml
@@ -15,3 +15,6 @@ segment_from_point:
 
     # The number of contender masks to return
     n_contender_masks: 3
+
+    # The rate (hz) at which to return feedback
+    rate_hz: 10.0

--- a/ada_feeding_perception/config/segment_from_point.yaml
+++ b/ada_feeding_perception/config/segment_from_point.yaml
@@ -1,17 +1,18 @@
 # NOTE: You have to change this node name if you change the node name in the launchfile.
 segment_from_point:
   ros__parameters:
-    # # The name of the Segment Anything model checkpoint to use
-    # model_name: sam_vit_b_01ec64.pth
-    # # The URL to download the model checkpoint from if it is not already downloaded
-    # model_base_url: "https://dl.fbaipublicfiles.com/segment_anything/"
-    # use_efficient_sam: false
+    # The name of the Segment Anything model checkpoint to use
+    sam_model_name: sam_vit_b_01ec64.pth
+    # The URL to download the model checkpoint from if it is not already downloaded
+    sam_model_base_url: "https://dl.fbaipublicfiles.com/segment_anything/"
 
     # The name of the Efficient Segment Anything model checkpoint to use
-    model_name: efficient_sam_vitt.pt
+    efficient_sam_model_name: efficient_sam_vitt.pt
     # The URL to download the model checkpoint from if it is not already downloaded
-    model_base_url: "https://raw.githubusercontent.com/yformer/EfficientSAM/main/weights/"
-    use_efficient_sam: true
+    efficient_sam_model_base_url: "https://raw.githubusercontent.com/yformer/EfficientSAM/main/weights/"
+
+    # Whether to use SAM or EfficientSAM
+    use_efficient_sam: false
 
     # The number of contender masks to return
     n_contender_masks: 3

--- a/ada_feeding_perception/config/segment_from_point.yaml
+++ b/ada_feeding_perception/config/segment_from_point.yaml
@@ -1,9 +1,15 @@
 # NOTE: You have to change this node name if you change the node name in the launchfile.
 segment_from_point:
   ros__parameters:
-    # The name of the Segment Anything model checkpoint to use
-    model_name: sam_vit_b_01ec64.pth
+    # # The name of the Segment Anything model checkpoint to use
+    # model_name: sam_vit_b_01ec64.pth
+    # # The URL to download the model checkpoint from if it is not already downloaded
+    # model_base_url: "https://dl.fbaipublicfiles.com/segment_anything/"
+
+    # The name of the Efficient Segment Anything model checkpoint to use
+    model_name: efficient_sam_vitt.pt
     # The URL to download the model checkpoint from if it is not already downloaded
-    model_base_url: "https://dl.fbaipublicfiles.com/segment_anything/"
+    model_base_url: "https://raw.githubusercontent.com/yformer/EfficientSAM/main/weights/"
+
     # The number of contender masks to return
     n_contender_masks: 3

--- a/ada_feeding_perception/config/segment_from_point.yaml
+++ b/ada_feeding_perception/config/segment_from_point.yaml
@@ -5,11 +5,13 @@ segment_from_point:
     # model_name: sam_vit_b_01ec64.pth
     # # The URL to download the model checkpoint from if it is not already downloaded
     # model_base_url: "https://dl.fbaipublicfiles.com/segment_anything/"
+    # use_efficient_sam: false
 
     # The name of the Efficient Segment Anything model checkpoint to use
     model_name: efficient_sam_vitt.pt
     # The URL to download the model checkpoint from if it is not already downloaded
     model_base_url: "https://raw.githubusercontent.com/yformer/EfficientSAM/main/weights/"
+    use_efficient_sam: true
 
     # The number of contender masks to return
     n_contender_masks: 3


### PR DESCRIPTION
# Description

This PR makes two changes to SegmentFromPoint:

1. **Speeds it up**: As documented in #134 , due to GPU throttling, SegmentAnything runs unreasonably slow on wheelchair power. This PR improves that by implementing [EfficientSAM](https://github.com/yformer/EfficientSAM/tree/main), which has a ~3x speedup relative to SAM.
2. **Returns feedback**: When nothing changes on the web app, it is hard for users to know if something has crashed or is working but just thinking. Thus, this PR returns feedback from SegmentFromPoint (elapsed time), which is already supported in the web app.

With this combination, I feel bite selection is usable on wheelchair power (although of course further speedups would be welcome).

Note that I also tried [FastSAM](https://github.com/CASIA-IVA-Lab/FastSAM/tree/main) on the images in `ada_feeding_perception/text/food_img`, but got very inaccurate results. This might be because FastSAM segments the entire image, and then filters through returned masks using the seed point; it doesn't account for the seed point in segmentation. I also tried FastSAM's text prompting with prompts like "the bite of watermelon," "the apple," etc. on the test images and also got inaccurate results.

# Testing procedure

On the real robot:
- [x] Launch code as documented in the [README](https://github.com/personalrobotics/ada_feeding/blob/ros2-devel/README.md).
- [x] With the web app, do bite selection on several different objects. Document the time here:
    - EfficientSAM First Segmentation: 2.2s
    - EfficientSAM Other Segmentations: 1s
- [x] Change the `use_efficient_sam` parameter to false and repeat the above:
    - SAM First Segmentation: 4s
    - SAM Other Segmentations: 3s
- [x] Verify that the app renders feedback

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
