### PR TITLE
Switch to Compressed Depth Images

### DIFF
--- a/ada_feeding_perception/README.md
+++ b/ada_feeding_perception/README.md
@@ -24,6 +24,7 @@ For running SegmentAnything test scripts (below), be sure to unzip `test/food_im
             1. `ros2config` (this takes several seconds)
             2. `ros2 launch realsense2_camera rs_launch.py rgb_camera.profile:='640,480,30' depth_module.profile:='640,480,30' align_depth.enable:='true' initial_reset:='true'`. See here for [a complete list of params](https://github.com/IntelRealSense/realsense-ros/blob/ros2-development/realsense2_camera/launch/rs_launch.py). **Note that `nano` must be connected to the same WiFi network as the computer running any ros2 nodes that subscribe to it.**
         3. (To visualize the camera stream, run `ros2 run rviz2 rviz2`)
+        4. **NOTE**: For the compressed depth stream, we found that `png_level` of 1 works best, to get compression while not slowing down FPS too much. Due to a quirk of our eye-in-hand setup, we hardcode this parameter directly in the compressed depth transport; thus, the code does not automatically set that parameter. Be sure to set the parameter yourself!
 6. Launch the web app ([instructions here](https://github.com/personalrobotics/feeding_web_interface/tree/main/feedingwebapp))
 
 ## Food Segmentation

--- a/ada_feeding_perception/ada_feeding_perception/depth_post_processors.py
+++ b/ada_feeding_perception/ada_feeding_perception/depth_post_processors.py
@@ -4,21 +4,157 @@ This module contains a series of post-processors for depth images.
 """
 
 # Standard imports
-from typing import Callable
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 # Third-party imports
-from builtin_interfaces.msg import Time
 import cv2 as cv
 from cv_bridge import CvBridge
 import numpy as np
 import numpy.typing as npt
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import CompressedImage, Image
 from std_msgs.msg import Header
+
+# Local imports
+from .helpers import ros_msg_to_cv2_image, cv2_image_to_ros_msg
+
+_CV2ImageMsg = Tuple[npt.NDArray, Header]
+_ImageMsgTypes = Union[Image, CompressedImage, _CV2ImageMsg]
+
+
+def post_processor_chain(
+    fns: List[Callable[[Any], Callable[[_ImageMsgTypes], _CV2ImageMsg]]],
+    kwargs: List[Dict[str, Any]],
+    compress: Optional[bool] = None,
+) -> Callable[[Union[Image, CompressedImage]], _ImageMsgTypes]:
+    """
+    Chains together multiple post-processors into a single function, where
+    the first post-processor takes as input a ROS2 message, the final one
+    outputs a ROS2 message if output_msg else a _CV2ImageMsg, and the intermediate
+    ones output a _CV2ImageMsg.
+
+    The main purpose of this function is to prevent unnecessary conversions
+    back-and-forth between ROS2 and CV2 image types.
+
+    Parameters
+    ----------
+    fns: List[Callable[[Any], Callable[[_ImageMsgTypes], _ImageMsgTypes]]]
+        A list of post-processor functions from this file.
+    kwargs: List[Dict[str, Any]]
+        The parameters to pass those functions.
+    compress: Optional[bool]
+        If None, the return message will be a _CV2ImageMsg. Else, it will be either
+        a CompressedImage or Image, as specified by the bool.
+
+    Returns
+    -------
+    Callable[[Union[Image, CompressedImage]], _ImageMsgTypes]
+        A function that runs the post-processors and returns the desired image type.
+    """
+    assert len(fns) == len(
+        kwargs
+    ), "The length of the functions and kwargs in a post-processor chain must be equal"
+    n = len(fns)
+    post_processors = []
+    bridge = None
+    for i in range(n):
+        post_processors.append(fns[i](**kwargs[i]))
+        if "bridge" in kwargs[i]:
+            bridge = kwargs[i]["bridge"]
+
+    def chain(msg: Union[Image, CompressedImage]) -> _ImageMsgTypes:
+        """
+        Post-process the image through all the specified post-processors.
+
+        Parameters
+        ----------
+        msg : Union[Image, CompressedImage]
+            The image to mask.
+
+        Returns
+        -------
+        _ImageMsgTypes
+            The masked image. All other attributes of the message remain the same.
+        """
+        # Run the post-processors
+        for post_processor in post_processors:
+            msg = post_processor(msg)
+
+        # Convert to the return type
+        if compress is None:
+            return msg
+        masked_img, header = msg
+        out_msg = cv2_image_to_ros_msg(masked_img, compress, bridge=bridge)
+        out_msg.header = header
+        return out_msg
+
+    return chain
+
+
+def __in_msg(msg: _ImageMsgTypes, bridge: CvBridge) -> _CV2ImageMsg:
+    """
+    A shared function across all post-processors to process the input image.
+
+    Parameters
+    ----------
+    msg : _ImageMsgTypes
+        The image to mask.
+    bridge : CvBridge
+        The CvBridge object to use.
+
+    Returns
+    -------
+    _CV2ImageMsg
+        The CV2 image and its associated header.
+    """
+    if isinstance(msg, (CompressedImage, Image)):
+        return (
+            ros_msg_to_cv2_image(msg, bridge),
+            msg.header,
+        )
+    return msg
+
+
+def create_identity_post_processor(
+    bridge: CvBridge,
+) -> Callable[[_ImageMsgTypes], _ImageMsgTypes]:
+    """
+    A dummy identity post-processer, that just returns the same message.
+
+    Parameters
+    ----------
+    bridge : CvBridge
+        The CvBridge object to use.
+
+    Returns
+    -------
+    Callable[[_ImageMsgTypes], _CV2ImageMsg]
+        The post-processor function.
+    """
+
+    def identity_post_processor(msg: _ImageMsgTypes) -> _CV2ImageMsg:
+        """
+        An identity post-processor that merely returns the same image.
+
+        Parameters
+        ----------
+        msg : _ImageMsgTypes
+            The image to mask.
+
+        Returns
+        -------
+        _CV2ImageMsg
+            The masked image. All other attributes of the message remain the same.
+        """
+        # Read the ROS msg as a CV image
+        return __in_msg(msg, bridge)
+
+    return identity_post_processor
 
 
 def create_mask_post_processor(
-    mask_img: npt.NDArray[np.uint8], bridge: CvBridge
-) -> Callable[[Image], Image]:
+    mask_img: npt.NDArray[np.uint8],
+    bridge: CvBridge,
+) -> Callable[[_ImageMsgTypes], _CV2ImageMsg]:
     """
     Creates the mask post-processor function, which applies a fixed mask to the image.
 
@@ -31,26 +167,26 @@ def create_mask_post_processor(
 
     Returns
     -------
-    Callable[[Image], Image]
+    Callable[[_ImageMsgTypes], _CV2ImageMsg]
         The post-processor function.
     """
 
-    def mask_post_processor(msg: Image) -> Image:
+    def mask_post_processor(msg: _ImageMsgTypes) -> _CV2ImageMsg:
         """
         Applies a fixed mask to the image. Scales the mask to the image.
 
         Parameters
         ----------
-        msg : Image
+        msg : _ImageMsgTypes
             The image to mask.
 
         Returns
         -------
-        Image
+        _CV2ImageMsg
             The masked image. All other attributes of the message remain the same.
         """
         # Read the ROS msg as a CV image
-        img = bridge.imgmsg_to_cv2(msg)
+        img, header = __in_msg(msg, bridge)
 
         # Scale the mask to be the size of the img
         mask = cv.resize(mask_img, img.shape[:2][::-1])
@@ -58,21 +194,16 @@ def create_mask_post_processor(
         # Apply the mask to the img
         masked_img = cv.bitwise_and(img, img, mask=mask)
 
-        # Get the new img message
-        masked_msg = bridge.cv2_to_imgmsg(masked_img)
-        masked_msg.header = Header(
-            stamp=Time(sec=msg.header.stamp.sec, nanosec=msg.header.stamp.nanosec),
-            frame_id=msg.header.frame_id,
-        )
-
-        return masked_msg
+        # Return the new img message
+        return masked_img, header
 
     return mask_post_processor
 
 
 def create_temporal_post_processor(
-    temporal_window_size: int, bridge: CvBridge
-) -> Callable[[Image], Image]:
+    temporal_window_size: int,
+    bridge: CvBridge,
+) -> Callable[[_ImageMsgTypes], _ImageMsgTypes]:
     """
     Creates the temporal post-processor function, with a dedicated window.
     This post-processor only keeps pixels that are consistently non-zero across
@@ -87,13 +218,13 @@ def create_temporal_post_processor(
 
     Returns
     -------
-    Callable[[Image], Image]
+    Callable[[_ImageMsgTypes], _CV2ImageMsg]
         The post-processor function.
     """
 
     temporal_window = []
 
-    def temporal_post_processor(msg: Image) -> Image:
+    def temporal_post_processor(msg: _ImageMsgTypes) -> _CV2ImageMsg:
         """
         The temporal post-processor stores the last `temporal_window_size` images.
         It returns the most recent image, but only the pixels in that image that
@@ -101,16 +232,16 @@ def create_temporal_post_processor(
 
         Parameters
         ----------
-        msg : Image
+        msg : _ImageMsgTypes
             The image to process.
 
         Returns
         -------
-        Image
+        _CV2ImageMsg
             The processed image. All other attributes of the message remain the same.
         """
         # Read the ROS msg as a CV image
-        img = bridge.imgmsg_to_cv2(msg)
+        img, header = __in_msg(msg, bridge)
 
         # Add it to the window
         temporal_window.append(img)
@@ -128,20 +259,15 @@ def create_temporal_post_processor(
         masked_img = cv.bitwise_and(img, img, mask=mask)
 
         # Get the new img message
-        masked_msg = bridge.cv2_to_imgmsg(masked_img)
-        masked_msg.header = Header(
-            stamp=Time(sec=msg.header.stamp.sec, nanosec=msg.header.stamp.nanosec),
-            frame_id=msg.header.frame_id,
-        )
-
-        return masked_msg
+        return masked_img, header
 
     return temporal_post_processor
 
 
 def create_spatial_post_processor(
-    spatial_num_pixels: int, bridge: CvBridge
-) -> Callable[[Image], Image]:
+    spatial_num_pixels: int,
+    bridge: CvBridge,
+) -> Callable[[_ImageMsgTypes], _ImageMsgTypes]:
     """
     Creates the spatial post-processor function, which applies the `opening` morpholical
     transformation to the image.
@@ -155,26 +281,26 @@ def create_spatial_post_processor(
 
     Returns
     -------
-    Callable[[Image], Image]
+    Callable[[_ImageMsgTypes], _CV2ImageMsg]
         The post-processor function.
     """
 
-    def spatial_post_processor(msg: Image) -> Image:
+    def spatial_post_processor(msg: _ImageMsgTypes) -> _CV2ImageMsg:
         """
         Applies the `opening` morpholical transformation to the image.
 
         Parameters
         ----------
-        msg : Image
+        msg : _ImageMsgTypes
             The image to process.
 
         Returns
         -------
-        Image
+        _CV2ImageMsg
             The processed image. All other attributes of the message remain the same.
         """
         # Read the ROS msg as a CV image
-        img = bridge.imgmsg_to_cv2(msg)
+        img, header = __in_msg(msg, bridge)
 
         # Apply the opening morphological transformation
         mask = (img > 0).astype(np.uint8)
@@ -183,20 +309,16 @@ def create_spatial_post_processor(
         masked_img = cv.bitwise_and(img, img, mask=opened_mask)
 
         # Get the new img message
-        masked_msg = bridge.cv2_to_imgmsg(masked_img)
-        masked_msg.header = Header(
-            stamp=Time(sec=msg.header.stamp.sec, nanosec=msg.header.stamp.nanosec),
-            frame_id=msg.header.frame_id,
-        )
-
-        return masked_msg
+        return masked_img, header
 
     return spatial_post_processor
 
 
 def create_threshold_post_processor(
-    threshold_min: int, threshold_max: int, bridge: CvBridge
-) -> Callable[[Image], Image]:
+    threshold_min: int,
+    threshold_max: int,
+    bridge: CvBridge,
+) -> Callable[[_ImageMsgTypes], _ImageMsgTypes]:
     """
     Creates the threshold post-processor function, which only keeps pixels within a
     min and max value.
@@ -212,17 +334,17 @@ def create_threshold_post_processor(
 
     Returns
     -------
-    Callable[[Image], Image]
+    Callable[[_ImageMsgTypes], _CV2ImageMsg]
         The post-processor function.
     """
 
-    def threshold_post_processor(msg: Image) -> Image:
+    def threshold_post_processor(msg: _ImageMsgTypes) -> _CV2ImageMsg:
         """
         Applies a threshold to the image.
 
         Parameters
         ----------
-        msg : Image
+        msg : _ImageMsgTypes
             The image to process.
         threshold_min : int
             The minimum threshold.
@@ -233,23 +355,17 @@ def create_threshold_post_processor(
 
         Returns
         -------
-        Image
+        _CV2ImageMsg
             The processed image. All other attributes of the message remain the same.
         """
         # Read the ROS msg as a CV image
-        img = bridge.imgmsg_to_cv2(msg)
+        img, header = __in_msg(msg, bridge)
 
         # Apply the threshold
         mask = cv.inRange(img, threshold_min, threshold_max)
         masked_img = cv.bitwise_and(img, img, mask=mask)
 
         # Get the new img message
-        masked_msg = bridge.cv2_to_imgmsg(masked_img)
-        masked_msg.header = Header(
-            stamp=Time(sec=msg.header.stamp.sec, nanosec=msg.header.stamp.nanosec),
-            frame_id=msg.header.frame_id,
-        )
-
-        return masked_msg
+        return masked_img, header
 
     return threshold_post_processor

--- a/ada_feeding_perception/ada_feeding_perception/face_detection.py
+++ b/ada_feeding_perception/ada_feeding_perception/face_detection.py
@@ -16,7 +16,6 @@ from typing import List, Tuple, Union
 import cv2
 from cv_bridge import CvBridge
 from geometry_msgs.msg import Point
-import numpy as np
 import numpy.typing as npt
 import rclpy
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
@@ -35,6 +34,7 @@ from ada_feeding_perception.helpers import (
     download_checkpoint,
     get_img_msg_type,
     cv2_image_to_ros_msg,
+    ros_msg_to_cv2_image,
 )
 
 
@@ -561,11 +561,7 @@ class FaceDetectionNode(Node):
                 f"Corresponding RGB image message received at {rgb_msg.header.stamp}. "
                 f"Time difference: {min_time_diff} seconds."
             )
-        # TODO: This should use the ros_msg_to_cv2_image helper function
-        image_depth = self.bridge.imgmsg_to_cv2(
-            closest_depth_msg,
-            desired_encoding="passthrough",
-        )
+        image_depth = ros_msg_to_cv2_image(closest_depth_msg, self.bridge)
 
         # Compute the depth of the mouth
         for method in methods:
@@ -650,10 +646,7 @@ class FaceDetectionNode(Node):
                 continue
 
             # Detect the largest face in the RGB image
-            # TODO: This should use the ros_msg_to_cv2_image helper function
-            image_bgr = cv2.imdecode(
-                np.frombuffer(rgb_msg.data, np.uint8), cv2.IMREAD_COLOR
-            )
+            image_bgr = ros_msg_to_cv2_image(rgb_msg, self.bridge)
             (
                 is_face_detected,
                 img_mouth_center,

--- a/ada_feeding_perception/ada_feeding_perception/helpers.py
+++ b/ada_feeding_perception/ada_feeding_perception/helpers.py
@@ -309,7 +309,7 @@ def cv2_image_to_ros_msg(
             success, data = cv2.imencode(
                 ".png",
                 image,
-                # PNG compression 1 is the best speed setting, and the setting
+                # PNG compression 1 is the best speed setting, and is the setting
                 # we use for our RealSense.
                 [cv2.IMWRITE_PNG_COMPRESSION, 1],
             )

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -110,9 +110,9 @@ class SegmentFromPointNode(Node):
             aligned_depth_type = get_img_msg_type(aligned_depth_topic, self)
         except ValueError as err:
             self.get_logger().error(
-                f"Error getting type of depth image topic. Defaulting to Image. {err}"
+                f"Error getting type of depth image topic. Defaulting to CompressedImage. {err}"
             )
-            aligned_depth_type = Image
+            aligned_depth_type = CompressedImage
         self.depth_image_subscriber = self.create_subscription(
             aligned_depth_type,
             aligned_depth_topic,

--- a/ada_feeding_perception/ada_feeding_perception/test_efficient_sam.py
+++ b/ada_feeding_perception/ada_feeding_perception/test_efficient_sam.py
@@ -4,6 +4,10 @@ segment an object from an image given a point inside the object. Unlike the
 other scripts in this package, this script does not use ROS. Therefore, it can
 be useful as an initial check to ensure Segment Anything works on your computer.
 """
+# pylint: disable=duplicate-code
+# Since this script is intentionally not a ROS node, it will have overlap with
+# the corresponding ROS node.
+
 # Standard imports
 import argparse
 import json

--- a/ada_feeding_perception/ada_feeding_perception/test_sam.py
+++ b/ada_feeding_perception/ada_feeding_perception/test_sam.py
@@ -4,6 +4,10 @@ segment an object from an image given a point inside the object. Unlike the
 other scripts in this package, this script does not use ROS. Therefore, it can
 be useful as an initial check to ensure Segment Anything works on your computer.
 """
+# pylint: disable=duplicate-code
+# Since this script is intentionally not a ROS node, it will have overlap with
+# the corresponding ROS node.
+
 # Standard imports
 import argparse
 import json

--- a/ada_feeding_perception/config/republisher.yaml
+++ b/ada_feeding_perception/config/republisher.yaml
@@ -5,23 +5,33 @@ republisher:
     from_topics:
       - /camera/color/image_raw/compressed
       - /camera/color/camera_info
-      - /camera/aligned_depth_to_color/image_raw
+      - /camera/aligned_depth_to_color/image_raw/compressedDepth
       - /camera/aligned_depth_to_color/camera_info
-      - /local/camera/aligned_depth_to_color/image_raw
+      - /local/camera/aligned_depth_to_color/image_raw/compressedDepth
 
     # The types of topics to republish from
-    topic_types:
+    in_topic_types:
       - sensor_msgs.msg.CompressedImage
       - sensor_msgs.msg.CameraInfo
-      - sensor_msgs.msg.Image
+      - sensor_msgs.msg.CompressedImage
       - sensor_msgs.msg.CameraInfo
+      - sensor_msgs.msg.CompressedImage
+
+    # If the republisher should convert types, specify the output type.
+    # Currently, the republisher only supports conversions from
+    # Image->CompressedImage and vice-versa.
+    out_topic_types:
+      - ""
+      - ""
+      - ""
+      - ""
       - sensor_msgs.msg.Image
 
     # The name of the topics to republish to
     to_topics:
       - /local/camera/color/image_raw/compressed
       - /local/camera/color/camera_info
-      - /local/camera/aligned_depth_to_color/image_raw
+      - /local/camera/aligned_depth_to_color/image_raw/compressedDepth
       - /local/camera/aligned_depth_to_color/camera_info
       - /local/camera/aligned_depth_to_color/depth_octomap
 
@@ -36,16 +46,16 @@ republisher:
 
     # The names of a post-processing functions to apply to the message before
     # republishing it. Current options are:
-    #  - none (Any): the identity
-    #  - temporal (Image): Stores the last `temporal_window_size` images and publishes
+    #  - temporal: Stores the last `temporal_window_size` images and publishes
     #    the last image, masking out pixels that are zero in *any* of the images
     #    in the window.
-    #  - spatial (Image): Applies the opening morphological operation to the mask of
+    #  - spatial: Applies the opening morphological operation to the mask of
     #    (non-)zero pixels in the image, with a square kernel of size `spatial_num_pixels`.
-    #  - mask (Image): Applies the mask stored in `mask_relative_path` to the image.
-    #  - threshold (Image): Masks out pixels whose values are outside of the specified
+    #  - mask: Applies the mask stored in `mask_relative_path` to the image.
+    #  - threshold: Masks out pixels whose values are outside of the specified
     #    range. This is intended to be used only with single-channel (e.g., depth) images.
     # Any of these post-processing functions can be combined in a comma-separated list.
+    # If an empty string, no post-processors are applied.
     post_processors:
       - ""
       - ""

--- a/ada_feeding_perception/launch/ada_feeding_perception.launch.py
+++ b/ada_feeding_perception/launch/ada_feeding_perception.launch.py
@@ -87,7 +87,7 @@ def generate_launch_description():
                 expression=[
                     "'",
                     prefix,
-                    "/camera/aligned_depth_to_color/image_raw'",
+                    "/camera/aligned_depth_to_color/image_raw/compressedDepth'",
                 ]
             ),
         ),
@@ -163,7 +163,7 @@ def generate_launch_description():
                 expression=[
                     "'",
                     prefix,
-                    "/camera/aligned_depth_to_color/image_raw'",
+                    "/camera/aligned_depth_to_color/image_raw/compressedDepth'",
                 ]
             ),
         ),

--- a/ada_feeding_perception/package.xml
+++ b/ada_feeding_perception/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-opencv</exec_depend>
   <exec_depend>python3-pandas</exec_depend>
+  <exec_depend>python3-parse</exec_depend>
   <!-- NOTE Version 0.9.19 of rosbags specifically is necessary. rosdep does not
   provide a way to install specific versions. https://gitlab.com/ternaris/rosbags/-/issues/73 -->
   <!-- <exec_depend>python3-rosbags-pip</exec_depend> -->

--- a/ada_feeding_perception/package.xml
+++ b/ada_feeding_perception/package.xml
@@ -19,7 +19,6 @@
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-opencv</exec_depend>
   <exec_depend>python3-pandas</exec_depend>
-  <exec_depend>python3-parse</exec_depend>
   <!-- NOTE Version 0.9.19 of rosbags specifically is necessary. rosdep does not
   provide a way to install specific versions. https://gitlab.com/ternaris/rosbags/-/issues/73 -->
   <!-- <exec_depend>python3-rosbags-pip</exec_depend> -->


### PR DESCRIPTION
# Description

This PR switches our entire stack from raw to compressed depth images, resulting in an over 10x reduction in topic bandwidth. As part of that, it makes somewhat large changes to the pre-processor and republisher, and smaller changes elsewhere.

# Testing procedure

- [x] Launch the entire stack in real: `python3 src/ada_feeding/start.py`. Run through 2 bites and verify all the perception elements work. Load the food on fork image in RVIZ and verify that appears as expected.
- [x] Modify a compressed depth callback function (I did it in FoodOnFork) to decode an image with `ros_msg_to_cv2_image` and re-encode the image with `cv2_image_to_ros_msg` and verify the `data` field of the original and reencoded messages are identical.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
