### PR TITLE
Change `in_front_of_face_wall` based on the planning scene namespace

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/ros/tf.py
+++ b/ada_feeding/ada_feeding/behaviors/ros/tf.py
@@ -341,6 +341,8 @@ class ApplyTransform(BlackboardBehavior):
         if self.tf_lock.locked():
             return py_trees.common.Status.RUNNING
 
+        self.logger.debug(f"Applying transform to {stamped_msg}")
+
         transformed_msg = None
         with self.tf_lock:
             if target_frame is not None:

--- a/ada_feeding/ada_feeding/idioms/servo_until.py
+++ b/ada_feeding/ada_feeding/idioms/servo_until.py
@@ -27,6 +27,7 @@ import numpy as np
 import py_trees
 from py_trees.behaviours import UnsetBlackboardVariable
 from py_trees.blackboard import Blackboard
+import rclpy  # TODO: remove!
 from rclpy.duration import Duration
 from rclpy.time import Time
 import ros2_numpy
@@ -38,6 +39,7 @@ from ada_feeding.behaviors.moveit2 import ServoMove
 from ada_feeding.behaviors.ros import (
     ApplyTransform,
     PoseStampedToTwistStamped,
+    SetStaticTransform,
     TrackHz,
     UpdateTimestamp,
 )
