### PR TITLE
Sync CameraInfo messages with AlignedDepth messages

### DIFF
--- a/ada_feeding_perception/config/republisher.yaml
+++ b/ada_feeding_perception/config/republisher.yaml
@@ -3,31 +3,26 @@ republisher:
   ros__parameters:
     # The name of the topics to republish from
     from_topics:
-      - /camera/aligned_depth_to_color/camera_info
       - /local/camera/aligned_depth_to_color/image_raw/compressedDepth
 
     # The types of topics to republish from
     in_topic_types:
-      - sensor_msgs.msg.CameraInfo
       - sensor_msgs.msg.CompressedImage
 
     # If the republisher should convert types, specify the output type.
     # Currently, the republisher only supports conversions from
     # Image->CompressedImage and vice-versa.
     out_topic_types:
-      - ""
       - sensor_msgs.msg.Image
 
     # The name of the topics to republish to. NOTE: the `prefix` in the launchfile
     # must match the below pattern!
     to_topics:
-      - /local/camera/aligned_depth_to_color/camera_info
       - /local/camera/aligned_depth_to_color/depth_octomap
 
     # The target rates (Hz) for the republished topics. Rates <= 0 will publish
     # every message.
     target_rates:
-      - 0
       - 0
 
     # The names of a post-processing functions to apply to the message before
@@ -43,7 +38,6 @@ republisher:
     # Any of these post-processing functions can be combined in a comma-separated list.
     # If an empty string, no post-processors are applied.
     post_processors:
-      - ""
       - threshold,mask,temporal,spatial # Apply filters to the depth image for the Octomap
     # The binary mask used for "mask" post-processing. This mask will get scaled,
     # possibly disproportionately, to the same of the image.

--- a/ada_planning_scene/config/ada_planning_scene.yaml
+++ b/ada_planning_scene/config/ada_planning_scene.yaml
@@ -160,12 +160,7 @@ ada_planning_scene:
     # from it, to get the robot URDF
     get_urdf_parameter_service_name: "/move_group/get_parameters"
     urdf_parameter_name: "robot_description"
-      # TODO: remove!
-      disable_workspace_wall_y_max: True # Remove the back wall, to be able to see in in RVIZ
-      disable_workspace_wall_x_min: True # Remove the back wall, to be able to see in in RVIZ
-      disable_workspace_wall_x_max: True # Remove the back wall, to be able to see in in RVIZ
-      disable_workspace_wall_z_min: True # Remove the back wall, to be able to see in in RVIZ
-      disable_workspace_wall_z_max: True # Remove the back wall, to be able to see in in RVIZ
+
     # The service that needs to be called, and parameters that need to be requested,
     # to get the robot joint positions that must be in the workspace walls. Note that
     # the parameter name is made by first getting the parameter value from the

--- a/nano_bridge/config/nano_bridge.yaml
+++ b/nano_bridge/config/nano_bridge.yaml
@@ -20,3 +20,36 @@ sender_compressed_image:
 receiver_compressed_image:
   ros__parameters:
     prefix: local
+
+    sync_camera_info_with_topic: /camera/aligned_depth_to_color/image_raw/compressedDepth
+    camera_info_pub_topic: /local/camera/aligned_depth_to_color/camera_info
+    camera_info:
+      frame_id: camera_color_optical_frame
+      height: 480
+      width: 640
+      distortion_model: plumb_bob
+      d: [0.0, 0.0, 0.0, 0.0, 0.0]
+      k:
+        - 614.5933227539062
+        - 0.0
+        - 312.1358947753906
+        - 0.0
+        - 614.6914672851562
+        - 223.70831298828125
+        - 0.0
+        - 0.0
+        - 1.0
+      r: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+      p:
+        - 614.5933227539062
+        - 0.0
+        - 312.1358947753906
+        - 0.0
+        - 0.0
+        - 614.6914672851562
+        - 223.70831298828125
+        - 0.0
+        - 0.0
+        - 0.0
+        - 1.0
+        - 0.0

--- a/nano_bridge/nano_bridge/receiver_compressed_image.py
+++ b/nano_bridge/nano_bridge/receiver_compressed_image.py
@@ -264,7 +264,7 @@ class ReceiverCompressedImageNode(Node):
 
         # Create the camera info message
         if self.__sync_camera_info_with_topic is not None:
