### PR TITLE
Fixed recovery in acquisition tree

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/moveit2_plan.py
@@ -346,14 +346,18 @@ class MoveIt2Plan(BlackboardBehavior):
                             goals_satisfied
                             and self.joint_constraint_satisfied(constraint_kwargs)
                         )
-                        self.logger.debug(f"MoveIt2Plan joint constraint satisfied {goals_satisfied}")
+                        self.logger.debug(
+                            f"MoveIt2Plan joint constraint satisfied {goals_satisfied}"
+                        )
                         self.moveit2.set_joint_goal(**constraint_kwargs)
                     elif constraint_type == MoveIt2ConstraintType.POSITION:
                         goals_satisfied = (
                             goals_satisfied
                             and self.position_constraint_satisfied(constraint_kwargs)
                         )
-                        self.logger.debug(f"MoveIt2Plan position constraint satisfied {goals_satisfied}")
+                        self.logger.debug(
+                            f"MoveIt2Plan position constraint satisfied {goals_satisfied}"
+                        )
                         ## If Cartesian, transform to base link frame
                         if self.blackboard_get("cartesian"):
                             self.transform_goal_to_base_link(constraint_kwargs)
@@ -363,7 +367,9 @@ class MoveIt2Plan(BlackboardBehavior):
                             goals_satisfied
                             and self.orientation_constraint_satisfied(constraint_kwargs)
                         )
-                        self.logger.debug(f"MoveIt2Plan orientation constraint satisfied {goals_satisfied}")
+                        self.logger.debug(
+                            f"MoveIt2Plan orientation constraint satisfied {goals_satisfied}"
+                        )
                         ## If Cartesian, transform to base link frame
                         if self.blackboard_get("cartesian"):
                             self.transform_goal_to_base_link(constraint_kwargs)

--- a/ada_feeding/ada_feeding/behaviors/moveit2/servo_move.py
+++ b/ada_feeding/ada_feeding/behaviors/moveit2/servo_move.py
@@ -208,6 +208,7 @@ class ServoMove(BlackboardBehavior):
             twist.header.frame_id = self.blackboard_get("default_frame_id")
             twist.twist = self.blackboard_get("twist")
         twist.header.stamp = self.node.get_clock().now().to_msg()
+        self.logger.debug(f"ServoMove publishing twist {twist}")
         self.pub.publish(twist)
 
         # Write the remaining distance

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -240,7 +240,7 @@ class AcquireFoodTree(MoveToTree):
                                         inputs={
                                             "default_frame_id": base_link,
                                             "twist": Twist(
-                                                linear=Vector3(x=0.0, y=0.0, z=0.03),
+                                                linear=Vector3(x=0.0, y=0.0, z=0.05),
                                                 angular=Vector3(),
                                             ),  # Default 1s duration
                                             "pub_topic": "~/cartesian_twist_cmds",
@@ -280,7 +280,9 @@ class AcquireFoodTree(MoveToTree):
                                     name="",
                                     ns=name,
                                     inputs={
-                                        "constraints": BlackboardKey("goal_constraints"),
+                                        "constraints": BlackboardKey(
+                                            "goal_constraints"
+                                        ),
                                         "quat_xyzw": (0.0, 0.0, 0.0, 1.0),
                                         "tolerance": (
                                             2.0 * np.pi,

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -77,7 +77,7 @@ class MoveToMouthTree(MoveToTree):
     def __init__(
         self,
         node: Node,
-        mouth_position_tolerance: float = 0.005,
+        mouth_position_tolerance: float = 0.0075,
         relaxed_mouth_position_tolerance: float = 0.025,
         head_object_id: str = "head",
         max_linear_speed: float = 0.05,

--- a/ada_feeding/ada_feeding/visitors/__init__.py
+++ b/ada_feeding/ada_feeding/visitors/__init__.py
@@ -3,4 +3,5 @@ This package contains custom BT Visitors that are used in the Ada Feeding
 project. All of these extend VisitorBase.
 """
 
+from .debug_visitor import DebugVisitor
 from .moveto_visitor import MoveToVisitor

--- a/ada_feeding/ada_feeding/visitors/debug_visitor.py
+++ b/ada_feeding/ada_feeding/visitors/debug_visitor.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This visitor logs the name and status of the behavior it is on.
+"""
+
+# Standard imports
+
+# Third-party imports
+from py_trees.behaviour import Behaviour
+from py_trees.visitors import VisitorBase
+
+# Local imports
+
+
+class DebugVisitor(VisitorBase):
+    """
+    This visitor logs the name and status of each behavior it visits.
+    """
+
+    def run(self, behaviour: Behaviour) -> None:
+        """
+        Log behaviour information on the debug channel.
+
+        Args:
+            behaviour: behaviour being visited.
+        """
+        behaviour.logger.debug(f"{behaviour.name} [{behaviour.status}]")

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -15,7 +15,6 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from ada_watchdog_listener import ADAWatchdogListener
 from ament_index_python.packages import get_package_share_directory
 import py_trees
-from py_trees.visitors import DebugVisitor
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType, SetParametersResult
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
@@ -28,6 +27,7 @@ import yaml
 # Local imports
 from ada_feeding import ActionServerBT
 from ada_feeding.helpers import import_from_string, register_logger
+from ada_feeding.visitors import DebugVisitor
 
 
 class ActionServerParams:


### PR DESCRIPTION
# Description

The recovery behaviors in the acquisition tree were broken. This PR fixes them, by:

1. Setting the right frame for servoing.
2. Setting the F/T threshold on the right controller for servoing.
3. Setting an orientation constraint on the cartesian motion.
4. Increasing the F/T threshold to 75 (because the extraction threshold is 50, which means that if extraction ends up going into the table, the measured force will be > 50.

# Testing procedure

- [x] Try an acquisition that fails. (in my experience, having the food item just up from the fork, being vertical, and then if the fork turns 180 degrees to target the food item, then extraction will go into the plate, making it fail.) Verify that servo rises up.
- [x] Make servo fail by commenting out the default frame ID input. Verify that the cartesian plan is at least computed (in my experience, the output is only a partial plan so often gets rejected.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