@@ -148,6 +150,18 @@ def pose_within_tolerances(
     linear_displacement = ros2_numpy.numpify(
         target_pose.pose.position
     ) - ros2_numpy.numpify(current_pose.pose.position)
+
+    # TODO: remove!
+    rclpy.logging.get_logger("pose_within_tolerances").info(
+        f"linear_displacement: {linear_displacement}"
+    )
+    rclpy.logging.get_logger("pose_within_tolerances").info(
+        f"target_pose: {ros2_numpy.numpify(target_pose.pose.position)}"
+    )
+    rclpy.logging.get_logger("pose_within_tolerances").info(
+        f"current_pose: {ros2_numpy.numpify(current_pose.pose.position)}"
+    )
+
     linear_distance = np.linalg.norm(linear_displacement)
     if linear_distance > tolerance_position:
         return False
@@ -187,6 +201,8 @@ def servo_until_pose(
     ignore_orientation: bool = False,
     subscribe_to_servo_status: bool = True,
     pub_topic: str = "~/servo_twist_cmds",
+    # TODO: change default to False!
+    viz: bool = True,
 ) -> py_trees.behaviour.Behaviour:
     """
     Servos until the end_effector_frame reaches within the specified tolerances
@@ -228,6 +244,7 @@ def servo_until_pose(
     subscribe_to_servo_status: if True, subscribe to the servo status topic and
         fail on failure statuses. If False, ignore that topic.
     pub_topic: The topic to publish twist commands to.
+    viz: if True, publish the target pose as a static TF transform.
 
     Returns
     -------
@@ -254,6 +271,127 @@ def servo_until_pose(
     if not subscribe_to_servo_status:
         servo_inputs["servo_status_sub_topic"] = None
 
+    # Sense the distance from the end effector to the target pose
+    sense_behavior = py_trees.composites.Sequence(
+        name=f"{name} ServoUntilPose Condition",
+        memory=True,
+        children=[
+            # Update the timestamp of the target_pose_stamped
+            UpdateTimestamp(
+                name=f"{name} Update Timestamp",
+                ns=ns,
+                inputs={
+                    "stamped_msg": target_pose_stamped_key,
+                    "timestamp": Time(seconds=0.0),  # Get latest transform
+                },
+                outputs={
+                    "stamped_msg": target_pose_stamped_key,
+                },
+            ),
+            # Get the target_pose_stamped in the end effector frame
+            ApplyTransform(
+                name=f"{name} ServoUntilPose GetEEDisplacement",
+                ns=ns,
+                inputs={
+                    "stamped_msg": target_pose_stamped_key,
+                    "target_frame": end_effector_frame,
+                },
+                outputs={
+                    "transformed_msg": BlackboardKey("ee_to_target_pose_stamped"),
+                },
+            ),
+        ],
+    )
+    if viz:
+        # Cache the target pose on the static TF tree
+        sense_behavior.add_child(
+            SetStaticTransform(
+                name=f"{name} ServoUntilPose PublishPose",
+                ns=name,
+                inputs={
+                    "transform": BlackboardKey("ee_to_target_pose_stamped"),
+                    "child_frame_id": "servo_until_pose_target",
+                },
+            ),
+        )
+
+    # Check whether the ee_to_target_pose_stamped is within the tolerances.
+    # Note that this behavior can technically return FAILURE for a reason
+    # other than the condition not being met, specifically if the blackboard
+    # variable doens't exist or the permissions are not correctly set.
+    # Therefore, it is crucial to be vigilant when testing this idiom.
+    check_behavior = py_trees.behaviours.CheckBlackboardVariableValue(
+        name=f"{name} ServoUntilPose CheckTolerances",
+        check=py_trees.common.ComparisonExpression(
+            variable=ee_to_target_pose_stamped_absolute_key,
+            value=PoseStamped(
+                header=Header(frame_id=end_effector_frame),
+                pose=Pose(
+                    position=Point(x=0.0, y=0.0, z=0.0),
+                    orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+                ),
+            ),
+            operator=partial(
+                pose_within_tolerances,
+                tolerance_position=tolerance_position,
+                tolerance_orientation=np.inf
+                if ignore_orientation
+                else tolerance_orientation,
+            ),
+        ),
+    )
+
+    # Compute the twist based on the ee_to_target_pose_stamped
+    compute_twist_behavior = py_trees.composites.Sequence(
+        name=f"{name} ServoUntilPose Condition",
+        memory=False,
+        children=[
+            # Monitor the rate at which this idiom is running
+            TrackHz(
+                name=f"{name} TrackHz",
+                ns=ns,
+                inputs={
+                    "num_ticks": BlackboardKey("num_ticks"),
+                    "start_time": BlackboardKey("start_time"),
+                },
+                outputs={
+                    "hz": BlackboardKey("servoHz"),
+                    "num_ticks": BlackboardKey("num_ticks"),
+                    "start_time": BlackboardKey("start_time"),
+                },
+            ),
+            # Compute the twist
+            PoseStampedToTwistStamped(
+                name=f"{name} {SERVO_UNTIL_POSE_DISTANCE_BEHAVIOR_NAME}",
+                ns=ns,
+                inputs={
+                    "pose_stamped": BlackboardKey("ee_to_target_pose_stamped"),
+                    "speed": speed,
+                    "hz": BlackboardKey("servoHz"),
+                    "round_decimals": round_decimals,
+                    "angular_override": Vector3(x=0.0, y=0.0, z=0.0)
+                    if ignore_orientation
+                    else None,
+                },
+                outputs={
+                    "twist_stamped": BlackboardKey("twist_in_ee_frame"),
+                },
+            ),
+            # Convert to base frame
+            ApplyTransform(
+                name=f"{name} ServoUntilPose GetEETwist",
+                ns=ns,
+                inputs={
+                    "stamped_msg": BlackboardKey("twist_in_ee_frame"),
+                    "target_frame": base_link,
+                },
+                outputs={
+                    "transformed_msg": twist_blackboard_key,
+                },
+            ),
+        ],
+    )
+
     return py_trees.composites.Selector(
         name=name,
         memory=True,
@@ -276,124 +414,9 @@ def servo_until_pose(
                     servo_until(
                         name=name,
                         ns=ns,
-                        # Sense the distance from the end effector to the target pose
-                        sense=py_trees.composites.Sequence(
-                            name=f"{name} ServoUntilPose Condition",
-                            memory=True,
-                            children=[
-                                # Update the timestamp of the target_pose_stamped
-                                UpdateTimestamp(
-                                    name=f"{name} Update Timestamp",
-                                    ns=ns,
-                                    inputs={
-                                        "stamped_msg": target_pose_stamped_key,
-                                        "timestamp": Time(
-                                            seconds=0.0
-                                        ),  # Get latest transform
-                                    },
-                                    outputs={
-                                        "stamped_msg": target_pose_stamped_key,
-                                    },
-                                ),
-                                # Get the target_pose_stamped in the end effector frame
-                                ApplyTransform(
-                                    name=f"{name} ServoUntilPose GetEEDisplacement",
-                                    ns=ns,
-                                    inputs={
-                                        "stamped_msg": target_pose_stamped_key,
-                                        "target_frame": end_effector_frame,
-                                    },
-                                    outputs={
-                                        "transformed_msg": BlackboardKey(
-                                            "ee_to_target_pose_stamped"
-                                        ),
-                                    },
-                                ),
-                            ],
-                        ),
-                        # Check whether the ee_to_target_pose_stamped is within the tolerances.
-                        # Note that this behavior can technically return FAILURE for a reason
-                        # other than the condition not being met, specifically if the blackboard
-                        # variable doens't exist or the permissions are not correctly set.
-                        # Therefore, it is crucial to be vigilant when testing this idiom.
-                        check=py_trees.behaviours.CheckBlackboardVariableValue(
-                            name=f"{name} ServoUntilPose CheckTolerances",
-                            check=py_trees.common.ComparisonExpression(
-                                variable=ee_to_target_pose_stamped_absolute_key,
-                                value=PoseStamped(
-                                    header=Header(frame_id=end_effector_frame),
-                                    pose=Pose(
-                                        position=Point(x=0.0, y=0.0, z=0.0),
-                                        orientation=Quaternion(
-                                            x=0.0, y=0.0, z=0.0, w=1.0
-                                        ),
-                                    ),
-                                ),
-                                operator=partial(
-                                    pose_within_tolerances,
-                                    tolerance_position=tolerance_position,
-                                    tolerance_orientation=np.inf
-                                    if ignore_orientation
-                                    else tolerance_orientation,
-                                ),
-                            ),
-                        ),
-                        # Compute the twist based on the ee_to_target_pose_stamped
-                        compute_twist=py_trees.composites.Sequence(
-                            name=f"{name} ServoUntilPose Condition",
-                            memory=False,
-                            children=[
-                                # Monitor the rate at which this idiom is running
-                                TrackHz(
-                                    name=f"{name} TrackHz",
-                                    ns=ns,
-                                    inputs={
-                                        "num_ticks": BlackboardKey("num_ticks"),
-                                        "start_time": BlackboardKey("start_time"),
-                                    },
-                                    outputs={
-                                        "hz": BlackboardKey("servoHz"),
-                                        "num_ticks": BlackboardKey("num_ticks"),
-                                        "start_time": BlackboardKey("start_time"),
-                                    },
-                                ),
-                                # Compute the twist
-                                PoseStampedToTwistStamped(
-                                    name=f"{name} {SERVO_UNTIL_POSE_DISTANCE_BEHAVIOR_NAME}",
-                                    ns=ns,
-                                    inputs={
-                                        "pose_stamped": BlackboardKey(
-                                            "ee_to_target_pose_stamped"
-                                        ),
-                                        "speed": speed,
-                                        "hz": BlackboardKey("servoHz"),
-                                        "round_decimals": round_decimals,
-                                        "angular_override": Vector3(x=0.0, y=0.0, z=0.0)
-                                        if ignore_orientation
-                                        else None,
-                                    },
-                                    outputs={
-                                        "twist_stamped": BlackboardKey(
-                                            "twist_in_ee_frame"
-                                        ),
-                                    },
-                                ),
-                                # Convert to base frame
-                                ApplyTransform(
-                                    name=f"{name} ServoUntilPose GetEETwist",
-                                    ns=ns,
-                                    inputs={
-                                        "stamped_msg": BlackboardKey(
-                                            "twist_in_ee_frame"
-                                        ),
-                                        "target_frame": base_link,
-                                    },
-                                    outputs={
-                                        "transformed_msg": twist_blackboard_key,
-                                    },
-                                ),
-                            ],
-                        ),
+                        sense=sense_behavior,
+                        check=check_behavior,
+                        compute_twist=compute_twist_behavior,
                         servo_inputs=servo_inputs,
                     ),
                 ],

--- a/ada_feeding/ada_feeding/idioms/servo_until.py
+++ b/ada_feeding/ada_feeding/idioms/servo_until.py
@@ -307,7 +307,7 @@ def servo_until_pose(
         sense_behavior.add_child(
             SetStaticTransform(
                 name=f"{name} ServoUntilPose PublishPose",
-                ns=name,
+                ns=ns,
                 inputs={
                     "transform": BlackboardKey("ee_to_target_pose_stamped"),
                     "child_frame_id": "servo_until_pose_target",

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -522,8 +522,8 @@ class AcquireFoodTree(MoveToTree):
                                     name="BackupFlipFoodFrameSel",
                                     memory=True,
                                     children=[
-                                        move_above_plan(True),
                                         move_above_plan(False),
+                                        move_above_plan(True),
                                     ],
                                 ),
                                 MoveIt2Execute(

--- a/ada_feeding/ada_feeding/trees/acquire_food_tree.py
+++ b/ada_feeding/ada_feeding/trees/acquire_food_tree.py
@@ -48,8 +48,8 @@ from ada_feeding.idioms import (
     retry_call_ros_service,
 )
 from ada_feeding.idioms.bite_transfer import (
-    get_add_in_front_of_wheelchair_wall_behavior,
-    get_remove_in_front_of_wheelchair_wall_behavior,
+    get_add_in_front_of_face_wall_behavior,
+    get_remove_in_front_of_face_wall_behavior,
 )
 from ada_feeding.idioms.ft_thresh_utils import ft_thresh_satisfied
 from ada_feeding.idioms.pre_moveto_config import set_parameter_response_all_success
@@ -154,14 +154,12 @@ class AcquireFoodTree(MoveToTree):
             resting_position_behaviors.append(
                 scoped_behavior(
                     name=name + " InFrontOfWheelchairWallScope",
-                    pre_behavior=get_add_in_front_of_wheelchair_wall_behavior(
+                    pre_behavior=get_add_in_front_of_face_wall_behavior(
                         name + "AddWheelchairWall",
-                        "in_front_of_wheelchair_wall",
                     ),
                     # Remove the wall in front of the wheelchair
-                    post_behavior=get_remove_in_front_of_wheelchair_wall_behavior(
+                    post_behavior=get_remove_in_front_of_face_wall_behavior(
                         name + "RemoveWheelchairWall",
-                        "in_front_of_wheelchair_wall",
                     ),
                     workers=[
                         py_trees_ros.service_clients.FromConstant(

--- a/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
@@ -78,7 +78,7 @@ class MoveFromMouthTree(MoveToTree):
         max_velocity_scaling_factor_to_end_configuration: float = 0.1,
         cartesian_jump_threshold_to_staging_configuration: float = 0.0,
         cartesian_max_step_to_staging_configuration: float = 0.0025,
-        wheelchair_collision_object_id: str = "wheelchair_collision",
+        wheelchair_collision_object_id: str = "body",
         force_threshold_to_staging_configuration: float = 1.0,
         torque_threshold_to_staging_configuration: float = 1.0,
         force_threshold_to_end_configuration: float = 4.0,

--- a/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_from_mouth_tree.py
@@ -29,8 +29,8 @@ from ada_feeding.behaviors.ros import CreatePoseStamped
 from ada_feeding.helpers import BlackboardKey
 from ada_feeding.idioms import pre_moveto_config, scoped_behavior, servo_until_pose
 from ada_feeding.idioms.bite_transfer import (
-    get_add_in_front_of_wheelchair_wall_behavior,
-    get_remove_in_front_of_wheelchair_wall_behavior,
+    get_add_in_front_of_face_wall_behavior,
+    get_remove_in_front_of_face_wall_behavior,
     get_toggle_collision_object_behavior,
 )
 from ada_feeding.trees import MoveToTree
@@ -216,7 +216,6 @@ class MoveFromMouthTree(MoveToTree):
 
         ### Define tree logic
 
-        in_front_of_wheelchair_wall_id = "in_front_of_wheelchair_wall"
         base_link = "j2n6s200_link_base"
 
         # The tree may or may not have orientation path constraints active
@@ -476,13 +475,11 @@ class MoveFromMouthTree(MoveToTree):
                 # Moving closer to the user than it currently is.
                 scoped_behavior(
                     name=name + " AddInFrontOfWheelchairWallScope",
-                    pre_behavior=get_add_in_front_of_wheelchair_wall_behavior(
+                    pre_behavior=get_add_in_front_of_face_wall_behavior(
                         name + "AddInFrontOfWheelchairWallScopePre",
-                        in_front_of_wheelchair_wall_id,
                     ),
-                    post_behavior=get_remove_in_front_of_wheelchair_wall_behavior(
+                    post_behavior=get_remove_in_front_of_face_wall_behavior(
                         name + "RemoveInFrontOfWheelchairWallScopePost",
-                        in_front_of_wheelchair_wall_id,
                     ),
                     workers=[
                         # Retare the F/T sensor and set the F/T Thresholds

--- a/ada_feeding/ada_feeding/trees/move_to_configuration_with_wheelchair_wall_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_configuration_with_wheelchair_wall_tree.py
@@ -28,8 +28,8 @@ from ada_feeding.behaviors.moveit2 import (
 from ada_feeding.helpers import BlackboardKey
 from ada_feeding.idioms import pre_moveto_config, scoped_behavior
 from ada_feeding.idioms.bite_transfer import (
-    get_add_in_front_of_wheelchair_wall_behavior,
-    get_remove_in_front_of_wheelchair_wall_behavior,
+    get_add_in_front_of_face_wall_behavior,
+    get_remove_in_front_of_face_wall_behavior,
 )
 from ada_feeding.trees import (
     MoveToTree,
@@ -112,8 +112,6 @@ class MoveToConfigurationWithWheelchairWallTree(MoveToTree):
 
         ### Define Tree Logic
 
-        in_front_of_wheelchair_wall_id = "in_front_of_wheelchair_wall"
-
         constraints = [
             # Goal configuration: staging configuration
             MoveIt2JointConstraint(
@@ -161,14 +159,12 @@ class MoveToConfigurationWithWheelchairWallTree(MoveToTree):
                 # from moving unnecessarily close to the user.
                 scoped_behavior(
                     name=name + " InFrontOfWheelchairWallScope",
-                    pre_behavior=get_add_in_front_of_wheelchair_wall_behavior(
+                    pre_behavior=get_add_in_front_of_face_wall_behavior(
                         name + "AddWheelchairWall",
-                        in_front_of_wheelchair_wall_id,
                     ),
                     # Remove the wall in front of the wheelchair
-                    post_behavior=get_remove_in_front_of_wheelchair_wall_behavior(
+                    post_behavior=get_remove_in_front_of_face_wall_behavior(
                         name + "RemoveWheelchairWall",
-                        in_front_of_wheelchair_wall_id,
                     ),
                     # Move to the staging configuration
                     workers=constraints

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -97,6 +97,12 @@ class MoveToMouthTree(MoveToTree):
             -0.5,
             0.5,
         ),
+        mouth_orientation: Tuple[float, float, float, float] = (
+            0.0,
+            0.0,
+            -0.7071068,
+            0.7071068,
+        ),  # Facing away from the wheelchair backrest
     ):
         """
         Initializes tree-specific parameters.
@@ -132,6 +138,8 @@ class MoveToMouthTree(MoveToTree):
         plan_distance_from_mouth: The distance (m) to plan from the mouth center.
         fork_target_orientation_from_mouth: The fork's target orientation, in *mouth*
             frame. Pointing straight to the mouth is (0.5, -0.5, -0.5, 0.5).
+        mouth_orientation: The quaternion for the mouth pose. By default, it is facing
+            away from the wheelchair backrest in the seated planning scene.
         """
 
         # pylint: disable=too-many-locals
@@ -159,6 +167,7 @@ class MoveToMouthTree(MoveToTree):
         self.face_detection_timeout = face_detection_timeout
         self.plan_distance_from_mouth = plan_distance_from_mouth
         self.fork_target_orientation_from_mouth = fork_target_orientation_from_mouth
+        self.mouth_orientation = mouth_orientation
 
         self.face_detection_relative_blackboard_key = "face_detection"
 
@@ -364,12 +373,7 @@ class MoveToMouthTree(MoveToTree):
                                     ns=name,
                                     inputs={
                                         "position": BlackboardKey("mouth_position"),
-                                        "quaternion": [
-                                            0.0,
-                                            0.0,
-                                            -0.7071068,
-                                            0.7071068,
-                                        ],  # Facing away from wheelchair backrest
+                                        "quaternion": self.mouth_orientation,
                                     },
                                     outputs={
                                         "pose_stamped": BlackboardKey(

--- a/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
+++ b/ada_feeding/ada_feeding/trees/move_to_mouth_tree.py
@@ -84,7 +84,7 @@ class MoveToMouthTree(MoveToTree):
         max_angular_speed: float = 0.15,
         linear_speed_near_mouth: float = 0.025,
         angular_speed_near_mouth: float = 0.075,
-        wheelchair_collision_object_id: str = "wheelchair_collision",
+        wheelchair_collision_object_id: str = "body",
         force_threshold: float = 1.0,
         torque_threshold: float = 1.0,
         allowed_face_distance: Tuple[float, float] = (0.4, 1.25),

--- a/ada_feeding/config/ada_feeding_action_servers_custom.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_custom.yaml
@@ -45,7 +45,7 @@ ada_feeding_action_servers:
       - -2.1827671763194583
       - 1.6106314909061383
       planning_scene_namespace_to_use: bedside
-    namespace_to_use: hospital_table_mount_1
+    namespace_to_use: default
     side_staging_1:
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.8849039817349507

--- a/ada_feeding/config/ada_feeding_action_servers_custom.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_custom.yaml
@@ -22,14 +22,14 @@ ada_feeding_action_servers:
       - 4.916644381246061
       - 1.7380801275071338
       MoveFromMouth.tree_kwargs.staging_configuration_position:
-      - 0.34747696493865265
-      - -0.07308038779785833
-      - 0.19207163519381526
+      - 0.6081959669757366
+      - -0.07835060871598665
+      - 0.20003578660416194
       MoveFromMouth.tree_kwargs.staging_configuration_quat_xyzw:
-      - 0.7090915266866867
-      - 0.08670448875279435
-      - 0.17412279154394644
-      - 0.6777557022085493
+      - 0.7144799976612057
+      - 0.07058338991982127
+      - 0.17428652585921275
+      - 0.6739143305446146
       MoveToRestingPosition.tree_kwargs.goal_configuration:
       - 1.969353563943468
       - 4.070232398326571
@@ -38,12 +38,12 @@ ada_feeding_action_servers:
       - -1.5705609033545338
       - 0.5052628782035897
       MoveToStagingConfiguration.tree_kwargs.goal_configuration:
-      - 2.2403158237891443
-      - 4.1219802814679
-      - 1.2300668363982512
-      - -1.4163968994364629
-      - -2.0259084528523905
-      - 0.761846098823169
+      - -3.690196913927282
+      - 4.26842937402412
+      - 1.9913679193043357
+      - -1.0381758266878451
+      - -2.0708628783690375
+      - 1.397755837070344
       planning_scene_namespace_to_use: bedside
     namespace_to_use: default
     side_staging_1:

--- a/ada_feeding/config/ada_feeding_action_servers_custom.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_custom.yaml
@@ -8,44 +8,44 @@ ada_feeding_action_servers:
     - hospital_table_mount_1
     hospital_table_mount_1:
       AcquireFood.tree_kwargs.resting_joint_positions:
-      - 1.969353563943468
+      - -1.17223908965
       - 4.070232398326571
       - 1.1134910875797221
       - -1.5986870802590785
       - -1.5705609033545338
       - 0.5052628782035897
       MoveAbovePlate.tree_kwargs.joint_positions:
-      - -3.339562994278577
+      - -0.19797034068
       - 3.6562432079254257
       - 1.6497725020792509
       - -2.659056359891099
       - 4.916644381246061
       - 1.7380801275071338
       MoveFromMouth.tree_kwargs.staging_configuration_position:
-      - 0.6081959669757366
-      - -0.07835060871598665
-      - 0.20003578660416194
+      - -0.6014194269891053
+      - 0.08069224383248258
+      - 0.19766024762409728
       MoveFromMouth.tree_kwargs.staging_configuration_quat_xyzw:
-      - 0.7144799976612057
-      - 0.07058338991982127
-      - 0.17428652585921275
-      - 0.6739143305446146
+      - 0.062023235263225555
+      - -0.7245047876010136
+      - -0.6768258670154677
+      - 0.1146851200873633
       MoveToRestingPosition.tree_kwargs.goal_configuration:
-      - 1.969353563943468
+      - -1.17223908965
       - 4.070232398326571
       - 1.1134910875797221
       - -1.5986870802590785
       - -1.5705609033545338
       - 0.5052628782035897
       MoveToStagingConfiguration.tree_kwargs.goal_configuration:
-      - -3.690196913927282
-      - 4.26842937402412
-      - 1.9913679193043357
-      - -1.0381758266878451
-      - -2.0708628783690375
-      - 1.397755837070344
+      - -0.5394174198411514
+      - 4.294121954324551
+      - 2.108729300644438
+      - -1.0393311059687216
+      - -2.1827671763194583
+      - 1.6106314909061383
       planning_scene_namespace_to_use: bedside
-    namespace_to_use: default
+    namespace_to_use: hospital_table_mount_1
     side_staging_1:
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.8849039817349507
@@ -62,14 +62,14 @@ ada_feeding_action_servers:
       - -1.9369287787234262
       - -3.5496749526931417
       MoveFromMouth.tree_kwargs.staging_configuration_position:
-      - 0.07124202809944423
-      - 0.08552555197552712
-      - 0.6020416159711184
+      - -0.6081959669757366
+      - 0.07835060871598665
+      - 0.20003578660416194
       MoveFromMouth.tree_kwargs.staging_configuration_quat_xyzw:
-      - 0.27572061763351097
-      - 0.6114675910385848
-      - 0.6683221188516021
-      - 0.32160701418807724
+      - 0.7144799976612057
+      - 0.07058338991982127
+      - -0.17428652585921275
+      - 0.6739143305446146
       MoveToRestingPosition.tree_kwargs.goal_configuration:
       - -0.8849039817349507
       - 4.195202297742974

--- a/ada_feeding/launch/ada_feeding_launch.xml
+++ b/ada_feeding/launch/ada_feeding_launch.xml
@@ -41,6 +41,7 @@
     <remap from="~/stop_servo" to="/servo_node/stop_servo" />
     <remap from="~/action_select" to="/ada_feeding_action_select/action_select" />
     <remap from="~/action_report" to="/ada_feeding_action_select/action_report" />
+    <remap from="~/modify_collision_object" to="/ada_planning_scene/modify_collision_object" />
   </node>
 
   <!-- Launch a republisher to pass web app servo commands to the servo node -->

--- a/ada_feeding_msgs/CMakeLists.txt
+++ b/ada_feeding_msgs/CMakeLists.txt
@@ -35,7 +35,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/AcquisitionReport.srv"
   "srv/AcquisitionSelect.srv"
   "srv/GetRobotState.srv"
-  "srv/ToggleFaceDetection.srv"
+  "srv/ModifyCollisionObject.srv"
 
   DEPENDENCIES geometry_msgs sensor_msgs std_msgs
 )

--- a/ada_feeding_msgs/srv/ModifyCollisionObject.srv
+++ b/ada_feeding_msgs/srv/ModifyCollisionObject.srv
@@ -1,0 +1,16 @@
+# A service to add or remove a collision object.
+
+# The operation, adapted from https://github.com/moveit/moveit_msgs/blob/humble/msg/CollisionObject.msg
+byte ADD=0
+byte REMOVE=1
+byte operation
+
+# The object name in MoveIt2
+string object_id
+
+---
+# Whether or not it was succesfully added
+bool success
+
+# Additional information
+string message

--- a/ada_feeding_msgs/srv/ToggleFaceDetection.srv
+++ b/ada_feeding_msgs/srv/ToggleFaceDetection.srv
@@ -1,8 +1,0 @@
-# The interface for a service that toggles face detection on/off.
-
-# If true, the service turns face detection on. If false, it turns face
-# detection off.
-bool turn_on
----
-# Whether or not face detection is on.
-bool face_detection_is_on

--- a/ada_planning_scene/ada_planning_scene/collision_object_manager.py
+++ b/ada_planning_scene/ada_planning_scene/collision_object_manager.py
@@ -30,9 +30,6 @@ class CollisionObjectManager:
        MoveIt2 has confirmed that the collision object has been added.
     """
 
-    # TODO: extend this class with the ability to remove specific collision objects
-    # (right now it can only clear the entire planning scene).
-
     __GLOBAL_BATCH_ID = "global"
     __BATCH_ID_FORMAT = "batch_{:d}"
 
@@ -490,3 +487,24 @@ class CollisionObjectManager:
             rate.sleep()
 
         return self.moveit2.process_clear_all_collision_objects_future(future)
+
+    def remove_collision_object(
+        self,
+        object_id: str,
+    ) -> bool:
+        """
+        Remove a specific collision object from the planning scene.
+
+        Parameters
+        ----------
+        object_id: The ID of the collision object to remove.
+
+        Returns
+        -------
+        True if the collision object was successfully removed, False otherwise.
+        """
+        # TODO: Extend this to verify that the object was removed in a closed-loop
+        # fashion, as `add_collision_objects` does.
+        self.__node.get_logger().info(f"Removing collision object {object_id}...")
+        self.moveit2.remove_collision_object(id=object_id)
+        return True

--- a/ada_planning_scene/ada_planning_scene/collision_object_manager.py
+++ b/ada_planning_scene/ada_planning_scene/collision_object_manager.py
@@ -201,6 +201,7 @@ class CollisionObjectManager:
         timeout: Duration = Duration(seconds=10.0),
         ignore_existing: bool = False,
         publish_feedback: Optional[Callable[[], None]] = None,
+        retry_until_added: bool = True,
     ) -> bool:
         """
         Add collision objects to the planning scene.
@@ -212,6 +213,7 @@ class CollisionObjectManager:
         timeout: The maximum amount of time to wait for the collision objects to be added.
         ignore_existing: If True, ignore the existing collision objects.
         publish_feedback: If specified, invoke this function periodically.
+        retry_until_added: If True, keep retrying until all collision objects are added.
 
         Returns
         -------
@@ -302,6 +304,8 @@ class CollisionObjectManager:
                         frame_id=params.frame_id,
                     )
                 rate.sleep()
+            if not retry_until_added:
+                break
 
         # Second, attach all collision objects that need to be attached
         attached_collision_object_ids = {
@@ -346,6 +350,8 @@ class CollisionObjectManager:
                     touch_links=params.touch_links,
                 )
                 rate.sleep()
+            if not retry_until_added:
+                break
 
         # Remove the batch that corresponds to this add_collision_objects
         # operation

--- a/ada_planning_scene/ada_planning_scene/helpers.py
+++ b/ada_planning_scene/ada_planning_scene/helpers.py
@@ -44,6 +44,8 @@ class CollisionObjectParams:
         # Optional parameters for attaching the collision object
         attached: bool = False,
         touch_links: Optional[List[str]] = None,
+        # Whether to add the collision object on initialization
+        add_on_initialize: bool = True,
     ):
         """
         Initialize the CollisionObjectParams.
