### PR TITLE
Keep adding collision objects until MoveIt processes them

### DIFF
--- a/ada_feeding/config/ada_planning_scene.yaml
+++ b/ada_feeding/config/ada_planning_scene.yaml
@@ -1,7 +1,6 @@
 # NOTE: You have to change this node name if you change the node name in the launchfile.
 ada_planning_scene:
   ros__parameters:
-    publish_hz: 1.0 # the rate at which to publish the planning scene. default: 10.0
     object_ids: # list of objects to add to the planning scene
       - wheelchair
       - wheelchair_collision

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -68,6 +68,7 @@
     <param name="assets_dir" value="$(find-pkg-share ada_feeding)/assets/"/>
     <remap from="~/face_detection" to="/face_detection" />
     <remap from="~/table_detection" to="/table_detection" />
+    <remap from="~/monitored_planning_scene" to="/monitored_planning_scene" />
   </node>
 
 </launch>


### PR DESCRIPTION
# Description

Currently, `ada_planning_scene.py` sends one message to the `/collision_objects` topic per collision object it is initializing in the planning scene. However, it is possible that that message gets dropped, which results in the planning scene not being fully initialized. This PR addresses that, by subscribing to the `/monitored_planning_scene` topic and continuing to publish messages until that object is confirmed to be added by the `/monitored_planning_scene` topic.

# Testing procedure

- [x] Launch code in mock: `python3 src/ada_feeding/start.py --sim mock`
- [x] Verify via RVIZ that the entire planning scene gets monitored in MoveIt.
- [x] Verify in the `feeding` screen that initialization stopped by finding the `Planning scene initialized` log.
- [x] Terminate the code in the `feeding` screen. Re-launch it. Verify that even though MoveIt already has the entire planning scene, initialization still terminates (i.e., you see the `Planning scene initialized` log).

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
