### PR TITLE
Couple each custom parameter namespace with a planning scene namespace

### DIFF
--- a/ada_feeding/config/ada_feeding_action_servers_custom.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_custom.yaml
@@ -7,6 +7,7 @@ ada_feeding_action_servers:
     - side_staging_3
     - hospital_table_mount_1
     hospital_table_mount_1:
+      planning_scene_namespace_to_use: bedside
       AcquireFood.tree_kwargs.resting_joint_positions:
       - 1.969353563943468
       - 4.070232398326571
@@ -46,6 +47,7 @@ ada_feeding_action_servers:
       - 0.761846098823169
     namespace_to_use: default
     side_staging_1:
+      planning_scene_namespace_to_use: seated
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.8849039817349507
       - 4.195202297742974
@@ -91,6 +93,7 @@ ada_feeding_action_servers:
       - -0.03213529960954986
       - 3.09639028777566
     side_staging_2:
+      planning_scene_namespace_to_use: seated
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.9352339979119222
       - 4.019241119250932
@@ -136,6 +139,7 @@ ada_feeding_action_servers:
       - 0.15785301466004853
       - 1.831326452018514
     side_staging_3:
+      planning_scene_namespace_to_use: seated
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.6599792550212555
       - 3.1739410060865496

--- a/ada_feeding/config/ada_feeding_action_servers_custom.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_custom.yaml
@@ -7,7 +7,6 @@ ada_feeding_action_servers:
     - side_staging_3
     - hospital_table_mount_1
     hospital_table_mount_1:
-      planning_scene_namespace_to_use: bedside
       AcquireFood.tree_kwargs.resting_joint_positions:
       - 1.969353563943468
       - 4.070232398326571
@@ -45,9 +44,9 @@ ada_feeding_action_servers:
       - -1.4163968994364629
       - -2.0259084528523905
       - 0.761846098823169
+      planning_scene_namespace_to_use: bedside
     namespace_to_use: default
     side_staging_1:
-      planning_scene_namespace_to_use: seated
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.8849039817349507
       - 4.195202297742974
@@ -92,8 +91,8 @@ ada_feeding_action_servers:
       - -6.180243112219014
       - -0.03213529960954986
       - 3.09639028777566
-    side_staging_2:
       planning_scene_namespace_to_use: seated
+    side_staging_2:
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.9352339979119222
       - 4.019241119250932
@@ -138,8 +137,8 @@ ada_feeding_action_servers:
       - -4.805756745041778
       - 0.15785301466004853
       - 1.831326452018514
-    side_staging_3:
       planning_scene_namespace_to_use: seated
+    side_staging_3:
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.6599792550212555
       - 3.1739410060865496
@@ -184,3 +183,4 @@ ada_feeding_action_servers:
       - 0.41718325265453116
       - 5.824282703942583
       - 2.9376642889102835
+      planning_scene_namespace_to_use: seated

--- a/ada_feeding/config/ada_feeding_action_servers_default.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_default.yaml
@@ -5,6 +5,8 @@ ada_feeding_action_servers:
     watchdog_timeout_sec: 0.5 # sec
 
     default:
+      planning_scene_namespace_to_use: seated
+
       # A list of the names of the action servers to create. Each one must have
       # it's own parameters (below) specifying action_type and tree_class.
       server_names:

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -466,7 +466,9 @@ class CreateActionServers(Node):
                             0
                         ].string_value
             if curr_planning_scene_namespace_to_use is None:
-                self.get_logger().warn("Failed to get parameters from ada_planning_scene.")
+                self.get_logger().warn(
+                    "Failed to get parameters from ada_planning_scene."
+                )
                 return False
 
             # If the parameter is the same, return