-            self.__camera_info_msg.header.stamp = msg.header.stamp
+            self.__camera_info_msg.header.stamp = msg.data.header.stamp
             self.__pub_camera_info.publish(self.__camera_info_msg)
 
         # Publish the message

--- a/nano_bridge/nano_bridge/receiver_compressed_image.py
+++ b/nano_bridge/nano_bridge/receiver_compressed_image.py
@@ -10,9 +10,10 @@ prepended with a parameter-specified prefix.
 
 # Standard imports
 import os
+from typing import Optional
 
 # Third-party imports
-from sensor_msgs.msg import CompressedImage as CompressedImageOutput
+from sensor_msgs.msg import CameraInfo, CompressedImage as CompressedImageOutput
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 import rclpy
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
@@ -40,10 +41,21 @@ class ReceiverCompressedImageNode(Node):
 
         # Load the parameters
         self.__prefix = ""
+        self.__sync_camera_info_with_topic: Optional[str] = None
+        self.__camera_info_pub_topic: Optional[str] = None
+        self.__camera_info_msg = None
         self.__load_parameters()
 
         # Create the publishers
         self.__pubs: dict[str, Publisher] = {}
+        if self.__sync_camera_info_with_topic is not None:
+            self.__pub_camera_info = self.create_publisher(
+                msg_type=CameraInfo,
+                topic=self.__camera_info_pub_topic,
+                qos_profile=QoSProfile(
+                    depth=1, reliability=ReliabilityPolicy.BEST_EFFORT
+                ),
+            )
 
         # Create the subscriber
         # pylint: disable=unused-private-member
@@ -71,6 +83,162 @@ class ReceiverCompressedImageNode(Node):
         )
         self.__prefix = prefix.value
 
