### PR TITLE
Determine amixer card num programatically

### DIFF
--- a/ada_feeding/config/ada_watchdog.yaml
+++ b/ada_feeding/config/ada_watchdog.yaml
@@ -53,12 +53,7 @@ ada_watchdog:
     #         - Run `pactl list short sinks`.
     #         - The name that is different is the name of the mic. If there are
     #           multiple, use the one without "monitor" appended to its name.
-    #     2. `amixer_card_num`:
-    #         - Run `pactl list sinks`.
-    #         - For the mic name you found above, check the "alsa.card" property.
-    #           Use that value.
-    #         - (Note: You can also get the card number by running `arecord -l`.)
-    #     3. `amixer_mic_toggle_control_name`:
+    #     2. `amixer_mic_toggle_control_name`:
     #         - Mute the microphone in the system settings.
     #         - Run `amixer` in a terminal.
     #         - Unmute the microphone in the system settings.
@@ -66,14 +61,14 @@ ada_watchdog:
     #         - See which control switched from [off] to [on]. That is the control
     #           name you want. (Note: saving amixer output to file and running `diff`
     #           make this process easier.)
-    #     4. `amixer_mic_control_names`:
+    #     3. `amixer_mic_control_names`:
     #         - Unmute the microphone in the system settings, and set its volume to be
     #           low but not 0%.
     #         - Run `amixer` in a terminal.
     #         - In system settings, set the microphone volume to be 100%.
     #         - Run `amixer` in a terminal.
     #         - See which controls changed. Those are the control names you want.
-    #     5. `amixer_mic_control_percentages`:
+    #     4. `amixer_mic_control_percentages`:
     #         - Open Audacity and System Settings side-by-side. Start recording in
     #           Audacity. Press the e-stop button and notice the curve. You want the
     #           low/high points of the curve to reach +/-1.0, but not exceed it (evidenced
@@ -83,8 +78,8 @@ ada_watchdog:
     #           in the previous step. Those are the percentages you want.
     #         - (Note: we have had this script work even if in audacity the curve only reaches
     #           +/- 0.5, but it is better to aim for +/- 1.0 if possible.)
-    #     6. `is_usb`: true if the microphone is a USB microphone, false otherwise (3.5mm aux).
-    #     7. `acpi_event_name`: Only applicable if `is_usb` is false.
+    #     5. `is_usb`: true if the microphone is a USB microphone, false otherwise (3.5mm aux).
+    #     6. `acpi_event_name`: Only applicable if `is_usb` is false.
     #         - Run `acpi_listen`.
     #         - Plug in the microphone.
     #         - Unplug the microphone.
@@ -92,14 +87,14 @@ ada_watchdog:
     #             jack/microphone MICROPHONE plug
     #             jack/microphone MICROPHONE unplug
     #         - Include the first two words in this parameter, exclude the third (plug/unplug).
-    #     8. `udev_id`: Only applicable if `is_usb` is true.
+    #     7. `udev_id`: Only applicable if `is_usb` is true.
     #         - Run `udevadm monitor -u -p --subsystem-match=sound`.
     #         - Plug in the microphone.
     #         - Get the value after `ID_ID=`.
     #         - Unplug the microphone.
     #         - Verify that the value is the same.
     #         - Use that value.
-    #     9. `device_name`: The name of the device. This isused to get the right device number
+    #     8. `device_name`: The name of the device. This isused to get the right device number
     #         for pyaudio. If unspecified, device number 0 is used (typically fine for 3.5mm aux mics).
     #         - Unplug the microphone.
     #         - Run `arecord -l`.
@@ -109,7 +104,6 @@ ada_watchdog:
     amixer_configuration_name: lovelace
     t0b1:
       pactl_mic_name: 'alsa_input.pci-0000_00_1f.3.analog-stereo'
-      amixer_card_num: 0
       amixer_mic_toggle_control_name: "'Capture',0"
       amixer_mic_control_names:
         - "'Capture',0"
@@ -121,7 +115,6 @@ ada_watchdog:
       acpi_event_name: "jack/microphone MICROPHONE"
     lovelace:
       pactl_mic_name: 'alsa_input.usb-Plugable_Plugable_USB_Audio_Device_000000000000-00.analog-stereo'
-      amixer_card_num: 2
       amixer_mic_toggle_control_name: "'Mic',0"
       amixer_mic_control_names:
         - "'Mic',0"


### PR DESCRIPTION
# Description

Although #187 had users input a device-specific `amixer_card_num` as a parameter, that card number can change when the computer is restarted. Hence, this PR has the code programmatically determine it instead.

# Testing procedure

- [x] Pull this code and re-build.
- [x] Restart the computer with the USB mic plugged in.
- [x] Run `setfacl -m u:ada:rw /dev/snd/*`, then wait ~5s.
- [x] Start the code, verify it reads the USB mic (e.g., by ensuring e-stop clicks are registered).
- [x] Verify unplugs are registered.
- [x] Restart the computer with the USB mic unplugged.
- [x] Plug in the USB mic.
- [x] Run `setfacl -m u:ada:rw /dev/snd/*`, then wait ~5s.
- [x] Start the code, verify it reads the USB mic (e.g., by ensuring e-stop clicks are registered).
- [x] Verify unplugs are registered.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