--- a/ada_feeding/scripts/create_action_servers.py
+++ b/ada_feeding/scripts/create_action_servers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=too-many-lines
 """
 This module contains a node, CreateActionServers, for creating action servers
 that wrap behavior trees.
@@ -16,10 +17,17 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from ada_watchdog_listener import ADAWatchdogListener
 from ament_index_python.packages import get_package_share_directory
 import py_trees
-from rcl_interfaces.msg import ParameterDescriptor, ParameterType, SetParametersResult
+from rcl_interfaces.msg import (
+    ParameterDescriptor,
+    ParameterType,
+    ParameterValue,
+    SetParametersResult,
+)
+from rcl_interfaces.srv import GetParameters, SetParametersAtomically
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.action.server import ServerGoalHandle
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from rclpy.parameter import Parameter
@@ -86,6 +94,9 @@ class CreateActionServers(Node):
     # pylint: disable=too-many-instance-attributes
     # Fine because of the generic parameters and watchdog capabiltiies.
 
+    # pylint: disable=attribute-defined-outside-init
+    # Fine because we are defining these attributes in the `initialize` function.
+
     DEFAULT_PARAMETER_NAMESPACE = "default"
 
     def __init__(self) -> None:
@@ -99,6 +110,25 @@ class CreateActionServers(Node):
         # seems to forget that some nodes were declared. This is a workaround.
         super().__init__("create_action_servers", allow_undeclared_parameters=True)
         register_logger(self.get_logger())
+
+    def initialize(self) -> None:
+        """
+        Initialize the node. This is a separate function from above so rclpy can
+        be spinning while this function is called.
+        """
+        # Create clients to get and set parameters for the `ada_planning_scene` node.
+        # This is necessary to couple custom configurations in this node with custom
+        # planning scenes.
+        self.planning_scene_get_parameters_client = self.create_client(
+            GetParameters,
+            "/ada_planning_scene/get_parameters",
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
+        self.planning_scene_set_parameters_client = self.create_client(
+            SetParametersAtomically,
+            "/ada_planning_scene/set_parameters_atomically",
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
 
         # Read the parameters that specify what action servers to create.
         self.namespace_to_use = CreateActionServers.DEFAULT_PARAMETER_NAMESPACE
@@ -198,6 +228,30 @@ class CreateActionServers(Node):
         )
         self.set_namespace_to_use(namespace_to_use.value)
 
+        # Get the planning scene namespace to use
+        for namespace in [default_namespace] + custom_namespaces:
+            planning_scene_namespace_to_use = self.declare_parameter(
+                f"{namespace}.planning_scene_namespace_to_use",
+                value="seated",
+                descriptor=ParameterDescriptor(
+                    name="planning_scene_namespace_to_use",
+                    type=ParameterType.PARAMETER_STRING,
+                    description=(
+                        "The planning scene namespace to use. Must be one of the "
+                        "parameters i the ada_planning_scene config file."
+                    ),
+                    read_only=False,
+                ),
+            )
+            planning_scene_namespace_to_use = planning_scene_namespace_to_use.value
+            self.parameters[namespace][
+                "planning_scene_namespace_to_use"
+            ] = planning_scene_namespace_to_use
+            if namespace == self.namespace_to_use:
+                self.set_planning_scene_namespace_to_use(
+                    planning_scene_namespace_to_use
+                )
+
         # Read each action server's params
         action_server_params = {}
         for server_name in server_names.value:
@@ -269,7 +323,7 @@ class CreateActionServers(Node):
                 for kw in tree_kws.value:
                     full_name = f"{server_name}.tree_kwargs.{kw}"
                     # Get the default value
-                    default_value = self.declare_tree_kwarg(
+                    default_value = self.declare_parameter_in_namespace(
                         namespace=default_namespace,
                         full_name=full_name,
                     )
@@ -285,7 +339,7 @@ class CreateActionServers(Node):
                     self.parameters[default_namespace][full_name] = default_value
                     # Get the custom value(s)
                     for namespace in custom_namespaces:
-                        custom_value = self.declare_tree_kwarg(
+                        custom_value = self.declare_parameter_in_namespace(
                             namespace=namespace,
                             full_name=full_name,
                         )
@@ -323,7 +377,7 @@ class CreateActionServers(Node):
         if namespace not in self.parameters.keys():
             self.parameters[namespace] = {}
         for full_name in self.parameters[default_namespace].keys():
-            custom_value = self.declare_tree_kwarg(
+            custom_value = self.declare_parameter_in_namespace(
                 namespace=namespace,
                 full_name=full_name,
             )
@@ -357,9 +411,94 @@ class CreateActionServers(Node):
                 )
                 self.namespace_to_use = default_namespace
 
-    def declare_tree_kwarg(self, namespace: str, full_name: str) -> Parameter:
+    def set_planning_scene_namespace_to_use(
+        self,
+        planning_scene_namespace_to_use: str,
+        timeout_secs: float = 10.0,
+        rate_hz: float = 10.0,
+    ) -> bool:
         """