+        # Camera Info
+        sync_camera_info_with_topic = self.declare_parameter(
+            "sync_camera_info_with_topic",
+            None,
+            descriptor=ParameterDescriptor(
+                name="sync_camera_info_with_topic",
+                type=ParameterType.PARAMETER_STRING,
+                description=("Whether to sync camera info with topic."),
+                read_only=True,
+            ),
+        )
+        self.__sync_camera_info_with_topic = sync_camera_info_with_topic.value
+
+        camera_info_pub_topic = self.declare_parameter(
+            "camera_info_pub_topic",
+            None,
+            descriptor=ParameterDescriptor(
+                name="camera_info_pub_topic",
+                type=ParameterType.PARAMETER_STRING,
+                description=("The topic to publish camera info."),
+                read_only=True,
+            ),
+        )
+        self.__camera_info_pub_topic = camera_info_pub_topic.value
+        if (
+            self.__sync_camera_info_with_topic is not None
+            and self.__camera_info_pub_topic is None
+        ):
+            raise ValueError(
+                "If sync_camera_info_with_topic is set, camera_info_pub_topic must be set."
+            )
+
+        if self.__sync_camera_info_with_topic is not None:
+            self.__camera_info_msg = CameraInfo()
+            frame_id = self.declare_parameter(
+                "camera_info.frame_id",
+                "camera_color_optical_frame",
+                descriptor=ParameterDescriptor(
+                    name="camera_info.frame_id",
+                    type=ParameterType.PARAMETER_STRING,
+                    description=("The frame ID of the camera."),
+                    read_only=True,
+                ),
+            )
+            self.__camera_info_msg.header.frame_id = frame_id.value
+            height = self.declare_parameter(
+                "camera_info.height",
+                480,
+                descriptor=ParameterDescriptor(
+                    name="camera_info.height",
+                    type=ParameterType.PARAMETER_INTEGER,
+                    description=("The height of the image."),
+                    read_only=True,
+                ),
+            )
+            self.__camera_info_msg.height = height.value
+            width = self.declare_parameter(
+                "camera_info.width",
+                640,
+                descriptor=ParameterDescriptor(
+                    name="camera_info.width",
+                    type=ParameterType.PARAMETER_INTEGER,
+                    description=("The width of the image."),
+                    read_only=True,
+                ),
+            )
+            self.__camera_info_msg.width = width.value
+            distortion_model = self.declare_parameter(
+                "camera_info.distortion_model",
+                "plumb_bob",
+                descriptor=ParameterDescriptor(
+                    name="camera_info.distortion_model",
+                    type=ParameterType.PARAMETER_STRING,
+                    description=("The distortion model of the camera."),
+                    read_only=True,
+                ),
+            )
+            self.__camera_info_msg.distortion_model = distortion_model.value
+            d = self.declare_parameter(
+                "camera_info.d",
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                descriptor=ParameterDescriptor(
+                    name="camera_info.d",
+                    type=ParameterType.PARAMETER_DOUBLE_ARRAY,
+                    description=("The distortion coefficients."),
+                    read_only=True,
+                ),
+            )
+            self.__camera_info_msg.d = d.value
+            k = self.declare_parameter(
+                "camera_info.k",
+                [
+                    614.5933227539062,
+                    0.0,
+                    312.1358947753906,
+                    0.0,
+                    614.6914672851562,
+                    223.70831298828125,
+                    0.0,
+                    0.0,
+                    1.0,
+                ],
+                descriptor=ParameterDescriptor(
+                    name="camera_info.k",
+                    type=ParameterType.PARAMETER_DOUBLE_ARRAY,
+                    description=("The camera matrix."),
+                    read_only=True,
+                ),
+            )
+            self.__camera_info_msg.k = k.value
+            r = self.declare_parameter(
+                "camera_info.r",
+                [
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                ],
+                descriptor=ParameterDescriptor(
+                    name="camera_info.r",
+                    type=ParameterType.PARAMETER_DOUBLE_ARRAY,
+                    description=("The rectification matrix."),
+                    read_only=True,
+                ),
+            )
+            self.__camera_info_msg.r = r.value
+            p = self.declare_parameter(
+                "camera_info.p",
+                [
+                    614.5933227539062,
+                    0.0,
+                    312.1358947753906,
+                    0.0,
+                    0.0,
+                    614.6914672851562,
+                    223.70831298828125,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                    0.0,
+                ],
+                descriptor=ParameterDescriptor(
+                    name="camera_info.p",
+                    type=ParameterType.PARAMETER_DOUBLE_ARRAY,
+                    description=("The projection matrix."),
+                    read_only=True,
+                ),
+            )
+            self.__camera_info_msg.p = p.value
+
     def __callback(self, msg: CompressedImageInput) -> None:
         """
         Callback function for the subscriber.
@@ -93,6 +261,11 @@ class ReceiverCompressedImageNode(Node):
                 ),
             )
             self.get_logger().info(f"Created publisher for {repub_topic_name}.")
+
+        # Create the camera info message
+        if self.__sync_camera_info_with_topic is not None:
+            self.__camera_info_msg.header.stamp = msg.header.stamp
+            self.__pub_camera_info.publish(self.__camera_info_msg)
 
         # Publish the message
         self.__pubs[topic_name].publish(msg.data)

--- a/nano_bridge/nano_bridge/sender_compressed_image.py
+++ b/nano_bridge/nano_bridge/sender_compressed_image.py
@@ -94,7 +94,7 @@ class SenderCompressedImageNode(Node):
                 self.__msg_recv_time[topic_name] = start_time
             self.__msg_count[topic_name] += 1
 
-        # Create the ByteMultiArray message
+        # Create the message
         msg_out = CompressedImageOutput(
             topic=topic_name,
             data=msg_in,


### PR DESCRIPTION
# Description

As of #193 , depth images are often out-of-sync with their camera info, because the camera info is published by `republisher` whereas the depth image is published by `nano_bridge`. In the best case, this fills up the `moveit` screen's logs, and in the worst case it takes compute from the `moveit` process.

To address this, this PR hardcodes a `camera_info` into `nano_bridge` and publishes that synchronized with the depth image.

# Testing procedure

- [x] Launch the code in `real`.
- [x] Go to the `moveit` screen, verify it doesn't print logs about camera info and image mismatch.
- [x] Echo the `local` camera info and the `camera` camera info. Verify they contain the exact same information.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