@@ -62,6 +64,7 @@ class CollisionObjectParams:
         within_workspace_walls: Whether the collision object is within the workspace walls.
         attached: Whether the collision object is attached to the robot.
         touch_links: The touch links of the collision object.
+        add_on_initialize: Whether to add the collision object on initialization.
         """
         # Store the parameters
         self.object_id = object_id
@@ -76,6 +79,7 @@ class CollisionObjectParams:
         self.within_workspace_walls = within_workspace_walls
         self.attached = attached
         self.touch_links = [] if touch_links is None else touch_links
+        self.add_on_initialize = add_on_initialize
 
 
 def duration_minus(

--- a/ada_planning_scene/ada_planning_scene/planning_scene_initializer.py
+++ b/ada_planning_scene/ada_planning_scene/planning_scene_initializer.py
@@ -10,10 +10,12 @@ from typing import List
 
 # Third-party imports
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.duration import Duration
 from rclpy.node import Node
 
 # Local imports
+from ada_feeding_msgs.srv import ModifyCollisionObject
 from ada_planning_scene.collision_object_manager import CollisionObjectManager
 from ada_planning_scene.helpers import (
     check_ok,
@@ -54,10 +56,14 @@ class PlanningSceneInitializer:
         self.__namespaces = namespaces
         self.__namespace_to_use = namespace_to_use
 
+        # Initialize the parameters
         self.objects = (
             {}
         )  # namespace (str) -> object_id (str) -> params (CollisionObjectParams)
         self.__load_parameters()
+
+        # Don't yet initialize the service to modify collision objects
+        self._modify_collision_object_service = None
 
     def __load_parameters(self) -> None:
         """
