### PR TITLE
Extended e-stop watchdog to allow for a USB adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This README is the definitive source for downloading, installing, and running th
         cd ~/colcon_ws
         colcon build --symlink-install # if sim-only, add '--packages-skip ada_hardware'
 
+### Setup (Robot Hardware)
+
+If you change the e-stop button, the e-stop button's adapter(s), and/or the device this code is being run on, you may have to change several device-specific parameters for the e-stop to work. Read the long comment above `amixer_configuration_name` in `ada_feeding/config/ada_watchdog.yaml` for detailed instructions on changing these parameters.
+
 ### Setup (Web App)
 
 1. Install the Node Version Manager (nvm): https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script

--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import numpy.typing as npt
 import pyaudio
+import pyudev
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 import rclpy
 from rclpy.duration import Duration
@@ -69,7 +70,7 @@ class EStopCondition(WatchdogCondition):
         self.__load_parameters()
 
         # Set system volume
-        self.__set_system_volume()
+        self.__configure_system_audio()
 
         # Initialize the accumulators
         self.start_time = None
@@ -86,14 +87,8 @@ class EStopCondition(WatchdogCondition):
         self.std_ema = None
         self.std_ema_lock = Lock()
 
-        # Start listening for ACPI events on a separate thread
-        self.acpi_thread = Thread(target=self.__acpi_listener, daemon=True)
-        self.acpi_thread.start()
-
-        # Initialize the pyaudio object
-        self.audio = pyaudio.PyAudio()
-
         # Initialize the stream, with a callback
+        self.audio = None
         self.stream = None
         self.last_stream_init_time = self._node.get_clock().now()
         self.__init_stream()
@@ -136,21 +131,6 @@ class EStopCondition(WatchdogCondition):
         )
         self.chunk = chunk.value
 
-        device = self._node.declare_parameter(
-            "device",
-            0,
-            ParameterDescriptor(
-                name="device",
-                type=ParameterType.PARAMETER_INTEGER,
-                description=(
-                    "The index of the audio device to use. This should usually "
-                    "be 0, to indicate the default audio device."
-                ),
-                read_only=True,
-            ),
-        )
-        self.device = device.value
-
         stream_open_retry_hz = self._node.declare_parameter(
             "stream_open_retry_hz",
             1.0,
@@ -183,23 +163,6 @@ class EStopCondition(WatchdogCondition):
             ),
         )
         self.initial_wait_duration = Duration(seconds=initial_wait_secs.value)
-
-        acpi_event_name = self._node.declare_parameter(
-            "acpi_event_name",
-            "jack/microphone MICROPHONE",
-            ParameterDescriptor(
-                name="acpi_event_name",
-                type=ParameterType.PARAMETER_STRING,
-                description=(
-                    "The name of the ACPI event that is triggered when the e-stop "
-                    "button is (un)plugged. Get this value by running `acpi_listener` "
-                    "in the terminal and unplugging the e-stop button. Exclude the word "
-                    "` plug` or ` unplug` from the end of the event name."
-                ),
-                read_only=True,
-            ),
-        )
-        self.acpi_event_name = acpi_event_name.value
 
         min_threshold = self._node.declare_parameter(
             "min_threshold",
@@ -267,6 +230,28 @@ class EStopCondition(WatchdogCondition):
                 read_only=True,
             ),
         )
+        pactl_mic_name = self._node.declare_parameter(
+            f"{amixer_configuration_name.value}.pactl_mic_name",
+            None,
+            ParameterDescriptor(
+                name=f"{amixer_configuration_name.value}.pactl_mic_name",
+                type=ParameterType.PARAMETER_STRING,
+                description=("The name of the microphone to set as default."),
+                read_only=True,
+            ),
+        )
+        amixer_card_num = self._node.declare_parameter(
+            f"{amixer_configuration_name.value}.amixer_card_num",
+            None,
+            ParameterDescriptor(
+                name=f"{amixer_configuration_name.value}.amixer_card_num",
+                type=ParameterType.PARAMETER_INTEGER,
+                description=(
+                    "The sound card number of the microphone to set as default."
+                ),
+                read_only=True,
+            ),
+        )
         amixer_mic_toggle_control_name = self._node.declare_parameter(
             f"{amixer_configuration_name.value}.amixer_mic_toggle_control_name",
             None,
@@ -310,10 +295,69 @@ class EStopCondition(WatchdogCondition):
                 read_only=True,
             ),
         )
