### PR TITLE
Added a `start_nano.py` script

### DIFF
--- a/ada_planning_scene/ada_planning_scene/collision_object_manager.py
+++ b/ada_planning_scene/ada_planning_scene/collision_object_manager.py
@@ -60,7 +60,7 @@ class CollisionObjectManager:
         )
 
         # Add the parameters to store the (attached) collision objects that have
-        # beed added since the start of each batch.
+        # been added since the start of each batch.
         self.__collision_objects_lock = Lock()
         self.__n_batches = 0
         self.__collision_objects_per_batch = {

--- a/start.py
+++ b/start.py
@@ -247,7 +247,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
                 "pm2 log server",
             ],
             "camera": [
-                "ssh nano './run_camera.sh'",
+                "ssh nano './start_nano.sh'",
             ],
             "ft": [
                 "ros2 run forque_sensor_hardware forque_sensor_hardware --ros-args -p host:=ft-sensor-2",

--- a/start.py
+++ b/start.py
@@ -91,8 +91,10 @@ async def execute_command(screen_name: str, command: str, indent: int = 8) -> No
     indentation = " " * indent
     printable_command = command.replace("\003", "SIGINT")
     print(f"# {indentation}`{printable_command}`")
+    if command != "\003":
+        command += "\n"
     await asyncio.create_subprocess_shell(
-        f"screen -S {screen_name} -X stuff '{command}\n'"
+        f"screen -S {screen_name} -X stuff '{command}'"
     )
     await asyncio.sleep(args.launch_wait_secs)
     if command.startswith("sudo"):
@@ -250,7 +252,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
                 "pm2 log server",
             ],
             "camera": [
-                "ssh nano './start_nano.sh'",
+                "ssh nano -t './start_nano.sh'",
             ],
             "ft": [
                 "ros2 run forque_sensor_hardware forque_sensor_hardware --ros-args -p host:=ft-sensor-2",

--- a/start.py
+++ b/start.py
@@ -10,6 +10,9 @@ import getpass
 import os
 import sys
 
+# pylint: disable=duplicate-code
+# This is intentionally similar to start_nano.py
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--sim",

--- a/start_nano.py
+++ b/start_nano.py
@@ -107,7 +107,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
             "start the camera."
         )
     else:
-        print(f"# Terminating nano's camera in a screen session")
+        print("# Terminating nano's camera in a screen session")
     print(
         "################################################################################"
     )
@@ -120,8 +120,8 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
     }
     close_commands = {}
     attach_to_screen_name = "camera"
-    initial_close_commands = ["\003"] # Ctrl+c termination
-    initial_start_commands = []
+    initial_close_commands = ["\003"]  # Ctrl+c termination
+    initial_start_commands = [f"cd {pwd}"]
     for screen_name, commands in screen_sessions.items():
         screen_sessions[screen_name] = initial_start_commands + commands
         if screen_name not in close_commands:

