### PR TITLE
Allow for Simulating Acquisition

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -103,7 +103,9 @@ class MoveIt2Plan(BlackboardBehavior):
             BlackboardKey, Optional[Union[JointState, List[float]]]
         ] = None,
         debug_trajectory_viz: Union[BlackboardKey, bool] = False,
-        max_path_len: Optional[Union[BlackboardKey, float]] = 10.0, #np.sqrt(6.0) * np.pi,
+        max_path_len: Optional[
+            Union[BlackboardKey, float]
+        ] = 10.0,  # np.sqrt(6.0) * np.pi,
         max_path_len_joint: Optional[Union[BlackboardKey, Dict[str, float]]] = None,
     ) -> None:
         """

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -6,6 +6,7 @@ wrap that behavior tree in a ROS2 action server.
 """
 
 # Standard imports
+import pickle
 from typing import List, Optional
 
 # Third-party imports
@@ -81,6 +82,7 @@ class AcquireFoodTree(MoveToTree):
         max_acceleration_scaling_move_into: Optional[float] = 0.8,
         max_velocity_scaling_to_resting_configuration: Optional[float] = 0.8,
         max_acceleration_scaling_to_resting_configuration: Optional[float] = 0.8,
+        pickle_goal_path: Optional[str] = None,
     ):
         """
         Initializes tree-specific parameters.
@@ -88,6 +90,13 @@ class AcquireFoodTree(MoveToTree):
         Parameters
         ----------
         resting_joint_positions: Final joint position after acquisition
+        max_velocity_scaling_move_above: Max velocity scaling for move above
+        max_acceleration_scaling_move_above: Max acceleration scaling for move above
+        max_velocity_scaling_move_into: Max velocity scaling for move into
+        max_acceleration_scaling_move_into: Max acceleration scaling for move into
+        max_velocity_scaling_to_resting_configuration: Max velocity scaling for move to resting configuration
+        max_acceleration_scaling_to_resting_configuration: Max acceleration scaling for move to resting configuration
+        pickle_goal_path: Path to pickle goal for debugging
         """
         # Initialize ActionServerBT
         super().__init__(node)
@@ -103,6 +112,7 @@ class AcquireFoodTree(MoveToTree):
         self.max_acceleration_scaling_to_resting_configuration = (
             max_acceleration_scaling_to_resting_configuration
         )
+        self.pickle_goal_path = pickle_goal_path
 
     @override
     def create_tree(
@@ -825,6 +835,12 @@ class AcquireFoodTree(MoveToTree):
         # Check goal type
         if not isinstance(goal, AcquireFood.Goal):
             return False
+
+        # Pickle goal for debugging
+        if self.pickle_goal_path is not None:
+            with open(self.pickle_goal_path, "wb") as file:
+                pickle.dump(goal, file)
+            self._node.get_logger().info(f"Pickled goal to {self.pickle_goal_path}")
 
         # Write tree inputs to blackboard
         name = tree.root.name

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -543,7 +543,14 @@ class CreateActionServers(Node):
                                 tree
                             )  # blocks until the preempt succeeds
                             goal_handle.canceled()
-                            result = tree_action_server.get_result(tree, action_type)
+
+                            try:
+                                result = tree_action_server.get_result(
+                                    tree, action_type
+                                )
+                            except KeyError:
+                                # The tree didn't get far enough to set a result
+                                result = action_type.Result()
                             break
 
                         # Check if the watchdog has failed
@@ -553,7 +560,13 @@ class CreateActionServers(Node):
                                 tree
                             )  # blocks until the preempt succeeds
                             goal_handle.abort()
-                            result = tree_action_server.get_result(tree, action_type)
+                            try:
+                                result = tree_action_server.get_result(
+                                    tree, action_type
+                                )
+                            except KeyError:
+                                # The tree didn't get far enough to set a result
+                                result = action_type.Result()
                             break
 
                         # Tick the tree once and publish feedback
@@ -578,7 +591,13 @@ class CreateActionServers(Node):
                         ):
                             self.get_logger().info("Tree failed")
                             goal_handle.abort()
-                            result = tree_action_server.get_result(tree, action_type)
+                            try:
+                                result = tree_action_server.get_result(
+                                    tree, action_type
+                                )
+                            except KeyError:
+                                # The tree didn't get far enough to set a result
+                                result = action_type.Result()
                             break
 
                         # Sleep

--- a/ada_feeding_action_select/ada_feeding_action_select/policy_service.py
+++ b/ada_feeding_action_select/ada_feeding_action_select/policy_service.py
@@ -487,6 +487,8 @@ def set_data_folder():
     Entry Point
     Create symlink from shared data directory
     """
+    logger = rclpy.logging.get_logger("policy_service")
+
     parser = argparse.ArgumentParser(
         prog="set_data_folder", description="Set data directory root."
     )
@@ -496,7 +498,7 @@ def set_data_folder():
     args = parser.parse_args()
     data_dir = args.directory[0]
     if not os.path.isdir(data_dir):
-        print(f"Error: Not a directory or does not exist; {data_dir}")
+        logger.error(f"Error: Not a directory or does not exist; {data_dir}")
         return 1
 
     link_name = os.path.join(
@@ -511,7 +513,7 @@ def set_data_folder():
         else:
             raise error
 
-    print("Success: Set installed data directory.")
+    logger.info("Success: Set installed data directory.")
     return 0
 
 
@@ -525,9 +527,14 @@ def main():
         get_package_share_directory("ada_feeding_action_select"), "data"
     )
     if not os.path.isdir(data_dir):
-        print("Error: No data directory set.")
-        print("Use `ros2 run ada_feeding_action_select set_data_folder <directory>`.")
-        return 1
+        logger = rclpy.logging.get_logger("policy_service")
+        logger.error("Error: No data directory set.")
+        logger.error(
+            "Create a folder where you want checkpoints and records saved in. "
+            "Then, symlink that folder to share/data by running: "
+            "`ros2 run ada_feeding_action_select set_data_folder <directory>`."
+        )
+        logger.error("For now, checkpoints and records will not be saved.")
 
     # Node Setup
     rclpy.init()


### PR DESCRIPTION
# Description

This PR, joint with [`feeding_web_interface`#124](https://github.com/personalrobotics/feeding_web_interface/pull/124), enables uses to simulate bite acquisition. It also improves error handling and logging.

# Testing procedure

See [`feeding_web_interface`#124](https://github.com/personalrobotics/feeding_web_interface/pull/124)

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