@@ -253,6 +259,18 @@ class PlanningSceneInitializer:
                         read_only=True,
                     ),
                 )
+                add_on_initialize = self.__node.declare_parameter(
+                    f"{namespace}.{object_id}.add_on_initialize",
+                    True,
+                    descriptor=ParameterDescriptor(
+                        name=f"{namespace}.{object_id}.add_on_initialize",
+                        type=ParameterType.PARAMETER_BOOL,
+                        description=(
+                            "Whether to add the object to the planning scene during initialization."
+                        ),
+                        read_only=True,
+                    ),
+                )
 
                 # Add the object to the list of objects
                 filepath = (
@@ -273,6 +291,7 @@ class PlanningSceneInitializer:
                     within_workspace_walls=within_workspace_walls.value,
                     attached=attached.value,
                     touch_links=touch_links,
+                    add_on_initialize=add_on_initialize.value,
                 )
 
     def __wait_for_moveit(self, timeout: Duration(seconds=10.0)) -> bool:
@@ -352,8 +371,13 @@ class PlanningSceneInitializer:
 
         # Add the objects to the planning scene
         self.__node.get_logger().info("Adding objects to the planning scene...")
+        objects_to_add = {
+            object_id: params
+            for object_id, params in self.objects[self.__namespace_to_use].items()
+            if params.add_on_initialize
+        }
         success = self.__collision_object_manager.add_collision_objects(
-            objects=self.objects[self.__namespace_to_use],
+            objects=objects_to_add,
             rate_hz=rate_hz,
             timeout=get_remaining_time(self.__node, start_time, timeout),
             ignore_existing=True,
@@ -364,6 +388,20 @@ class PlanningSceneInitializer:
             )
             return False
         self.__node.get_logger().info("Initialized planning scene.")