--- a/start_nano.py
+++ b/start_nano.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module starts all the screen sessions to run the ada_feeding demo.
+"""
+
+import asyncio
+import argparse
+import getpass
+import os
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-t",
+    "--termination_wait_secs",
+    default=5,
+    help="How long (secs) to wait for the code within screens to terminate (default, 5)",
+)
+parser.add_argument(
+    "-l",
+    "--launch_wait_secs",
+    default=0.1,
+    help=(
+        "How long (secs) to wait between running code in screens. Not that "
+        "too low of a value can result in commands getting rearranged. (default, 0.1)"
+    ),
+)
+parser.add_argument(
+    "-c",
+    "--close",
+    action="store_true",
+    help="If set, only terminate the code in the screens.",
+)
+
+
+async def get_existing_screens():
+    """
+    Get a list of active screen sessions.
+
+    Adapted from
+    https://serverfault.com/questions/886405/create-screen-session-in-background-only-if-it-doesnt-already-exist
+    """
+    proc = await asyncio.create_subprocess_shell(
+        "screen -ls", stdout=asyncio.subprocess.PIPE
+    )
+    stdout, _ = await proc.communicate()
+    existing_screens = [
+        line.split(".")[1].split("\t")[0].rstrip()
+        for line in stdout.decode("utf-8").splitlines()
+        if line.startswith("\t")
+    ]
+    return existing_screens
+
+
+async def execute_command(screen_name: str, command: str, indent: int = 8) -> None:
+    """
+    Execute a command in a screen.
+    """
+    global sudo_password  # pylint: disable=global-statement
+    indentation = " " * indent
+    printable_command = command.replace("\003", "SIGINT")
+    print(f"# {indentation}`{printable_command}`")
+    await asyncio.create_subprocess_shell(
+        f"screen -S {screen_name} -X stuff '{command}\n'"
+    )
+    await asyncio.sleep(args.launch_wait_secs)
+    if command.startswith("sudo"):
+        if sudo_password is None:
+            sudo_password = getpass.getpass(
+                prompt=f"# {indentation}Enter sudo password: "
+            )
+        await asyncio.create_subprocess_shell(
+            f"screen -S {screen_name} -X stuff '{sudo_password}\n'"
+        )
+        await asyncio.sleep(args.launch_wait_secs)
+    elif command.startswith("ssh"):
+        ssh_password = getpass.getpass(prompt=f"# {indentation}Enter ssh password: ")
+        await asyncio.create_subprocess_shell(
+            f"screen -S {screen_name} -X stuff '{ssh_password}\n'"
+        )
+        await asyncio.sleep(args.launch_wait_secs)
+
+
+async def main(args: argparse.Namespace, pwd: str) -> None:
+    """
+    Start the ada_feeding demo.
+
+    Args:
+        args: The command-line arguments.
+        pwd: The absolute path to the current directory.
+    """
+
+    # pylint: disable=too-many-branches, too-many-statements
+    # This is meant to be a flexible function, hence the many branches and statements.
+    # pylint: disable=redefined-outer-name
+    # That is okay in this case.
+
+    print(
+        "################################################################################"
+    )
+    if not args.close:
+        print("# Running nano's camera in a screen session")
+        print("# Prerequisites / Notes:")
+        print(
+            "#     1. The home directory should contain the run_camera.sh script to "
+            "start the camera."
+        )
+    else:
+        print(f"# Terminating nano's camera in a screen session")
+    print(
+        "################################################################################"
+    )
+
+    # Determine which screen sessions to start and what commands to run
+    screen_sessions = {
+        "camera": [
+            "~/run_camera.sh",
+        ],
+    }
+    close_commands = {}
+    attach_to_screen_name = "camera"
+    initial_close_commands = ["\003"] # Ctrl+c termination
+    initial_start_commands = []
+    for screen_name, commands in screen_sessions.items():
+        screen_sessions[screen_name] = initial_start_commands + commands
+        if screen_name not in close_commands:
+            close_commands[screen_name] = []
+        close_commands[screen_name] = (
+            initial_close_commands + close_commands[screen_name]
+        )
+
+    # Determine which screens are already running
+    print("# Checking for existing screen sessions")
+    terminated_screen = False
+    existing_screens = await get_existing_screens()
+    for screen_name in screen_sessions:
+        if screen_name in existing_screens:
+            print(f"#    Found session `{screen_name}`: ")
+            for command in close_commands[screen_name]:
+                await execute_command(screen_name, command)
+            terminated_screen = True
+        elif not args.close:
+            print(f"#    Creating session `{screen_name}`")
+            await asyncio.create_subprocess_shell(f"screen -dmS {screen_name}")
+            await asyncio.sleep(args.launch_wait_secs)
+
+    print(
+        "################################################################################"
+    )
+
+    if not args.close:
+        # Sleep for a bit to allow the screens to terminate
+        if terminated_screen:
+            print(f"# Waiting {args.termination_wait_secs} secs for code to terminate")
+            await asyncio.sleep(args.termination_wait_secs)
+            print(
+                "################################################################################"
+            )
+
+        # Start the screen sessions
+        print("# Starting camera code")
+        for screen_name, commands in screen_sessions.items():
+            print(f"#     `{screen_name}`")
+            for command in commands:
+                await execute_command(screen_name, command)
+        print(
+            "################################################################################"
+        )
+
+        print(f"# Done! Attaching to the {attach_to_screen_name} screen session")
+        await asyncio.create_subprocess_shell(f"screen -rd {attach_to_screen_name}")
+
+
+if __name__ == "__main__":
+    # Get the arguments
+    args = parser.parse_args()
+    # Check args
+    if args.sim not in ["real", "mock", "dummy"]:
+        raise ValueError(
+            f"Unknown sim value {args.sim}. Must be one of ['real', 'mock', 'dummy']."
+        )
+
+    # Ensure the script is not being run as sudo. Sudo has a different screen
+    # server and may have different versions of libraries installed.
+    if os.geteuid() == 0:
+        print(
+            "ERROR: This script should not be run as sudo. Run as a regular user.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Get the path to the home folder.
+    home_pwd = os.path.abspath("~")
+
+    # Run the main function
+    sudo_password = None  # pylint: disable=invalid-name
+    asyncio.run(main(args, home_pwd))
+
+    # Return success
+    sys.exit(0)

--- a/start_nano.sh
+++ b/start_nano.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Create a SIGINT handler
+control_c() {
+    # Terminate the camera screen
+    python3 ~/start_nano.py -c
+    # Exit the script
+    exit
+}
+trap control_c SIGINT
+
+# Get the TTY device for the current terminal
+TTY=$(tty)
+
+# This starts the camera screen
+python3 ~/start_nano.py --tty=$TTY
+
+# This idles until Ctrl+C is pressed. https://stackoverflow.com/a/36991974
+read -r -d '' _ </dev/tty

--- a/start_nano.sh
+++ b/start_nano.sh
@@ -2,6 +2,7 @@
 
 # Create a SIGINT handler
 control_c() {
+    echo "Ctrl+C pressed"
     # Terminate the camera screen
     python3 ~/start_nano.py -c
     # Exit the script


### PR DESCRIPTION
# Description

## Current State

We currently launch the camera code on nano through an ssh session that runs a bash script. However, the downside is that sometimes, passing SIGINT (Ctrl+c) to the ssh session only terminates the ssh session, and not the bash script running on nano. This results in the camera code still running, which causes an error when we re-run the robot's start script. Currently, we've been addressing this by ssh-ing into nano, listing all processes with "camera" in them (`ps -aux | grep camera`) and manually killing their PID (e.g., `kill {pid}`).

## PR Change

This PR improves upon the above by adding a script for `nano` to run the camera **_within a screen session_**. Because it keeps using the the same screen shell to run the camera, even if the previous invokation did not properly terminate the camera, this invokation will first terminate the camera and then re-run it. Thus, you should never have multiple cameras running in parallel.

# Configuring this code to run on `nano`

- [x] Pull this branch on `lovelace`.
- [x] Use `scp` to move `start_nano.py` and `start_nano.sh` to the home directory (`~`) of `nano`.
- [x] Make both scripts executable:
    - [x] `chmod +x start_nano.sh`
    - [x] `chmod +x start_nano.py`

# Testing procedure

- [x] Test on `nano`:
    - [x] SSH into `nano`
    - [x] From the home directory, run `./start_nano.sh`. Verify that the camera loads and its output appears on your terminal screen.
    - [x] Terminate it (Ctrl+C). Verify it cleanly terminates. Go into the screen (`screen -r camera`) and verify it has terminated there as well.
    - [x] Repeat the above steps, to verify it succesfully re-launches after the screen is already open.
- [x] Test on `lovelace`:
    - [x] Start the code in real: `python3 src/ada_feeding/start.py`
    - [x] Verify the camera started (e.g., `ros2 node list` or checking that the camera image appears on the web app)
    - [x] Terminate the code: `python3 src/ada_feeding_start.py -c`
    - [x] Verify that the camera node terminated (e.g., with `ros2 node list`)
    - [x] Repeat the above steps, to verify it succesfully re-launches after having been closed.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