-        This method declares a tree_kwarg parameter in the given namespace.
+        Sets the planning scene namespace to use for the node. Further, it gets the
+        current parameter value for the planning scene node and, if it is different,
+        updates the parameter value for that node.
+
+        Parameters
+        ----------
+        planning_scene_namespace_to_use: The planning scene namespace to use.
+        timeout_secs: The timeout in seconds for the service calls.
+        rate_hz: The rate at which to check for the parameter value.
+
+        Returns
+        -------
+        True if the parameter was set successfully, False otherwise.
+        """
+        start_time = self.get_clock().now()
+        timeout = rclpy.time.Duration(seconds=timeout_secs)
+        rate = self.create_rate(rate_hz)
+
+        # First, get the current value of the parameter
+        request = GetParameters.Request()
+        request.names = ["namespace_to_use"]
+        future = self.planning_scene_get_parameters_client.call_async(request)
+        while (
+            rclpy.ok()
+            and not future.done()
+            and (self.get_clock().now() - start_time < timeout)
+        ):
+            rate.sleep()
+        curr_planning_scene_namespace_to_use = None
+        if future.done():
+            response = future.result()
+            if len(response.values) > 0:
+                if response.values[0].type == ParameterType.PARAMETER_STRING:
+                    curr_planning_scene_namespace_to_use = response.values[
+                        0
+                    ].string_value
+        if curr_planning_scene_namespace_to_use is None:
+            self.get_logger().warn("Failed to get parameters from ada_planning_scene.")
+            return False
+
+        # If the parameter is the same, return
+        if curr_planning_scene_namespace_to_use == planning_scene_namespace_to_use:
+            return True
+
+        # Otherwise, set the parameter
+        request = SetParametersAtomically.Request()
+        request.parameters = [
+            Parameter(
+                name="namespace_to_use",
+                value=ParameterValue(
+                    type=ParameterType.PARAMETER_STRING,
+                    string_value=planning_scene_namespace_to_use,
+                ),
+            )
+        ]
+        future = self.planning_scene_set_parameters_client.call_async(request)
+        while (
+            rclpy.ok()
+            and not future.done()
+            and (self.get_clock().now() - start_time < timeout)
+        ):
+            rate.sleep()
+        if future.done():
+            response = future.result()
+            if response.successful:
+                self.get_logger().info(
+                    f"Successfully set planning scene namespace from {curr_planning_scene_namespace_to_use} to "
+                    f"{planning_scene_namespace_to_use}"
+                )
+                return True
+        self.get_logger().warn(
+            f"Failed to set planning scene namespace from {curr_planning_scene_namespace_to_use} to "
+            f"{planning_scene_namespace_to_use}"
+        )
+        return False
+
+    def declare_parameter_in_namespace(
+        self, namespace: str, full_name: str
+    ) -> Parameter:
+        """
+        This method declares a dynamically-typed parameter in the given namespace.
 
         Parameters
         ----------
@@ -426,6 +565,17 @@ class CreateActionServers(Node):
                 updated_parameters = True
                 # If this namespace has custom parameters, switch to them
                 for full_name, value in self.parameters[self.namespace_to_use].items():
