### PR TITLE
Allow ActivateControllers to re-tare the FT sensor

### DIFF
--- a/ada_feeding/ada_feeding/idioms/retry_call_ros_service.py
+++ b/ada_feeding/ada_feeding/idioms/retry_call_ros_service.py
@@ -40,7 +40,7 @@ def retry_call_ros_service(
     key_request: The key for the request in the blackboard. If None, the constant
         value in `request` is used. Note that exactly one of `key_request` and
         `request` must be None.
-    request: The request for the ROS service. If None, the value atored in the
+    request: The request for the ROS service. If None, the value stored in the
         blackboard with key `key_request` will be used. Note that exactly one of
         `key_request` and `request` must be None.
     key_response: The key to write the response to the blackboard. If None, the

--- a/ada_feeding/ada_feeding/trees/__init__.py
+++ b/ada_feeding/ada_feeding/trees/__init__.py
@@ -22,6 +22,6 @@ from .move_to_mouth_tree import MoveToMouthTree
 from .trigger_tree import TriggerTree
 from .start_servo_tree import StartServoTree
 from .stop_servo_tree import StopServoTree
-from .activate_controller import ActivateController
+from .activate_controller import ActivateControllerTree
 
 from .acquire_food_tree import AcquireFoodTree

--- a/ada_feeding/ada_feeding/trees/activate_controller.py
+++ b/ada_feeding/ada_feeding/trees/activate_controller.py
@@ -15,13 +15,15 @@ from overrides import override
 import py_trees
 from py_trees.blackboard import Blackboard
 from rclpy.node import Node
+from std_srvs.srv import SetBool
 
 # Local imports
+from ada_feeding_msgs.action import ActivateController
 from ada_feeding.idioms import retry_call_ros_service
 from .trigger_tree import TriggerTree
 
 
-class ActivateController(TriggerTree):
+class ActivateControllerTree(TriggerTree):
     """
     This behavior tree calls the `~/switch_controller` service to activate a
     user-specified controller and deactivate all others.
@@ -32,6 +34,7 @@ class ActivateController(TriggerTree):
         node: Node,
         controller_to_activate: Optional[str] = "jaco_arm_cartesian_controller",
         all_controller_names: Optional[List[str]] = None,
+        re_tare: bool = False,
     ) -> None:
         """
         Initializes the behavior tree.
@@ -44,6 +47,7 @@ class ActivateController(TriggerTree):
         all_controller_names: The names of all controllers. If None, the default
             controllers are "jaco_arm_cartesian_controller", "jaco_arm_controller",
             and "jaco_arm_servo_controller"
+        re_tare: If True, re-tare the force-torque sensor before activating the controller.
         """
         # Initialize the TriggerTree class
         super().__init__(node=node)
@@ -55,6 +59,7 @@ class ActivateController(TriggerTree):
                 "jaco_arm_controller",
                 "jaco_arm_servo_controller",
             ]
+        self.re_tare = re_tare
 
     @override
     def create_tree(
@@ -63,40 +68,132 @@ class ActivateController(TriggerTree):
     ) -> py_trees.trees.BehaviourTree:
         # Docstring copied from @override
 
-        # Create the behavior to switch controllers
-        switch_controller_req = SwitchController.Request(
-            activate_controllers=[]
-            if self.controller_to_activate is None
-            else [self.controller_to_activate],
-            deactivate_controllers=[
-                controller
-                for controller in self.all_controller_names
-                if controller != self.controller_to_activate
+        # Write tree inputs to blackboard. Note that write access also gives
+        # read access.
+        blackboard = py_trees.blackboard.Client(name=name, namespace=name)
+        blackboard.register_key(
+            key="controller_to_activate", access=py_trees.common.Access.WRITE
+        )
+        blackboard.controller_to_activate = self.controller_to_activate
+        blackboard.register_key(key="re_tare", access=py_trees.common.Access.WRITE)
+        blackboard.re_tare = self.re_tare
+
+        # Create the behavior to re-tare the force-torque sensor
+        re_tare_ft_sensor_key_response = Blackboard.separator.join(
+            [name, "re_tare_ft_sensor", "response"]
+        )
+        re_tare = py_trees.composites.Selector(
+            name=name + "Re-tare Selector",
+            memory=True,
+            children=[
+                # Check if re-tare is **not** requested
+                py_trees.behaviours.CheckBlackboardVariableValue(
+                    name=name + "Check Re-tare",
+                    check=py_trees.common.ComparisonExpression(
+                        variable=Blackboard.separator.join([name, "re_tare"]),
+                        value=False,
+                        operator=operator.eq,
+                    ),
+                ),
+                # If the above is false (e.g., re-tare is requested), re-tare the sensor
+                retry_call_ros_service(
+                    name=name + "Re-tare F/T Sensor",
+                    service_type=SetBool,
+                    service_name="~/re_tare_ft",
+                    key_request=None,
+                    request=SetBool.Request(data=True),
+                    key_response=re_tare_ft_sensor_key_response,
+                    response_checks=[
+                        py_trees.common.ComparisonExpression(
+                            variable=re_tare_ft_sensor_key_response + ".success",
+                            value=True,
+                            operator=operator.eq,
+                        )
+                    ],
+                ),
             ],
-            activate_asap=True,
-            strictness=SwitchController.Request.BEST_EFFORT,
+        )
+
+        # Create the behavior to switch controllers
+        def switch_controller_request() -> SwitchController.Request:
+            return SwitchController.Request(
+                activate_controllers=(
+                    []  # Only possible via the __init__ parameter, not from the Action interface
+                    if blackboard.controller_to_activate is None
+                    else [blackboard.controller_to_activate]
+                ),
+                deactivate_controllers=[
+                    controller
+                    for controller in self.all_controller_names
+                    if controller != blackboard.controller_to_activate
+                ],
+                activate_asap=True,
+                strictness=SwitchController.Request.BEST_EFFORT,
+            )
+
+        switch_controllers_key_request = Blackboard.separator.join(
+            [name, "switch_controllers", "request"]
         )
         switch_controllers_key_response = Blackboard.separator.join(
             [name, "switch_controllers", "response"]
         )
-        switch_controllers = retry_call_ros_service(
-            name=name + "Activate Controller",
-            service_type=SwitchController,
-            service_name="~/switch_controller",
-            key_request=None,
-            request=switch_controller_req,
-            key_response=switch_controllers_key_response,
-            response_checks=[
-                py_trees.common.ComparisonExpression(
-                    variable=switch_controllers_key_response + ".ok",
-                    value=True,
-                    operator=operator.eq,
-                )
+        switch_controllers = py_trees.composites.Sequence(
+            name=name,
+            memory=True,
+            children=[
+                py_trees.behaviours.SetBlackboardVariable(
+                    name=name + "Set SwitchController Request",
+                    variable_name=switch_controllers_key_request,
+                    variable_value=switch_controller_request,
+                    overwrite=True,
+                ),
+                retry_call_ros_service(
+                    name=name + "Activate Controller",
+                    service_type=SwitchController,
+                    service_name="~/switch_controller",
+                    key_request=switch_controllers_key_request,
+                    key_response=switch_controllers_key_response,
+                    response_checks=[
+                        py_trees.common.ComparisonExpression(
+                            variable=switch_controllers_key_response + ".ok",
+                            value=True,
+                            operator=operator.eq,
+                        )
+                    ],
+                ),
             ],
         )
 
         # Put them together in a sequence
         # pylint: disable=duplicate-code
         return py_trees.trees.BehaviourTree(
-            root=switch_controllers,
+            root=py_trees.composites.Sequence(
+                name=name,
+                memory=True,
+                children=[
+                    re_tare,
+                    switch_controllers,
+                ],
+            )
         )
+
+    # Override goal to read arguments into local blackboard
+    @override
+    def send_goal(self, tree: py_trees.trees.BehaviourTree, goal: object) -> bool:
+        # Docstring copied by @override
+        # Note: if here, tree is root, not a subtree
+
+        # If it is a ActivateController.Goal, override the blackboard
+        if isinstance(goal, ActivateController.Goal):
+            # Write tree inputs to blackboard
+            name = tree.root.name
+            blackboard = py_trees.blackboard.Client(name=name, namespace=name)
+            blackboard.register_key(
+                key="controller_to_activate", access=py_trees.common.Access.WRITE
+            )
+            blackboard.controller_to_activate = goal.controller_to_activate
+            blackboard.register_key(key="re_tare", access=py_trees.common.Access.WRITE)
+            blackboard.re_tare = goal.re_tare
+
+        # Adds MoveToVisitor for Feedback
+        return super().send_goal(tree, goal)

--- a/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
@@ -34,7 +34,7 @@ from ada_feeding.idioms.bite_transfer import (
     get_toggle_collision_object_behavior,
 )
 from ada_feeding.trees import MoveToTree
-from .activate_controller import ActivateController
+from .activate_controller import ActivateControllerTree
 
 
 class MoveFromMouthTree(MoveToTree):
@@ -379,7 +379,7 @@ class MoveFromMouthTree(MoveToTree):
                                 [self.wheelchair_collision_object_id],
                                 True,
                             ),
-                            ActivateController(self._node)
+                            ActivateControllerTree(self._node)
                             .create_tree(name=name + "ActivateCartesianController")
                             .root,
                         ],
@@ -388,7 +388,9 @@ class MoveFromMouthTree(MoveToTree):
                         name=name,
                         memory=True,
                         children=[
-                            ActivateController(self._node, controller_to_activate=None)
+                            ActivateControllerTree(
+                                self._node, controller_to_activate=None
+                            )
                             .create_tree(name=name + "DeactivateCartesianController")
                             .root,
                             get_toggle_collision_object_behavior(

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -54,7 +54,7 @@ from ada_feeding.idioms.bite_transfer import (
 from ada_feeding.trees import (
     MoveToTree,
 )
-from .activate_controller import ActivateController
+from .activate_controller import ActivateControllerTree
 
 
 class MoveToMouthTree(MoveToTree):
@@ -474,7 +474,7 @@ class MoveToMouthTree(MoveToTree):
                                 [self.wheelchair_collision_object_id],
                                 True,
                             ),
-                            ActivateController(self._node)
+                            ActivateControllerTree(self._node)
                             .create_tree(name=name + "ActivateCartesianController")
                             .root,
                         ],
@@ -485,7 +485,9 @@ class MoveToMouthTree(MoveToTree):
                         name=name,
                         memory=True,
                         children=[
-                            ActivateController(self._node, controller_to_activate=None)
+                            ActivateControllerTree(
+                                self._node, controller_to_activate=None
+                            )
                             .create_tree(name=name + "DeactivateCartesianController")
                             .root,
                             get_toggle_collision_object_behavior(

--- a/ada_feeding/ada_feeding/trees/start_servo_tree.py
+++ b/ada_feeding/ada_feeding/trees/start_servo_tree.py
@@ -17,7 +17,7 @@ from std_srvs.srv import Trigger
 
 # Local imports
 from ada_feeding.idioms import retry_call_ros_service
-from .activate_controller import ActivateController
+from .activate_controller import ActivateControllerTree
 from .trigger_tree import TriggerTree
 
 
@@ -57,7 +57,7 @@ class StartServoTree(TriggerTree):
 
         # Create the behavior to switch controllers
         switch_controllers = (
-            ActivateController(
+            ActivateControllerTree(
                 self._node,
                 controller_to_activate=self.servo_controller_name,
             )

--- a/ada_feeding/ada_feeding/trees/stop_servo_tree.py
+++ b/ada_feeding/ada_feeding/trees/stop_servo_tree.py
@@ -22,7 +22,7 @@ from std_srvs.srv import Trigger
 from ada_feeding.behaviors.ros import UpdateTimestamp
 from ada_feeding.helpers import BlackboardKey
 from ada_feeding.idioms import retry_call_ros_service, wait_for_secs
-from .activate_controller import ActivateController
+from .activate_controller import ActivateControllerTree
 from .trigger_tree import TriggerTree
 
 
@@ -133,7 +133,7 @@ class StopServoTree(TriggerTree):
 
         # Create the behavior to turn off the controllers
         stop_controllers = (
-            ActivateController(
+            ActivateControllerTree(
                 self._node,
                 controller_to_activate=None,
             )

--- a/ada_feeding/ada_feeding/watchdog/ft_sensor_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/ft_sensor_condition.py
@@ -230,7 +230,7 @@ class FTSensorCondition(WatchdogCondition):
         else:
             condition_2 = (
                 "MESSAGES NOT UP-TO-DATE: The most recent message(s) have timestamps that are "
-                f">- {self.ft_timeout.nanoseconds / 10.0**9} secs in the past."
+                f">= {self.ft_timeout.nanoseconds / 10.0**9} secs in the past."
             )
 
         return [(status_1, name_1, condition_1), (status_2, name_2, condition_2)]

--- a/ada_feeding/config/ada_feeding_action_servers_default.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_default.yaml
@@ -18,8 +18,7 @@ ada_feeding_action_servers:
         - TestMoveToPose
         - StartServo
         - StopServo
-        - ActivateCartesianController
-        - ActivateJointController
+        - ActivateController
         - MoveToConfiguration
 
       # Parameters for the MoveAbovePlate action
@@ -268,20 +267,10 @@ ada_feeding_action_servers:
         tree_class: ada_feeding.trees.StopServoTree # required
         tick_rate: 10 # Hz, optional, default: 30
 
-      # Parameters for the ActivateCartesianController action
-      ActivateCartesianController: # required
-        action_type: ada_feeding_msgs.action.Trigger # required
-        tree_class: ada_feeding.trees.ActivateController # required
-        tick_rate: 10 # Hz, optional, default: 30
-
       # Parameters for the ActivateJointController action
-      ActivateJointController: # required
-        action_type: ada_feeding_msgs.action.Trigger # required
-        tree_class: ada_feeding.trees.ActivateController # required
-        tree_kws:
-          - controller_to_activate
-        tree_kwargs:
-          controller_to_activate: jaco_arm_servo_controller
+      ActivateController: # required
+        action_type: ada_feeding_msgs.action.ActivateController # required
+        tree_class: ada_feeding.trees.ActivateControllerTree # required
         tick_rate: 10 # Hz, optional, default: 30
 
       # Parameters for a generic MoveToConfiguration action

--- a/ada_feeding/scripts/dummy_ft_sensor.py
+++ b/ada_feeding/scripts/dummy_ft_sensor.py
@@ -124,6 +124,7 @@ class DummyForceTorqueSensor(Node):
             response.message = "Successfully unset the bias"
         with self.set_bias_request_time_lock:
             self.set_bias_request_time = self.get_clock().now()
+        self.get_logger().info(response.message)
         return response
 
     def publish_msg(self) -> None:

--- a/ada_feeding_msgs/CMakeLists.txt
+++ b/ada_feeding_msgs/CMakeLists.txt
@@ -23,6 +23,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Mask.msg"
 
   "action/AcquireFood.action"
+  "action/ActivateController.action"
   "action/MoveTo.action"
   "action/MoveToConfiguration.action"
   "action/MoveToMouth.action"

--- a/ada_feeding_msgs/action/ActivateController.action
+++ b/ada_feeding_msgs/action/ActivateController.action
@@ -1,0 +1,14 @@
+# This action type "inherits" from Trigger in that it has all the fields as
+# Trigger, and more.
+
+# What controller to activate. The action will deactive all other controllers.
+string controller_to_activate
+
+# Whether to also re-tare the force-torque sensor
+bool re_tare
+
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages
+---
+builtin_interfaces/Duration elapsed_time


### PR DESCRIPTION
# Description

This PR modifies the activate controller tree in two ways:

1. It allows it to also re-tare the F/T sensor. This brings teleop in line with all our other actions, where we re-tare the F/T sensor at the beginning of the action.
2. It allows users to pass in the controller to activate in the action goal (and hence consolidates similar actions into one).

# Testing procedure

- [x] Launch the code in real: `python3 src/ada_feeding/start.py`
- [x] Invoke the below actions. Verify (with `moveit` logs) that the appropriate controllers get activated, and verify (with `ft` logs) that the force-torque sensor does(n't) get re-tared.
    - [x] `ros2 action send_goal /ActivateController ada_feeding_msgs/action/ActivateController "{controller_to_activate: 'jaco_arm_cartesian_controller', re_tare: false}"`
    - [x] `ros2 action send_goal /ActivateController ada_feeding_msgs/action/ActivateController "{controller_to_activate: 'jaco_arm_servo_controller', re_tare: false}"`
    - [x] `ros2 action send_goal /ActivateController ada_feeding_msgs/action/ActivateController "{controller_to_activate: 'jaco_arm_cartesian_controller', re_tare: true}"`
    - [x] `ros2 action send_goal /ActivateController ada_feeding_msgs/action/ActivateController "{controller_to_activate: 'jaco_arm_servo_controller', re_tare: true}"`
- [x] Eat an entire bite with the web app.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