+
+        # Initialize the service to modify collision objects
+        self.__node.get_logger().info(
+            "Initializing service to modify collision objects..."
+        )
+        self._modify_collision_object_service = self.__node.create_service(
+            ModifyCollisionObject,
+            "~/modify_collision_object",
+            self.__modify_collision_object_callback,
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
+        self.__node.get_logger().info(
+            "...initialized service to modify collision objects."
+        )
 
         return True
 
@@ -386,3 +424,43 @@ class PlanningSceneInitializer:
                 f"Namespace '{namespace_to_use}' not in the list of namespaces {self.__namespaces}."
             )
         self.__namespace_to_use = namespace_to_use
+
+    def __modify_collision_object_callback(
+        self,
+        request: ModifyCollisionObject.Request,
+        response: ModifyCollisionObject.Response,
+    ) -> ModifyCollisionObject.Response:
+        """
+        Add or remove a collision object in the planning scene.
+
+        Parameters
+        ----------
+        request: The request to modify the collision object.
+        response: The response to modify the collision object.
+
+        Returns
+        -------
+        response: The response to modify the collision object.
+        """
+        object_id = request.object_id
+        if object_id not in self.objects[self.__namespace_to_use]:
+            success = False
+            message = f"Object '{object_id}' not found."
+        else:
+            if request.operation == ModifyCollisionObject.Request.ADD:
+                success = self.__collision_object_manager.add_collision_objects(
+                    objects=self.objects[self.__namespace_to_use][object_id],
+                    ignore_existing=True,
+                )
+                message = f"Object '{object_id}' {'' if success else 'not '}added."
+            elif request.operation == ModifyCollisionObject.Request.REMOVE:
+                success = self.__collision_object_manager.remove_collision_object(
+                    object_id=object_id
+                )
+                message = f"Object '{object_id}' {'' if success else 'not '}removed."
+            else:
+                success = False
+                message = "Invalid operation."
+        response.success = success
+        response.message = message
+        return response