+                    # Handle non tree_kwargs
+                    if full_name == "planning_scene_namespace_to_use":
+                        if value is None:
+                            self.get_logger().info(
+                                f"Namespace {param.value} has no parameter `{full_name}`. "
+                                f"Resorting to default value {self.parameters[default_namespace][full_name]}."
+                            )
+                            value = self.parameters[default_namespace][full_name]
+                        self.set_planning_scene_namespace_to_use(value)
+
+                    # Handle tree_kwargs
                     if "tree_kwargs" not in full_name:
                         self.get_logger().warn(
                             f"Non tree_kwarg parameter {full_name} in self.parameters. "
@@ -480,6 +630,40 @@ class CreateActionServers(Node):
                     if namespace not in self.parameters.keys():
                         self.declare_namespace_parameters(namespace)
                 updated_parameters = True
+                continue
+
+            # Change the planning_scene_namespace_to_use
+            if "planning_scene_namespace_to_use" in param.name:
+                # Deconstruct the parameter name
+                namespace, full_name = param.name.split(".")
+                # Verify it is a valid parameter name
+                if namespace not in self.parameters.keys():
+                    self.get_logger().warn(
+                        f"Unknown namespace {namespace} for parameter {param.name}. "
+                        "Skipping this parameter."
+                    )
+                    continue
+                if full_name != "planning_scene_namespace_to_use":
+                    self.get_logger().warn(
+                        f"Unknown parameter {param.name}. Skipping this parameter."
+                    )
+                    continue
+                param_value = CreateActionServers.get_parameter_value(param)
+                if not isinstance(
+                    param_value, type(self.parameters[default_namespace][full_name])
+                ):
+                    self.get_logger().warn(
+                        f"Parameter {param.name} must be of type "
+                        f"{type(self.parameters[default_namespace][full_name])} "
+                        f"but is of type {type(param_value)}"
+                    )
+                    return SetParametersResult(successful=False, reason="type mismatch")
+                # Change the parameter
+                self.parameters[namespace][full_name] = param_value
+                updated_parameters = True
+                # If this is the namespace we're using, update the planning_scene_namespace_to_use
+                if namespace == self.namespace_to_use:
+                    self.set_planning_scene_namespace_to_use(param_value)
                 continue
 
             # Change a tree_kwarg
@@ -935,10 +1119,23 @@ def main(args: List = None) -> None:
     # Use a MultiThreadedExecutor to enable processing goals concurrently
     executor = MultiThreadedExecutor(num_threads=multiprocessing.cpu_count() * 2)
 
+    # Spin in the background until the node has initialized
+    spin_thread = threading.Thread(
+        target=rclpy.spin,
+        args=(create_action_servers,),
+        kwargs={"executor": executor},
+        daemon=True,
+    )
+    spin_thread.start()
+
     # pylint: disable=broad-exception-caught
     # All exceptions need printing at shutdown
     try:
-        rclpy.spin(create_action_servers, executor=executor)
+        # Initialize the node
+        create_action_servers.initialize()
+
+        # Spin in the foreground
+        spin_thread.join()
     except Exception:
         traceback.print_exc()
 

--- a/ada_planning_scene/config/ada_planning_scene.yaml
+++ b/ada_planning_scene/config/ada_planning_scene.yaml
@@ -49,7 +49,7 @@ ada_planning_scene:
       #     `within_workspace_walls` to be True.
       wheelchair: # the wheelchair mesh
         filename: wheelchair.stl
-        position: [0.02, -0.02, -0.15]
+        position: [0.02, -0.02, -0.05]
         quat_xyzw: [0.0, 0.0, 0.0, 1.0]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
@@ -58,7 +58,7 @@ ada_planning_scene:
       # bite transfer.
       body: 
         filename: body_collision_in_wheelchair.stl
-        position: [0.20, -0.01, -0.05] # should match the wheelchair position
+        position: [0.02, -0.02, -0.05] # should match the wheelchair position
         quat_xyzw: [0.0, 0.0, 0.0, 1.0] # should match the wheelchair orientation
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair


### PR DESCRIPTION
# Description

This PR addresses two related issues:

1. When the app changes a parameter namespace, the planning scene doesn't change, even though each parameter namespace is designed for a specific planning scene arrangement. (Currently, the only way to change the parameter namespace is by modifying the YAML and re-building the workspace).
2. When we update a configuration via the app, the workspace walls don't change, even though each configuration requires different workspace walls.

This PR addresses both of the above by coupling each custom parameter namespace with a planning scene namespace, and setting that any time the namespace is changed. `ada_planning_scene` is already defined to clear the workspace, insert the objects, and update the workspace walls, anytime the namespace changes.

# Testing procedure

- [x] In sim `mock`:
  - [x] Launch the code and open RVIZ.
  - [x] Via the app, change the namespace to the "hospital table" one. Verify it updates in RVIZ.
  - [x] Change back to `default`. Verify it updates in RVIZ.
  - [x] Change to one of the side-feeding configurations. Verify that the workspace walls update in RVIZ.
  - [x] Create a new namespace. Verify the planning scene reverts to the default (TODO: see `Future Work`).
- [x] Repeat all the above tests in `real`, verify they work.

# Future Work

We should modify `feeding_web_interface` to have a component of the Settings menu to change the planning scene namespace associated with the custom configuration. Because currently, even if you create a custom namespace, that will always be with the `seated` planning scene, never `bedside`.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