-        self.amixer_configuration = {
+        is_usb = self._node.declare_parameter(
+            f"{amixer_configuration_name.value}.is_usb",
+            False,
+            ParameterDescriptor(
+                name="is_usb",
+                type=ParameterType.PARAMETER_BOOL,
+                description=(
+                    "Whether the microphone is a USB microphone. If True, the "
+                    "udev event listener is used to detect it being unplugged, "
+                    "else the ACPI event listener is used."
+                ),
+                read_only=True,
+            ),
+        )
+        acpi_event_name = self._node.declare_parameter(
+            f"{amixer_configuration_name.value}.acpi_event_name",
+            None,
+            ParameterDescriptor(
+                name="acpi_event_name",
+                type=ParameterType.PARAMETER_STRING,
+                description=(
+                    "The name of the ACPI event that is triggered when the e-stop "
+                    "button is (un)plugged. Only applicable if `is_usb` is False."
+                ),
+                read_only=True,
+            ),
+        )
+        udev_id = self._node.declare_parameter(
+            f"{amixer_configuration_name.value}.udev_id",
+            None,
+            ParameterDescriptor(
+                name="udev_id",
+                type=ParameterType.PARAMETER_STRING,
+                description=(
+                    "The id of the USB device. Only applicable if `is_usb` is True."
+                ),
+                read_only=True,
+            ),
+        )
+        device_name = self._node.declare_parameter(
+            f"{amixer_configuration_name.value}.device_name",
+            None,
+            ParameterDescriptor(
+                name="device_name",
+                type=ParameterType.PARAMETER_STRING,
+                description=(
+                    "The name of the audio device. This is used to get the device "
+                    "index for `pyaudio`. If unspecified, device index 0 is used, "
+                    "which typically works if your device is connected by the 3.5mm aux port."
+                ),
+                read_only=True,
+            ),
+        )
+        self.audio_configuration = {
+            "pactl_mic_name": pactl_mic_name.value,
+            "amixer_card_num": amixer_card_num.value,
             "amixer_mic_toggle_control_name": amixer_mic_toggle_control_name.value,
             "amixer_mic_control_names": amixer_mic_control_names.value,
             "amixer_mic_control_percentages": amixer_mic_control_percentages.value,
+            "is_usb": is_usb.value,
+            "acpi_event_name": acpi_event_name.value,
+            "device_name": device_name.value,
+            "udev_id": udev_id.value,
         }
 
         std_ema_min_thresh = self._node.declare_parameter(
@@ -375,30 +419,52 @@ class EStopCondition(WatchdogCondition):
         )
         self.num_secs_threshold = num_secs_threshold.value
 
-    def __set_system_volume(self) -> None:
+    def __configure_system_audio(self) -> None:
         """
-        Set the system volume using `amixer`. This is necessary because the
-        e-stop button is a microphone, so the system's microphone volume will
-        impact the amplitude of readings for the e-stop button.
+        Configure the system audio. This function sets the default mic and sets
+        its volume. This is necessary because the  e-stop button is a microphone,
+        so the system's microphone volume will impact the amplitude of readings
+        for the e-stop button.
 
         TODO: Although not crucial, we should consider storing the original
         system volume, and then restoring it when thos watchdog condition is
         terminated.
         """
-        # Get the amixer_configuration
-        toggle_control_name = self.amixer_configuration[
-            "amixer_mic_toggle_control_name"
-        ]
-        control_names = self.amixer_configuration["amixer_mic_control_names"]
-        control_percentages = self.amixer_configuration[
-            "amixer_mic_control_percentages"
-        ]
+        # pylint: disable=too-many-branches
+        # There are several steps to the configuration, so we need many branches.
 
-        # First, unmute the microphone
+        # Get the amixer_configuration
+        pactl_mic_name = self.audio_configuration["pactl_mic_name"]
+        amixer_card_num = self.audio_configuration["amixer_card_num"]
+        if amixer_card_num is None:
+            amixer_card_num = "0"
+        if not isinstance(amixer_card_num, str):
+            amixer_card_num = str(amixer_card_num)
+        toggle_control_name = self.audio_configuration["amixer_mic_toggle_control_name"]
+        control_names = self.audio_configuration["amixer_mic_control_names"]
+        control_percentages = self.audio_configuration["amixer_mic_control_percentages"]
+        is_usb = self.audio_configuration["is_usb"]
+
+        # Set the default microphone
+        if pactl_mic_name is not None:
+            try:
+                set_default_mic = subprocess.check_output(
+                    ["pactl", "set-default-source", pactl_mic_name]
+                )
+                if b"Failure" in set_default_mic:
+                    self._node.get_logger().error(
+                        f"Failed to set default microphone to {pactl_mic_name}:\n{set_default_mic}"
+                    )
+            except subprocess.CalledProcessError as exc:
+                self._node.get_logger().error(
+                    f"Error setting default microphone: {exc.output}"
+                )
+
+        # Unmute the microphone
         if toggle_control_name is not None:
             try:
                 toggle_output = subprocess.check_output(
-                    ["amixer", "sget", toggle_control_name]
+                    ["amixer", "-c", amixer_card_num, "sget", toggle_control_name]
                 )
                 if b"[off]" in toggle_output:
                     toggle_output = subprocess.check_output(
@@ -418,14 +484,21 @@ class EStopCondition(WatchdogCondition):
                 "cannot be unmuted"
             )
 
-        # Then, set the microphone volume
+        # Set the microphone volume
         if control_names is not None and control_percentages is not None:
             for i in range(min(len(control_names), len(control_percentages))):
                 try:
                     control_name = control_names[i]
                     control_percentage = control_percentages[i]
                     control_output = subprocess.check_output(
-                        ["amixer", "sset", control_name, f"{control_percentage}%"]
+                        [
+                            "amixer",
+                            "-c",
+                            amixer_card_num,
+                            "sset",
+                            control_name,
+                            f"{control_percentage}%",
+                        ]
                     )
                     if f"[{control_percentage}%]".encode() not in control_output:
                         self._node.get_logger().error(
@@ -442,11 +515,48 @@ class EStopCondition(WatchdogCondition):
                 "are not set, so the system microphone volume cannot be set"
             )
 
+        # Monitor for the audio device being unplugged
+        if is_usb:
+            self.udev_context = pyudev.Context()
+            self.udev_monitor = pyudev.Monitor.from_netlink(self.udev_context)
+            self.udev_monitor.filter_by(subsystem="sound")
+            self.udev_observer = pyudev.MonitorObserver(
+                self.udev_monitor, self.__udev_listener
+            )
+            self.udev_observer.start()
+        else:
+            # Start listening for ACPI events on a separate thread
+            self.acpi_thread = Thread(target=self.__acpi_listener, daemon=True)
+            self.acpi_thread.start()
+
     def __init_stream(self) -> None:
         """
         Initialize the audio stream. This function opens the audio stream and
         sets the callback function.
         """
+        # Initialize the pyaudio object
+        self.audio = pyaudio.PyAudio()
+
+        # Get the device index
+        device_i = 0
+        device_name = self.audio_configuration["device_name"]
+        if device_name is not None:
+            device_i = None
+            names = []
+            for i in range(self.audio.get_device_count()):
+                device_info = self.audio.get_device_info_by_index(i)
+                if device_info["maxInputChannels"] > 0:
+                    names.append(device_info["name"])
+                    if device_name in device_info["name"]:
+                        device_i = i
+                        break
+            if device_i is None:
+                self._node.get_logger().error(
+                    f"Device name {device_name} not found. Available devices: {repr(names)}. "
+                    "Using device index 0."
+                )
+                device_i = 0
+
         self.last_stream_init_time = self._node.get_clock().now()
         try:
             self.stream = self.audio.open(
@@ -455,18 +565,52 @@ class EStopCondition(WatchdogCondition):
                 rate=self.rate,
                 input=True,
                 frames_per_buffer=self.chunk,
-                input_device_index=self.device,
+                input_device_index=device_i,
                 stream_callback=self.__audio_callback,
             )
         except OSError as exc:
             self._node.get_logger().error(
                 (
-                    f"Error opening audio device {self.device}. "
+                    f"Error opening audio device with index {device_i}. "
                     f"{EStopCondition.PYAUDIO_STREAM_TROUBLESHOOTING}\n\n"
                     f"Excpetion: {exc}"
                 ),
                 throttle_duration_sec=1,
             )
+
+    def __deinit_stream(self) -> None:
+        """
+        Deinitialize the audio stream. This function stops the audio stream and
+        closes it.
+        """
+        if self.audio is not None:
+            self.audio.terminate()
+            self.audio = None
+        if self.stream is not None:
+            self.stream.stop_stream()
+            self.stream.close()
+            self.stream = None
+
+    def __udev_listener(self, action: str, device: pyudev.Device) -> None:
+        """
+        Listens for UDEV events. If the e-stop button is unplugged, sets the
+        `is_mic_unplugged` flag to True.
+        """
+        udev_id = self.audio_configuration["udev_id"]
+        device_id = device.get("ID_ID")
+        self._node.get_logger().info(f"UDEV event: {action} {device_id}")
+        if device_id is not None and udev_id in device_id:
+            if action == "remove":
+                self._node.get_logger().info("E-Stop button unplugged")
+                with self.is_mic_unplugged_lock:
+                    self.is_mic_unplugged = True
+            # Although there is also an "add" action, that doesn't have the devce ID.
+            elif action == "change":
+                self._node.get_logger().info("E-Stop button plugged in")
+                with self.is_mic_unplugged_lock:
+                    self.is_mic_unplugged = False
+                self.__deinit_stream()
+                self.__init_stream()
 
     def __acpi_listener(self) -> None:
         """
@@ -476,6 +620,7 @@ class EStopCondition(WatchdogCondition):
         chunk = 4096
         plug_keyword = "plug"
         unplug_keyword = "unplug"
+        acpi_event_name = self.audio_configuration["acpi_event_name"]
 
         # Open a socket to listen for ACPI events
         stream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -486,12 +631,14 @@ class EStopCondition(WatchdogCondition):
             data_bytes = stream.recv(chunk)
             data = data_bytes.decode("utf-8")
             for event in data.split("\n"):
-                if self.acpi_event_name in event:
+                if acpi_event_name in event:
                     keyword = event.split(" ")[-1]
                     if unplug_keyword == keyword:
+                        self._node.get_logger().info("E-Stop button unplugged")
                         with self.is_mic_unplugged_lock:
                             self.is_mic_unplugged = True
                     elif plug_keyword == keyword:
+                        self._node.get_logger().info("E-Stop button plugged in")
                         with self.is_mic_unplugged_lock:
                             self.is_mic_unplugged = False
 
@@ -614,6 +761,9 @@ class EStopCondition(WatchdogCondition):
 
         # Convert the data to a numpy array
         data_arr = np.frombuffer(data, dtype=np.int16)
+        self._node.get_logger().debug(
+            f"Data max: {np.max(data_arr)}, min: {np.min(data_arr)}"
+        )
 
         # Check if the e-stop button has been pressed
         if EStopCondition.rising_edge_detector(
@@ -633,6 +783,7 @@ class EStopCondition(WatchdogCondition):
             ):
                 self.prev_button_click_start_time = self._node.get_clock().now()
                 with self.num_clicks_lock:
+                    self._node.get_logger().info("E-Stop button clicked")
                     self.num_clicks += 1
 
         # Return the data
@@ -764,8 +915,4 @@ class EStopCondition(WatchdogCondition):
         """
         Terminate the EStop condition. This cleanly closes the pyaudio connection.
         """
-        # Close the audio stream
-        if self.stream is not None:
-            self.stream.stop_stream()
-            self.stream.close()
-        self.audio.terminate()
+        self.__deinit_stream()

--- a/ada_feeding/ada_feeding/watchdog/estop_condition.py
+++ b/ada_feeding/ada_feeding/watchdog/estop_condition.py
@@ -464,17 +464,20 @@ class EStopCondition(WatchdogCondition):
         # Unmute the microphone
         if toggle_control_name is not None:
             try:
-                toggle_output = subprocess.check_output(
-                    ["amixer", "-c", amixer_card_num, "sget", toggle_control_name]
+                unmute_output = subprocess.check_output(
+                    [
+                        "amixer",
+                        "-c",
+                        amixer_card_num,
+                        "sset",
+                        toggle_control_name,
+                        "unmute",
+                    ]
                 )
-                if b"[off]" in toggle_output:
-                    toggle_output = subprocess.check_output(
-                        ["amixer", "sset", toggle_control_name, "toggle"]
+                if b"[on]" not in unmute_output:
+                    self._node.get_logger().error(
+                        f"Microphone remained muted even after unmuting:\n{unmute_output}"
                     )
-                    if b"[on]" not in toggle_output:
-                        self._node.get_logger().error(
-                            f"Microphone remained muted even after toggling:\n{toggle_output}"
-                        )
             except subprocess.CalledProcessError as exc:
                 self._node.get_logger().error(
                     f"Error toggling microphone on: {exc.output}"

--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -106,10 +106,10 @@ ada_watchdog:
     #         - Plug in the microphone.
     #         - Run `arecord -l`.
     #         - The name that is different, within square brackets, is the name of the mic.
-    amixer_configuration_name: lovelace
+    amixer_configuration_name: t0b1
     t0b1:
-      pactl_mic_name: ''  # TODO
-      amixer_card_num: 0  # TODO
+      pactl_mic_name: 'alsa_input.pci-0000_00_1f.3.analog-stereo'
+      amixer_card_num: 0
       amixer_mic_toggle_control_name: "'Capture',0"
       amixer_mic_control_names:
         - "'Capture',0"

--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -25,21 +25,11 @@ ada_watchdog:
     # The number of samples to take at a time. If you are getting overflow
     # errors, try increasing this number.
     chunk: 4800
-    # The device ID of the microphone (e-stop button). This should usually
-    # be 0, the system default
-    device: 0
     # How often (in Hz) to retry opening the microphone if it fails.
     stream_open_retry_hz: 1.0
     # How long to wait before checking the microphone readings. This is because
     # there is initial noise when we first listen to the microphone.
     initial_wait_secs: 2.0
-    # The ACPI event for when the microphone is (un)plugged. To find this, run
-    # `acpi_listen` in a terminal and plug/unplug the microphone. The output
-    # should look something like this:
-    #   jack/microphone MICROPHONE plug
-    #   jack/microphone MICROPHONE unplug
-    # Include the first two words in this parameter, exclude the third.
-    acpi_event_name: "jack/microphone MICROPHONE"
     # If there is a falling edge that passes this 16-bit int, it is considered a button
     # click.
     min_threshold: -10000
@@ -56,7 +46,19 @@ ada_watchdog:
     # controls, we specify device-specific configurations.
     # 
     # Instructions to get the amixer parameters are here:
-    #     1. `amixer_mic_toggle_control_name`:
+    #     1. `pactl_mic_name`:
+    #         - Unplug the microphone.
+    #         - Run `pactl list short sinks`.
+    #         - Plug in the microphone.
+    #         - Run `pactl list short sinks`.
+    #         - The name that is different is the name of the mic. If there are
+    #           multiple, use the one without "monitor" appended to its name.
+    #     2. `amixer_card_num`:
+    #         - Run `pactl list sinks`.
+    #         - For the mic name you found above, check the "alsa.card" property.
+    #           Use that value.
+    #         - (Note: You can also get the card number by running `arecord -l`.)
+    #     3. `amixer_mic_toggle_control_name`:
     #         - Mute the microphone in the system settings.
     #         - Run `amixer` in a terminal.
     #         - Unmute the microphone in the system settings.
@@ -64,14 +66,14 @@ ada_watchdog:
     #         - See which control switched from [off] to [on]. That is the control
     #           name you want. (Note: saving amixer output to file and running `diff`
     #           make this process easier.)
-    #     2. `amixer_mic_control_names`:
+    #     4. `amixer_mic_control_names`:
     #         - Unmute the microphone in the system settings, and set its volume to be
     #           low but not 0%.
     #         - Run `amixer` in a terminal.
     #         - In system settings, set the microphone volume to be 100%.
     #         - Run `amixer` in a terminal.
     #         - See which controls changed. Those are the control names you want.
-    #     3. `amixer_mic_control_percentages`:
+    #     5. `amixer_mic_control_percentages`:
     #         - Open Audacity and System Settings side-by-side. Start recording in
     #           Audacity. Press the e-stop button and notice the curve. You want the
     #           low/high points of the curve to reach +/-1.0, but not exceed it (evidenced
@@ -79,8 +81,35 @@ ada_watchdog:
     #           System Settings until you get this.
     #         - Run `amixer` in a terminal. Check the percentages for the controls you found
     #           in the previous step. Those are the percentages you want.
+    #         - (Note: we have had this script work even if in audacity the curve only reaches
+    #           +/- 0.5, but it is better to aim for +/- 1.0 if possible.)
+    #     6. `is_usb`: true if the microphone is a USB microphone, false otherwise (3.5mm aux).
+    #     7. `acpi_event_name`: Only applicable if `is_usb` is false.
+    #         - Run `acpi_listen`.
+    #         - Plug in the microphone.
+    #         - Unplug the microphone.
+    #         - The output should look something like this:
+    #             jack/microphone MICROPHONE plug
+    #             jack/microphone MICROPHONE unplug
+    #         - Include the first two words in this parameter, exclude the third (plug/unplug).
+    #     8. `udev_id`: Only applicable if `is_usb` is true.
+    #         - Run `udevadm monitor -u -p --subsystem-match=sound`.
+    #         - Plug in the microphone.
+    #         - Get the value after `ID_ID=`.
+    #         - Unplug the microphone.
+    #         - Verify that the value is the same.
+    #         - Use that value.
+    #     9. `device_name`: The name of the device. This isused to get the right device number
+    #         for pyaudio. If unspecified, device number 0 is used (typically fine for 3.5mm aux mics).
+    #         - Unplug the microphone.
+    #         - Run `arecord -l`.
+    #         - Plug in the microphone.
+    #         - Run `arecord -l`.
+    #         - The name that is different, within square brackets, is the name of the mic.
     amixer_configuration_name: lovelace
     t0b1:
+      pactl_mic_name: ''  # TODO
+      amixer_card_num: 0  # TODO
       amixer_mic_toggle_control_name: "'Capture',0"
       amixer_mic_control_names:
         - "'Capture',0"
@@ -88,11 +117,16 @@ ada_watchdog:
       amixer_mic_control_percentages:
         - 37
         - 0
+      is_usb: false
+      acpi_event_name: "jack/microphone MICROPHONE"
     lovelace:
-      amixer_mic_toggle_control_name: "'Capture',0"
+      pactl_mic_name: 'alsa_input.usb-Plugable_Plugable_USB_Audio_Device_000000000000-00.analog-stereo'
+      amixer_card_num: 2
+      amixer_mic_toggle_control_name: "'Mic',0"
       amixer_mic_control_names:
-        - "'Capture',0"
-        - "'Internal Mic Boost',0"
+        - "'Mic',0"
       amixer_mic_control_percentages:
-        - 40
-        - 0
+        - 100
+      is_usb: true
+      udev_id: 'usb-Plugable_Plugable_USB_Audio_Device_000000000000-00'
+      device_name: 'Plugable USB Audio Device'

--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -106,7 +106,7 @@ ada_watchdog:
     #         - Plug in the microphone.
     #         - Run `arecord -l`.
     #         - The name that is different, within square brackets, is the name of the mic.
-    amixer_configuration_name: t0b1
+    amixer_configuration_name: lovelace
     t0b1:
       pactl_mic_name: 'alsa_input.pci-0000_00_1f.3.analog-stereo'
       amixer_card_num: 0

--- a/ada_feeding/package.xml
+++ b/ada_feeding/package.xml
@@ -16,9 +16,10 @@
 
   <exec_depend>moveit_msgs</exec_depend>
   <exec_depend>pymoveit2</exec_depend>
+  <exec_depend>python3-overrides</exec_depend>
   <exec_depend>python3-pyaudio</exec_depend>
   <exec_depend>python-pyrealsense2-pip</exec_depend>
-  <exec_depend>python3-overrides</exec_depend>
+  <exec_depend>python3-pyudev</exec_depend>
   <exec_depend>python3-skimage</exec_depend>
   <exec_depend>python3-sounddevice-pip</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>

--- a/ada_feeding_perception/ada_feeding_perception/helpers.py
+++ b/ada_feeding_perception/ada_feeding_perception/helpers.py
@@ -41,6 +41,12 @@ __COMPRESSED_DEPTH_16UC1_HEADER = array.array(
     "B", [0, 0, 0, 0, 46, 32, 133, 4, 192, 24, 60, 78]
 )
 
+try:
+    generic_image_type = Union[Image, rImage, CompressedImage, rCompressedImage]
+except NameError as _:
+    # This only happens if rosbags wasn't imported, which is logged above.
+    generic_image_type = Union[Image, CompressedImage]
+
 
 def show_normalized_depth_img(img, wait=True, window_name="img"):
     """
@@ -227,7 +233,7 @@ def depth_img_to_pointcloud(
 
 
 def ros_msg_to_cv2_image(
-    msg: Union[Image, rImage, CompressedImage, rCompressedImage],
+    msg: generic_image_type,
     bridge: Optional[CvBridge] = None,
 ) -> npt.NDArray:
     """
@@ -277,7 +283,7 @@ def cv2_image_to_ros_msg(
     compress: bool,
     bridge: Optional[CvBridge] = None,
     encoding: str = "passthrough",
-) -> Union[Image, CompressedImage]:
+) -> generic_image_type:
     """
     Convert a cv2 image to a ROS Image or CompressedImage message. Note that this
     does not set the header of the message; that must be done outside of this


### PR DESCRIPTION
# Description

Our previous e-stop setup was the following:

1. [Egg Switch](https://buildmywheelchair.com/egg-switch/) (TS mono mic)
2. [TS -> TRS Mic Adapter](https://www.amazon.com/gp/product/B0778NK96C?th=1)
3. TRS -> TRRS Adapter ([here](https://www.amazon.com/gp/product/B07V4XFLMM) or [here](https://www.amazon.com/gp/product/B07YC79TCP?th=1)), which enabled us to plug the e-stop into our laptop's TRRS headset port.

However, having so many adapters creates unnecessary points-of-failure, plus we had serious quality issues with all the aforementioned adapters. Thus, we have since moved to the following e-stop setup:
1. [Egg Switch](https://buildmywheelchair.com/egg-switch/) (TS mono mic)
2. [T(R)S Mic + TRS Speaker -> USB Adapter](https://a.co/d/gL0ZfVE), which plugs into the computer's USB port.

However, this new setup, with a USB mic, requires different audio configuration than the previous setup. This PR does that. The big changes include:

1. Setting the default audio device programmatically, instead of requiring users to do it via the GUI.
2. Allowing users to configure audio for a sound card other than 0.
3. Allowing users to specify a device name, which is used to determine which device index `PyAudio` should listen to.
4. Listening to (un)plug events on `udev` (not `acpi`) if the e-stop is a USB mic.

# Testing procedure

- [x] Pull this branch, re-build.
- [x] On `t0b1`:
    - [x] In the config, change `amixer_configuration_name` to `t0b1`
    - [x] Plug the egg switch directly into the TRS microphone port.
    - [x] Run `ros2 launch ada_feeding ada_feeding_launch.xml use_estop:=true run_web_bridge:=false`
    - [x] Run `ros2 run ada_feeding dummy_ft_sensor.py`
    - [x] Run `ros2 topic echo /ada_watchdog/watchdog`.
    - [x] Click the e-stop button, unplug it, re-plug it, verify all these events are properly recorded, and that no false positive events are recorded.
- [x] On `lovelace`:
    - [x] Plug the egg switch into the USB adapter, which is plugged into any USB port.
    - [x] Run `ros2 launch ada_feeding ada_feeding_launch.xml use_estop:=true run_web_bridge:=false`
    - [x] Run `ros2 run ada_feeding dummy_ft_sensor.py`
    - [x] Run `ros2 topic echo /ada_watchdog/watchdog`.
    - [x] Click the e-stop button, unplug it, re-plug it, verify all these events are properly recorded, and that no false positive events are recorded.
    - [x] Verify that it still works even if you plug it into a different USB port.
    - [x] Verify that if you unplug the e-stop but not the USB, it does not register as an unplug. (This is an unfortunate reality of using an adapter. In practice though, it often spikes, registering as a click.)

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