--- a/ada_planning_scene/ada_planning_scene/planning_scene_initializer.py
+++ b/ada_planning_scene/ada_planning_scene/planning_scene_initializer.py
@@ -451,6 +451,7 @@ class PlanningSceneInitializer:
                 success = self.__collision_object_manager.add_collision_objects(
                     objects=self.objects[self.__namespace_to_use][object_id],
                     ignore_existing=True,
+                    retry_until_added=False,
                 )
                 message = f"Object '{object_id}' {'' if success else 'not '}added."
             elif request.operation == ModifyCollisionObject.Request.REMOVE:

--- a/ada_planning_scene/ada_planning_scene/update_from_face_detection.py
+++ b/ada_planning_scene/ada_planning_scene/update_from_face_detection.py
@@ -11,6 +11,7 @@ from threading import Lock
 from typing import Dict, List
 
 # Third-party imports
+from builtin_interfaces.msg import Time
 from geometry_msgs.msg import Point, Pose, PoseStamped, Quaternion, Transform, Vector3
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 import rclpy
@@ -290,6 +291,9 @@ class UpdateFromFaceDetection:
 
         # Transform the detected mouth center from the camera frame into the base frame
         try:
+            msg.detected_mouth_center.header.stamp = Time(
+                sec=0, nanosec=0
+            )  # Get latest transform
             detected_mouth_center = self.__tf_buffer.transform(
                 msg.detected_mouth_center,
                 self.__base_frame_id,

--- a/ada_planning_scene/ada_planning_scene/update_from_face_detection.py
+++ b/ada_planning_scene/ada_planning_scene/update_from_face_detection.py
@@ -32,7 +32,13 @@ from ada_planning_scene.helpers import CollisionObjectParams
 # Define a namedtuple to store latest the joint state
 UpdateFromFaceDetectionParams = namedtuple(
     "UpdateFromFaceDetectionParams",
-    ["head_object_id", "body_object_id", "head_distance_threshold", "mouth_frame_id"],
+    [
+        "head_object_id",
+        "body_object_id",
+        "head_distance_threshold",
+        "mouth_frame_id",
+        "update_body",
+    ],
 )
 
 
@@ -259,11 +265,29 @@ class UpdateFromFaceDetection:
                     f"{namespace}.mouth_frame_id"
                 )
 
+            try:
+                # Whether to move the body as well as the head
+                update_body = self.__node.declare_parameter(
+                    f"{namespace}.update_body",
+                    False,
+                    descriptor=ParameterDescriptor(
+                        name=f"{namespace}.update_body",
+                        type=ParameterType.PARAMETER_BOOL,
+                        description=(
+                            "Whether to update the body as well as the head based on face detection."
+                        ),
+                        read_only=True,
+                    ),
+                )
+            except ParameterAlreadyDeclaredException:
+                update_body = self.__node.get_parameter(f"{namespace}.update_body")
+
             self.__namespace_to_params[namespace] = UpdateFromFaceDetectionParams(
                 head_object_id=head_object_id.value,
                 body_object_id=body_object_id.value,
                 head_distance_threshold=head_distance_threshold.value,
                 mouth_frame_id=mouth_frame_id.value,
+                update_body=update_body.value,
             )
 
     def __face_detection_callback(self, msg: FaceDetection) -> None:
@@ -318,6 +342,7 @@ class UpdateFromFaceDetection:
         body_object_id = self.__namespace_to_params[
             self.__namespace_to_use
         ].body_object_id
+        update_body = self.__namespace_to_params[self.__namespace_to_use].update_body
         default_head_pose = self.__default_head_poses[self.__namespace_to_use]
         default_head_params = self.__default_head_params[self.__namespace_to_use]
         default_body_pose = self.__default_body_poses[self.__namespace_to_use]
@@ -380,36 +405,37 @@ class UpdateFromFaceDetection:
         )
 
         # Scale the body object based on the user's head pose.
-        if (
-            detected_mouth_pose.header.frame_id != default_head_params.frame_id
-            or detected_mouth_pose.header.frame_id != default_head_params.frame_id
-        ):
-            self.__node.get_logger().error(
-                "The detected mouth pose frame_id does not match the expected frame_id."
+        if update_body:
+            if (
+                detected_mouth_pose.header.frame_id != default_head_params.frame_id
+                or detected_mouth_pose.header.frame_id != default_head_params.frame_id
+            ):
+                self.__node.get_logger().error(
+                    "The detected mouth pose frame_id does not match the expected frame_id."
+                )
+                return
+
+            # Compute the new body scale
+            body_scale = (
+                1.0,
+                1.0,
+                (detected_mouth_pose.pose.position.z - default_body_pose.position.z)
+                / (default_head_pose.position.z - default_body_pose.position.z),
             )
-            return
 
-        # Compute the new body scale
-        body_scale = (
-            1.0,
-            1.0,
-            (detected_mouth_pose.pose.position.z - default_body_pose.position.z)
-            / (default_head_pose.position.z - default_body_pose.position.z),
-        )
-
-        # We have to re-add it because the scale changed.
-        self.__collision_object_manager.add_collision_objects(
-            objects=CollisionObjectParams(
-                object_id=body_object_id,
-                frame_id=default_body_params.frame_id,
-                position=default_body_params.position,
-                quat_xyzw=default_body_params.quat_xyzw,
-                mesh_filepath=default_body_params.mesh_filepath,
-                mesh=default_body_params.mesh,
-                mesh_scale=body_scale,
-            ),
-            rate_hz=self.__update_face_hz * 3.0,
-        )
+            # We have to re-add it because the scale changed.
+            self.__collision_object_manager.add_collision_objects(
+                objects=CollisionObjectParams(
+                    object_id=body_object_id,
+                    frame_id=default_body_params.frame_id,
+                    position=default_body_params.position,
+                    quat_xyzw=default_body_params.quat_xyzw,
+                    mesh_filepath=default_body_params.mesh_filepath,
+                    mesh=default_body_params.mesh,
+                    mesh_scale=body_scale,
+                ),
+                rate_hz=self.__update_face_hz * 3.0,
+            )
 
     # pylint: disable=duplicate-code
     # Many of the classes in ada_planning_scene have this property and setter.

--- a/ada_planning_scene/ada_planning_scene/update_from_table_detection.py
+++ b/ada_planning_scene/ada_planning_scene/update_from_table_detection.py
@@ -319,6 +319,9 @@ class UpdateFromTableDetection:
         default_table_quat_wxyz = self.__default_table_quat_wxyz[
             self.__namespace_to_use
         ]
+        self.__node.get_logger().debug(
+            f"Detected table position: {default_table_position}"
+        )
 
         # Translate detected position of table into table's origin
         detected_table_pose.pose.position.x += table_origin_offset[0]

--- a/ada_planning_scene/config/ada_planning_scene.yaml
+++ b/ada_planning_scene/config/ada_planning_scene.yaml
@@ -30,11 +30,15 @@ ada_planning_scene:
     ############################################################################
     
     seated:
-      object_ids: # list of objects to add to the planning scene
+      # list of objects to add to the planning scene. Before changing names,
+      # check where else they are used (e.g., in `ada_feeding`). Ideally, the object_ids
+      # across different namespaces should be the same.
+      object_ids:
         - wheelchair
-        - body
+        - body # expanded mesh around the wheelchair to account for a user sitting in it
         - table
         - head
+        - in_front_of_face_wall # a wall in front of the user's face so robot motions don't unnecessarily move towards them.
       # For each object, specify:
       #   - Shape: EITHER `filepath` (for a mesh) OR `primitive_type` and
       #     `primitive_dims`(for a primitive -- see shape_msgs/SolidPrimitive.msg)
@@ -47,16 +51,17 @@ ada_planning_scene:
       #     ignored for collision checking.
       #   - [Optional] to ensure the workspace walls include the object, specify
       #     `within_workspace_walls` to be True.
+      #   - [Optional] to specify that the object should not initially be added to the
+      #     planning scene, specify `add_on_initialize` to False.
       wheelchair: # the wheelchair mesh
         filename: wheelchair.stl
         position: [0.02, -0.02, -0.05]
         quat_xyzw: [0.0, 0.0, 0.0, 1.0]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
-      # an expanded mesh around the wheelchair to account for a user sitting in it
       # NOTE: If you change this you must also change the hardcoded initial pose in
       # bite transfer.
-      body: 
+      body: # an expanded mesh around the wheelchair to account for a user sitting in it
         filename: body_collision_in_wheelchair.stl
         position: [0.02, -0.02, -0.05] # should match the wheelchair position
         quat_xyzw: [0.0, 0.0, 0.0, 1.0] # should match the wheelchair orientation
@@ -80,13 +85,24 @@ ada_planning_scene:
         quat_xyzw: [-0.0616284, -0.0616284, -0.6804416, 0.704416]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
+      in_front_of_face_wall: # a wall in front of the user's face so robot motions don't unnecessarily move towards them.
+        primitive_type: 1 # shape_msgs/SolidPrimitive.BOX
+        primitive_dims: [0.65, 0.01, 0.4]
+        position: [0.37, 0.17, 0.85]
+        quat_xyzw: [0.0, 0.0, 0.0, 1.0]
+        frame_id: root # the frame_id that the pose is relative to
+        add_on_initialize: False # don't add this to the planning scene initially
 
     bedside:
+      # list of objects to add to the planning scene. Before changing names,
+      # check where else they are used (e.g., in `ada_feeding`). Ideally, the object_ids
+      # across different namespaces should be the same.
       object_ids: # list of objects to add to the planning scene
         - bed
-        - body
+        - body # expanded mesh above the bed to account for a user lying in it
         - table
         - head
+        - in_front_of_face_wall # a wall in front of the user's face so robot motions don't unnecessarily move towards them.
       bed: # the wheelchair mesh
         filename: bed_with_back.stl
         position: [0.68, -0.6, -1.05]
@@ -115,6 +131,14 @@ ada_planning_scene:
         quat_xyzw: [-0.0626945, -0.0626602, 0.6918303, 0.7165989]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
+      # TODO: UPDATE!!!
+      in_front_of_face_wall: # a wall in front of the user's face so robot motions don't unnecessarily move towards them.
+        primitive_type: 1 # shape_msgs/SolidPrimitive.BOX
+        primitive_dims: [0.65, 0.01, 0.4]
+        position: [0.37, 0.17, 0.85]
+        quat_xyzw: [0.0, 0.0, 0.0, 1.0]
+        frame_id: root # the frame_id that the pose is relative to
+        add_on_initialize: False # don't add this to the planning scene initially
 
     ############################################################################
     # Parameters related to the WorkspaceWalls class

--- a/ada_planning_scene/config/ada_planning_scene.yaml
+++ b/ada_planning_scene/config/ada_planning_scene.yaml
@@ -105,36 +105,36 @@ ada_planning_scene:
         - in_front_of_face_wall # a wall in front of the user's face so robot motions don't unnecessarily move towards them.
       bed: # the wheelchair mesh
         filename: bed_with_back.stl
-        position: [0.68, -0.4, -1.24]
-        quat_xyzw: [0.0, 0.0, 1.0, 0.0]
+        position: [-0.68, 0.4, -1.24]
+        quat_xyzw: [0.0, 0.0, 0.0, 1.0]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: False # whether to add workspace walls around the wheelchair
       body: 
         filename: body_collision_in_bed.stl
-        position: [0.68, -0.4, -1.24] # should match the wheelchair position
-        quat_xyzw: [0.0, 0.0, 1.0, 0.0] # should match the wheelchair orientation
+        position: [-0.68, 0.4, -1.24] # should match the wheelchair position
+        quat_xyzw: [0.0, 0.0, 0.0, 1.0] # should match the wheelchair orientation
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
       table: # the table mesh
         filename: hospital_table.stl
         # Initial predicted position and orientation of the table; these values get
         # updated as the robot perceives the table.
-        position: [0.68, -0.6, -1.04]
-        quat_xyzw: [0.0, 0.0, 1.0, 0.0]
+        position: [-0.68, 0.6, -1.04]
+        quat_xyzw: [0.0, 0.0, 0.0, 1.0]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
       head: # the head mesh
         filename: tom.stl
         # This is an initial guess of head position; it will be updated as the
         # robot perceives the face.
-        position: [0.68, -0.22, 0.08]
-        quat_xyzw: [0.0010617, -0.0010994, 0.6946612, 0.7193354]
+        position: [-0.68, 0.22, 0.08]
+        quat_xyzw: [0.0010617, -0.0010994, -0.6946612, 0.7193354]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
       in_front_of_face_wall: # a wall in front of the user's face so robot motions don't unnecessarily move towards them.
         primitive_type: 1 # shape_msgs/SolidPrimitive.BOX
         primitive_dims: [0.65, 0.01, 0.6]
-        position: [0.37, -0.11, 0.26]
+        position: [-0.37, 0.11, 0.26]
         quat_xyzw: [0.0, 0.0, 0.0, 1.0]
         frame_id: root # the frame_id that the pose is relative to
         add_on_initialize: False # don't add this to the planning scene initially
@@ -209,9 +209,11 @@ ada_planning_scene:
     seated:
       head_object_id: head
       head_distance_threshold: 0.5 # m
+      update_body: True
     bedside:
       head_object_id: head
       head_distance_threshold: 0.5 # m
+      update_body: False
 
     ############################################################################
     # Parameters related to the UpdateFromTableDetectionpace class

--- a/ada_planning_scene/config/ada_planning_scene.yaml
+++ b/ada_planning_scene/config/ada_planning_scene.yaml
@@ -105,13 +105,13 @@ ada_planning_scene:
         - in_front_of_face_wall # a wall in front of the user's face so robot motions don't unnecessarily move towards them.
       bed: # the wheelchair mesh
         filename: bed_with_back.stl
-        position: [0.68, -0.6, -1.05]
+        position: [0.68, -0.4, -1.24]
         quat_xyzw: [0.0, 0.0, 1.0, 0.0]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: False # whether to add workspace walls around the wheelchair
       body: 
         filename: body_collision_in_bed.stl
-        position: [0.68, -0.6, -1.05] # should match the wheelchair position
+        position: [0.68, -0.4, -1.24] # should match the wheelchair position
         quat_xyzw: [0.0, 0.0, 1.0, 0.0] # should match the wheelchair orientation
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
@@ -119,7 +119,7 @@ ada_planning_scene:
         filename: hospital_table.stl
         # Initial predicted position and orientation of the table; these values get
         # updated as the robot perceives the table.
-        position: [0.68, -0.6, -1.05]
+        position: [0.68, -0.6, -1.04]
         quat_xyzw: [0.0, 0.0, 1.0, 0.0]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
@@ -127,15 +127,14 @@ ada_planning_scene:
         filename: tom.stl
         # This is an initial guess of head position; it will be updated as the
         # robot perceives the face.
-        position: [0.68, -0.42, 0.27]
-        quat_xyzw: [-0.0626945, -0.0626602, 0.6918303, 0.7165989]
+        position: [0.68, -0.22, 0.08]
+        quat_xyzw: [0.0010617, -0.0010994, 0.6946612, 0.7193354]
         frame_id: root # the frame_id that the pose is relative to
         within_workspace_walls: True # whether to add workspace walls around the wheelchair
-      # TODO: UPDATE!!!
       in_front_of_face_wall: # a wall in front of the user's face so robot motions don't unnecessarily move towards them.
         primitive_type: 1 # shape_msgs/SolidPrimitive.BOX
-        primitive_dims: [0.65, 0.01, 0.4]
-        position: [0.37, 0.17, 0.85]
+        primitive_dims: [0.65, 0.01, 0.6]
+        position: [0.37, -0.11, 0.26]
         quat_xyzw: [0.0, 0.0, 0.0, 1.0]
         frame_id: root # the frame_id that the pose is relative to
         add_on_initialize: False # don't add this to the planning scene initially
@@ -152,6 +151,12 @@ ada_planning_scene:
       disable_workspace_wall_y_max: True # Remove the back wall, to be able to see in in RVIZ
     bedside:
       disable_workspace_wall_y_min: True # Remove the back wall, to be able to see in in RVIZ
+      # TODO: remove!
+      disable_workspace_wall_y_max: True # Remove the back wall, to be able to see in in RVIZ
+      disable_workspace_wall_x_min: True # Remove the back wall, to be able to see in in RVIZ
+      disable_workspace_wall_x_max: True # Remove the back wall, to be able to see in in RVIZ
+      disable_workspace_wall_z_min: True # Remove the back wall, to be able to see in in RVIZ
+      disable_workspace_wall_z_max: True # Remove the back wall, to be able to see in in RVIZ
 
     # Whether the workspace walls should contain the robot's current configuration
     # at time of recomputation.
@@ -219,19 +224,11 @@ ada_planning_scene:
     #    latest table quaternion.
     # - `table_pos_dist_thresh`: The threshold on the linear distance (in m) between the default table position
     #    and the latest table position to determine whether to reject or accept the latest table position.
-
     seated:
       table_origin_offset: [-0.20, -0.25, -0.79]
       table_quat_dist_thresh: 0.349
       table_pos_dist_thresh: 0.5
     bedside:
-      disable_table_detection: true
-      # TODO: The offset values have to be tuned. The z-value has already been computed, 
-      # by analytically computing the z value of the top-surface of the table. The x and
-      # y have to be tuned. Note that given how close the robot is to the table, the table
-      # detector node may have to be extended to only allow updating certain dimensions of
-      # the pose, and leaving other dimensions the default (e.g., don't update x or yaw, as
-      # those could allow the table to collide with the robot base in the planning scene).
-      table_origin_offset: [-0.20, -0.25, 1.0067]
+      table_origin_offset: [0.23, -0.71, -1.0067]
       table_quat_dist_thresh: 0.349
       table_pos_dist_thresh: 0.5

--- a/ada_planning_scene/launch/ada_moveit_launch.xml
+++ b/ada_planning_scene/launch/ada_moveit_launch.xml
@@ -4,6 +4,7 @@
   <arg name="sim" default="real" description="Which sim to use: 'mock', 'isaac', or 'real'"/>
   <arg name="use_rviz" default="True" description="Whether or not to launch RVIZ"/>
   <arg name="run_moveit" default="True" description="Whether or not to launch MoveIt"/>
+  <arg name="run_planning_scene" default="True" description="Whether or not to launch the planning scene node"/>
 
   <!-- Launch MoveIt -->
   <group if="$(var run_moveit)">
@@ -16,13 +17,15 @@
   </group>
 
   <!-- Populate the planning scene -->
-  <node pkg="ada_planning_scene" exec="ada_planning_scene" name="ada_planning_scene" respawn="true" args="--ros-args --log-level $(var log_level) --log-level rcl:=INFO --log-level rmw_fastrtps_cpp:=INFO">
-    <param from="$(find-pkg-share ada_planning_scene)/config/ada_planning_scene.yaml"/>
-    <param name="assets_dir" value="$(find-pkg-share ada_planning_scene)/assets/"/>
-    <remap from="~/face_detection" to="/face_detection" />
-    <remap from="~/joint_states" to="/joint_states" />
-    <remap from="~/monitored_planning_scene" to="/monitored_planning_scene" />
-    <remap from="~/table_detection" to="/table_detection" />
-  </node>
+  <group if="$(var run_planning_scene)">
+    <node pkg="ada_planning_scene" exec="ada_planning_scene" name="ada_planning_scene" respawn="true" args="--ros-args --log-level $(var log_level) --log-level rcl:=INFO --log-level rmw_fastrtps_cpp:=INFO">
+      <param from="$(find-pkg-share ada_planning_scene)/config/ada_planning_scene.yaml"/>
+      <param name="assets_dir" value="$(find-pkg-share ada_planning_scene)/assets/"/>
+      <remap from="~/face_detection" to="/face_detection" />
+      <remap from="~/joint_states" to="/joint_states" />
+      <remap from="~/monitored_planning_scene" to="/monitored_planning_scene" />
+      <remap from="~/table_detection" to="/table_detection" />
+    </node>
+  </group>
 
 </launch>

--- a/cyclonedds.xml
+++ b/cyclonedds.xml
@@ -12,5 +12,4 @@
       </Interfaces>
     </General>
   </Domain>
-
 </CycloneDDS>


### PR DESCRIPTION
# Description

Earlier, the code hardcoded a location for an "in front of face wall," which essentially ensured that when the robot arm moved to/from the resting configuration and to the staging configuration, it wouldn't move unnecessarily close to the user's face. (e.g., the behavior we wanted to avoid was the robot moving closer to the user's face and then moving back). However, now that we have different options for planning scene namespaces, the wall position cannot be hardcoded, and should depend on the namespace.

This PR addresses that, by adding the in front of face wall to `ada_planning_scene`, and extending `ada_planning_scene` with: (1) the ability to not add an object to the planning scene initially; (2) a service that arrows clients to add/remove objects from the planning scene.

Then, in `ada_feeding`, when adding/removing the in front of wheelchair wall, it calls that service.

# Testing procedure

- [x] Launch the code in `real`.
- [x] Run it with the `seated` configuration. Verify everything works as expected.
- [x] Open RVIZ. Verify it adds/removes the in front of face wall as expected.
- [x] Run it with the `bedside` configuration. Verify everything works as expected.
- [x] Open RVIZ. Verify it adds/removes the in front of face wall as expected.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
