### PR TITLE
Add option to combine all perception nodes into one

### DIFF
--- a/ada_feeding_perception/ada_feeding_perception/ada_feeding_perception_node.py
+++ b/ada_feeding_perception/ada_feeding_perception/ada_feeding_perception_node.py
@@ -1,0 +1,231 @@
+"""
+This module contains the ADAFeedingPerceptionNode class, which is used as a component
+of all perception nodes in the ADA Feeding project. Specifically, by storing all
+functionality to get camera images (RGB and depth) and info in this node, it makes
+it easier to combine one or more perception functionalities into a single node,
+which will reduce the number of parallel subscriptions the ROS2 middleware has to
+manage.
+"""
+# Standard imports
+from collections import deque
+from functools import partial
+from threading import Lock, Thread
+from typing import Any, Optional, Type, Union
+
+# Third-party imports
+import rclpy
+from rclpy.callback_groups import CallbackGroup, MutuallyExclusiveCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from rclpy.subscription import Subscription
+
+# Local imports
+
+
+class ADAFeedingPerceptionNode(Node):
+    """
+    Class that contains all functionality to get camera images (RGB and depth) and
+    camera info. This class is meant to consolidate the number of parallel subscriptions
+    the ROS2 middleware has to manage.
+    """
+
+    def __init__(self, name: str):
+        """
+        Constructor for the ADAFeedingPerceptionNode class.
+
+        Parameters
+        ----------
+        name : str
+            The name of the node.
+        """
+        super().__init__(name)
+        self.__msg_locks: dict[str, Lock] = {}
+        self.__latest_msgs: dict[str, deque[Any]] = {}
+        self.__subs: dict[str, Subscription] = {}
+
+    # pylint: disable=too-many-arguments
+    # These are fine to mimic ROS2 API
+    def add_subscription(
+        self,
+        msg_type: Type,
+        topic: str,
+        qos_profile: Union[QoSProfile, int] = QoSProfile(
+            depth=1, reliability=ReliabilityPolicy.BEST_EFFORT
+        ),
+        callback_group: Optional[CallbackGroup] = MutuallyExclusiveCallbackGroup(),
+        num_msgs: int = 1,
+    ) -> None:
+        """
+        Adds a subscription to this node.
+
+        Parameters
+        ----------
+        msg_type : Type
+            The type of message to subscribe to.
+        topic : str
+            The name of the topic to subscribe to.
+        qos_profile : Union[QoSProfile, int], optional
+            The quality of service profile to use for the subscription, by default
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT).
+        callback_group : Optional[CallbackGroup], optional
+            The callback group to use for the subscription, by default
+            MutuallyExclusiveCallbackGroup().
+        num_msgs : int, optional
+            The number of messages to store in the subscription, by default 1.
+        """
+        if topic in self.__msg_locks:
+            with self.__msg_locks[topic]:
+                if num_msgs > self.__latest_msgs[topic].maxlen:
+                    # Grow the deque
+                    self.__latest_msgs[topic] = deque(
+                        self.__latest_msgs[topic], maxlen=num_msgs
+                    )
+            return
+        self.__msg_locks[topic] = Lock()
+        self.__latest_msgs[topic] = deque(maxlen=num_msgs)
+        self.__subs[topic] = self.create_subscription(
+            msg_type=msg_type,
+            topic=topic,
+            callback=partial(self.__callback, topic=topic),
+            qos_profile=qos_profile,
+            callback_group=callback_group,
+        )
+
+    def get_latest_msg(self, topic: str) -> Optional[Any]:
+        """
+        Returns the latest message from the specified topic.
+
+        Parameters
+        ----------
+        topic : str
+            The name of the topic to get the latest message from.
+
+        Returns
+        -------
+        Optional[Any]
+            The latest message from the specified topic, or None if no message has been
+            received.
+        """
+        if topic not in self.__msg_locks:
+            self.get_logger().error(f"Topic '{topic}' not found.")
+            return None
+        with self.__msg_locks[topic]:
+            if len(self.__latest_msgs[topic]) == 0:
+                self.get_logger().error(f"No message received from topic '{topic}'.")
+                return None
+            return self.__latest_msgs[topic][-1]
+
+    def get_all_msgs(self, topic: str, copy: bool = True) -> Optional[deque[Any]]:
+        """
+        Returns all messages from the specified topic.
+
+        Parameters
+        ----------
+        topic : str
+            The name of the topic to get the messages from.
+        copy : bool, optional
+            Whether to return a copy of the messages, by default True.
+
+        Returns
+        -------
+        Optional[deque[Any]]
+            All messages from the specified topic, or None if no messages have been
+            received.
+        """
+        if topic not in self.__msg_locks:
+            self.get_logger().error(f"Topic '{topic}' not found.")
+            return None
+        with self.__msg_locks[topic]:
+            if len(self.__latest_msgs[topic]) == 0:
+                self.get_logger().error(f"No message received from topic '{topic}'.")
+                return None
+            if copy:
+                return deque(
+                    self.__latest_msgs[topic], maxlen=self.__latest_msgs[topic].maxlen
+                )
+            return self.__latest_msgs[topic]
+
+    def __callback(self, msg: Any, topic: str) -> None:
+        """
+        Callback function for the subscription.
+
+        Parameters
+        ----------
+        msg : Any
+            The message received from the subscription.
+        topic : str
+            The name of the topic the message was received from.
+        """
+        with self.__msg_locks[topic]:
+            self.__latest_msgs[topic].append(msg)
+
+
+# pylint: disable=too-many-locals
+def main(args=None):
+    """
+    Launch the ROS node and spin.
+    """
+    # Import the necessary modules
+    # pylint: disable=import-outside-toplevel
+    from ada_feeding_perception.face_detection import FaceDetectionNode
+    from ada_feeding_perception.food_on_fork_detection import FoodOnForkDetectionNode
+    from ada_feeding_perception.segment_from_point import SegmentFromPointNode
+    from ada_feeding_perception.table_detection import TableDetectionNode
+
+    rclpy.init(args=args)
+
+    node = ADAFeedingPerceptionNode("ada_feeding_perception")
+    face_detection = FaceDetectionNode(node)
+    food_on_fork_detection = FoodOnForkDetectionNode(node)
+    segment_from_point = SegmentFromPointNode(node)  # pylint: disable=unused-variable
+    table_detection = TableDetectionNode(node)
+    executor = MultiThreadedExecutor(num_threads=16)
+
+    # Spin in the background initially
+    spin_thread = Thread(
+        target=rclpy.spin,
+        args=(node,),
+        kwargs={"executor": executor},
+        daemon=True,
+    )
+    spin_thread.start()
+
+    # Run the perception nodes
+    def face_detection_run():
+        try:
+            face_detection.run()
+        except KeyboardInterrupt:
+            pass
+
+    def food_on_fork_detection_run():
+        try:
+            food_on_fork_detection.run()
+        except KeyboardInterrupt:
+            pass
+
+    def table_detection_run():
+        try:
+            table_detection.run()
+        except KeyboardInterrupt:
+            pass
+
+    face_detection_thread = Thread(target=face_detection_run, daemon=True)
+    face_detection_thread.start()
+    food_on_fork_detection_thread = Thread(
+        target=food_on_fork_detection_run, daemon=True
+    )
+    food_on_fork_detection_thread.start()
+    table_detection_thread = Thread(target=table_detection_run, daemon=True)
+    table_detection_thread.start()
+
+    # Spin in the foreground
+    spin_thread.join()
+
+    # Terminate this node
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ada_feeding_perception/ada_feeding_perception/face_detection.py
+++ b/ada_feeding_perception/ada_feeding_perception/face_detection.py
@@ -160,7 +160,7 @@ class FaceDetectionNode(Node):
             image_type,
             image_topic,
             self.camera_callback,
-            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
@@ -180,7 +180,7 @@ class FaceDetectionNode(Node):
             aligned_depth_type,
             aligned_depth_topic,
             self.depth_callback,
-            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
@@ -193,7 +193,7 @@ class FaceDetectionNode(Node):
             CameraInfo,
             "~/camera_info",
             self.camera_info_callback,
-            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 

--- a/ada_feeding_perception/ada_feeding_perception/food_on_fork_detection.py
+++ b/ada_feeding_perception/ada_feeding_perception/food_on_fork_detection.py
@@ -130,7 +130,7 @@ class FoodOnForkDetectionNode(Node):
             CameraInfo,
             "~/camera_info",
             self.camera_info_callback,
-            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
@@ -151,7 +151,7 @@ class FoodOnForkDetectionNode(Node):
             aligned_depth_type,
             aligned_depth_topic,
             self.depth_callback,
-            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
@@ -175,7 +175,7 @@ class FoodOnForkDetectionNode(Node):
                 image_type,
                 image_topic,
                 self.camera_callback,
-                QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+                QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
                 callback_group=MutuallyExclusiveCallbackGroup(),
             )
 

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -7,7 +7,7 @@ point using Segment Anything, and returns the top n contender masks.
 # Standard imports
 import os
 import threading
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 # Third-party imports
 import cv2
@@ -21,7 +21,6 @@ from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.action.server import ServerGoalHandle
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
-from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 from segment_anything import sam_model_registry, SamPredictor
@@ -41,9 +40,10 @@ from ada_feeding_perception.helpers import (
     get_img_msg_type,
     ros_msg_to_cv2_image,
 )
+from ada_feeding_perception.ada_feeding_perception_node import ADAFeedingPerceptionNode
 
 
-class SegmentFromPointNode(Node):
+class SegmentFromPointNode:
     """
     The SegmentFromPointNode launches an action server that takes in a seed point,
     segments the latest image with that seed point using Segment Anything, and
@@ -55,16 +55,24 @@ class SegmentFromPointNode(Node):
     # every subscription we need to store the subscription, mutex, and data,
     # and we have 3 subscriptions.
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        node: ADAFeedingPerceptionNode,
+    ) -> None:
         """
         Initialize the SegmentFromPointNode.
-        """
 
-        super().__init__("segment_from_point")
+        Parameters
+        ----------
+        node : ADAFeedingPerceptionNode
+            The node that contains all functionality to get camera images (RGB and depth)
+            and camera info.
+        """
+        self._node = node
 
         # Check if cuda is available
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.get_logger().info(f"Using device {self.device}")
+        self._node.get_logger().info(f"Using device {self.device}")
 
         # Read the parameters
         # NOTE: These parameters are only read once. Any changes after the node
@@ -83,9 +91,11 @@ class SegmentFromPointNode(Node):
         # Download the checkpoint if it doesn't exist
         model_path = os.path.join(model_dir, model_name)
         if not os.path.isfile(model_path):
-            self.get_logger().info("Model checkpoint does not exist. Downloading...")
+            self._node.get_logger().info(
+                "Model checkpoint does not exist. Downloading..."
+            )
             download_checkpoint(model_name, model_dir, model_base_url)
-            self.get_logger().info(f"Model checkpoint downloaded {model_path}.")
+            self._node.get_logger().info(f"Model checkpoint downloaded {model_path}.")
 
         # Create the shared resource to ensure that the action server rejects all
         # goals while a goal is currently active.
@@ -93,51 +103,46 @@ class SegmentFromPointNode(Node):
         self.active_goal_request = None
 
         # Subscribe to the camera info topic, to get the camera intrinsics
+        self.camera_info_topic = "~/camera_info"
         self.camera_info = None
-        self.camera_info_lock = threading.Lock()
-        self.camera_info_subscriber = self.create_subscription(
+        self.got_camera_info = False
+        self._node.add_subscription(
             CameraInfo,
-            "~/camera_info",
-            self.camera_info_callback,
+            self.camera_info_topic,
             QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
         # Subscribe to the aligned depth image topic, to store the latest depth image
         # NOTE: We assume this is in the same frame as the RGB image
-        self.latest_depth_img_msg = None
-        self.latest_depth_img_msg_lock = threading.Lock()
-        aligned_depth_topic = "~/aligned_depth"
+        self.aligned_depth_topic = "~/aligned_depth"
         try:
-            aligned_depth_type = get_img_msg_type(aligned_depth_topic, self)
+            aligned_depth_type = get_img_msg_type(self.aligned_depth_topic, self._node)
         except ValueError as err:
-            self.get_logger().error(
-                f"Error getting type of depth image topic. Defaulting to CompressedImage. {err}"
+            self._node.get_logger().error(
+                f"Error getting type of depth image topic. Defaulting to Image. {err}"
             )
-            aligned_depth_type = CompressedImage
-        self.depth_image_subscriber = self.create_subscription(
+            aligned_depth_type = Image
+        # Subscribe to the depth image
+        self._node.add_subscription(
             aligned_depth_type,
-            aligned_depth_topic,
-            self.depth_image_callback,
+            self.aligned_depth_topic,
             QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
         # Subscribe to the RGB image topic, to store the latest image
-        self.latest_img_msg = None
-        self.latest_img_msg_lock = threading.Lock()
-        image_topic = "~/image"
+        self.rgb_image_topic = "~/image"
         try:
-            image_type = get_img_msg_type(image_topic, self)
+            image_type = get_img_msg_type(self.rgb_image_topic, self._node)
         except ValueError as err:
-            self.get_logger().error(
+            self._node.get_logger().error(
                 f"Error getting type of image topic. Defaulting to CompressedImage. {err}"
             )
             image_type = CompressedImage
-        self.image_subscriber = self.create_subscription(
+        self._node.add_subscription(
             image_type,
-            image_topic,
-            self.image_callback,
+            self.rgb_image_topic,
             QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
@@ -154,7 +159,7 @@ class SegmentFromPointNode(Node):
         # Create the Action Server.
         # Note: remapping action names does not work: https://github.com/ros2/ros2/issues/1312
         self._action_server = ActionServer(
-            self,
+            self._node,
             SegmentFromPoint,
             "SegmentFromPoint",
             self.execute_callback,
@@ -192,7 +197,7 @@ class SegmentFromPointNode(Node):
             rate_hz,
             min_depth_mm,
             max_depth_mm,
-        ) = self.declare_parameters(
+        ) = self._node.declare_parameters(
             "",
             [
                 (
@@ -242,10 +247,10 @@ class SegmentFromPointNode(Node):
                     ),
                 ),
                 (
-                    "model_dir",
+                    "segment_from_point_model_dir",
                     None,
                     ParameterDescriptor(
-                        name="model_dir",
+                        name="segment_from_point_model_dir",
                         type=ParameterType.PARAMETER_STRING,
                         description=(
                             "The location of the directory where the model "
@@ -275,10 +280,10 @@ class SegmentFromPointNode(Node):
                     ),
                 ),
                 (
-                    "rate_hz",
+                    "segment_from_point_rate_hz",
                     10.0,
                     ParameterDescriptor(
-                        name="rate_hz",
+                        name="segment_from_point_rate_hz",
                         type=ParameterType.PARAMETER_DOUBLE,
                         description="The rate at which to return feedback.",
                         read_only=True,
@@ -342,7 +347,7 @@ class SegmentFromPointNode(Node):
         ------
         ValueError if the model name does not contain vit_h, vit_l, or vit_b
         """
-        self.get_logger().info("Initializing SAM...")
+        self._node.get_logger().info("Initializing SAM...")
         # Load the model and move it to the specified device
         if "vit_b" in model_name:  # base model
             model_type = "vit_b"
@@ -360,7 +365,7 @@ class SegmentFromPointNode(Node):
         # a lock.
         self.predictor = SamPredictor(sam)
 
-        self.get_logger().info("...Done!")
+        self._node.get_logger().info("...Done!")
 
     def initialize_efficient_sam(self, model_name: str, model_path: str) -> None:
         """
@@ -379,7 +384,7 @@ class SegmentFromPointNode(Node):
         ------
         ValueError if the model name does not contain efficient_sam
         """
-        self.get_logger().info("Initializing EfficientSAM...")
+        self._node.get_logger().info("Initializing EfficientSAM...")
         # Hardcoded from https://github.com/yformer/EfficientSAM/blob/main/efficient_sam/build_efficient_sam.py
         if "vits" in model_name:
             encoder_patch_embed_dim = 384
@@ -396,40 +401,7 @@ class SegmentFromPointNode(Node):
         ).eval()
         self.efficient_sam.to(device=self.device)
 
-        self.get_logger().info("...Done!")
-
-    def camera_info_callback(self, msg: CameraInfo) -> None:
-        """
-        Store the latest camera info message.
-
-        Parameters
-        ----------
-        msg: The camera info message.
-        """
-        with self.camera_info_lock:
-            self.camera_info = msg
-
-    def depth_image_callback(self, msg: Union[Image, CompressedImage]) -> None:
-        """
-        Store the latest depth image message.
-
-        Parameters
-        ----------
-        msg: The depth image message.
-        """
-        with self.latest_depth_img_msg_lock:
-            self.latest_depth_img_msg = msg
-
-    def image_callback(self, msg: Union[Image, CompressedImage]) -> None:
-        """
-        Store the latest image message.
-
-        Parameters
-        ----------
-        msg: The image message.
-        """
-        with self.latest_img_msg_lock:
-            self.latest_img_msg = msg
+        self._node.get_logger().info("...Done!")
 
     def goal_callback(self, goal_request: SegmentFromPoint.Goal) -> GoalResponse:
         """
@@ -444,25 +416,25 @@ class SegmentFromPointNode(Node):
         ----------
         goal_request: The goal request message.
         """
-        self.get_logger().info("Received goal request")
-        with self.latest_img_msg_lock:
-            if self.latest_img_msg is None:
-                self.get_logger().info(
-                    "Rejecting goal request since no color image received"
-                )
-                return GoalResponse.REJECT
-        with self.latest_depth_img_msg_lock:
-            if self.latest_depth_img_msg is None:
-                self.get_logger().info(
-                    "Rejecting goal request since no depth image received"
-                )
-                return GoalResponse.REJECT
+        self._node.get_logger().info("Received goal request")
+        latest_rgb_img_msg = self._node.get_latest_msg(self.rgb_image_topic)
+        if latest_rgb_img_msg is None:
+            self._node.get_logger().info(
+                "Rejecting goal request since no color image received"
+            )
+            return GoalResponse.REJECT
+        latest_depth_img_msg = self._node.get_latest_msg(self.aligned_depth_topic)
+        if latest_depth_img_msg is None:
+            self._node.get_logger().info(
+                "Rejecting goal request since no depth image received"
+            )
+            return GoalResponse.REJECT
         with self.active_goal_request_lock:
             if self.active_goal_request is None:
-                self.get_logger().info("Accepting goal request")
+                self._node.get_logger().info("Accepting goal request")
                 self.active_goal_request = goal_request
                 return GoalResponse.ACCEPT
-            self.get_logger().info(
+            self._node.get_logger().info(
                 "Rejecting goal request since there is already an active one"
             )
             return GoalResponse.REJECT
@@ -477,7 +449,7 @@ class SegmentFromPointNode(Node):
         ----------
         goal_handle: The goal handle.
         """
-        self.get_logger().info("Received cancel request, accepting")
+        self._node.get_logger().info("Received cancel request, accepting")
         return CancelResponse.ACCEPT
 
     def run_sam(
@@ -496,7 +468,7 @@ class SegmentFromPointNode(Node):
         masks: The masks outputted by the model.
         scores: The scores outputted by the model.
         """
-        self.get_logger().info("Segmenting image with SAM...")
+        self._node.get_logger().info("Segmenting image with SAM...")
         # Convert image from BGR to RGB
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
@@ -527,7 +499,7 @@ class SegmentFromPointNode(Node):
         masks: The masks outputted by the model.
         scores: The scores outputted by the model.
         """
-        self.get_logger().info("Segmenting image with EfficientSAM...")
+        self._node.get_logger().info("Segmenting image with EfficientSAM...")
         # Convert image from BGR to RGB
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
@@ -575,21 +547,21 @@ class SegmentFromPointNode(Node):
         # pylint: disable=too-many-locals
         # All are necessary.
 
-        self.get_logger().info("Segmenting image...")
+        self._node.get_logger().info("Segmenting image...")
         # Create the result
         result = SegmentFromPoint.Result()
         result.header = image_msg.header
-        with self.camera_info_lock:
-            if self.camera_info is not None:
-                result.camera_info = self.camera_info
-            else:
-                self.get_logger().warn(
-                    "Camera info not received, not including in result message"
-                )
+        if self.camera_info is None:
+            self.camera_info = self._node.get_latest_msg(self.camera_info_topic)
+        if self.camera_info is not None:
+            result.camera_info = self.camera_info
+        else:
+            self._node.get_logger().warn(
+                "Camera info not received, not including in result message"
+            )
 
         # Get the latest depth image
-        with self.latest_depth_img_msg_lock:
-            depth_img_msg = self.latest_depth_img_msg
+        depth_img_msg = self._node.get_latest_msg(self.aligned_depth_topic)
 
         # Convert the image to OpenCV format
         image = ros_msg_to_cv2_image(image_msg, self.bridge)
@@ -599,13 +571,13 @@ class SegmentFromPointNode(Node):
         depth_img = ros_msg_to_cv2_image(depth_img_msg, self.bridge)
 
         # Segment the image
-        start_time = self.get_clock().now()
+        start_time = self._node.get_clock().now()
         if self.use_efficient_sam:
             masks, scores = self.run_efficient_sam(image, seed_point)
         else:
             masks, scores = self.run_sam(image, seed_point)
-        elpased_time = self.get_clock().now() - start_time
-        self.get_logger().info(
+        elpased_time = self._node.get_clock().now() - start_time
+        self._node.get_logger().info(
             f"Elapsed time Model: {elpased_time.nanoseconds / 10.0**9} secs"
         )
 
@@ -667,7 +639,7 @@ class SegmentFromPointNode(Node):
             ]
         )
         if np.isnan(average_depth_mm):
-            self.get_logger().warn(
+            self._node.get_logger().warn(
                 f"No depth points within [{self.min_depth_mm}, {self.max_depth_mm}] mm range "
                 f"for mask {item_id}. Skipping mask."
             )
@@ -722,21 +694,19 @@ class SegmentFromPointNode(Node):
         -------
         result: The result message containing the contender masks.
         """
-        self.get_logger().info(f"Executing goal...{goal_handle}")
-        start_time = self.get_clock().now()
+        self._node.get_logger().info(f"Executing goal...{goal_handle}")
+        start_time = self._node.get_clock().now()
 
         # Get the latest image
-        latest_img_msg = None
-        with self.latest_img_msg_lock:
-            latest_img_msg = self.latest_img_msg
+        latest_img_msg = self._node.get_latest_msg(self.rgb_image_topic)
 
         # Start image segmentation as a co-routine
         seed_point = (
             int(goal_handle.request.seed_point.point.x),
             int(goal_handle.request.seed_point.point.y),
         )
-        rate = self.create_rate(self.rate_hz)
-        segment_image_task = self.executor.create_task(
+        rate = self._node.create_rate(self.rate_hz)
+        segment_image_task = self._node.executor.create_task(
             self.segment_image, seed_point, latest_img_msg
         )
 
@@ -747,32 +717,32 @@ class SegmentFromPointNode(Node):
             and not goal_handle.is_cancel_requested
             and not segment_image_task.done()
         ):
-            feedback.elapsed_time = (self.get_clock().now() - start_time).to_msg()
+            feedback.elapsed_time = (self._node.get_clock().now() - start_time).to_msg()
             goal_handle.publish_feedback(feedback)
             rate.sleep()
 
         # Check if there was a cancel request
         if goal_handle.is_cancel_requested or not rclpy.ok():
-            self.get_logger().info("Goal canceled")
+            self._node.get_logger().info("Goal canceled")
             goal_handle.canceled()
             result = SegmentFromPoint.Result()
             result.status = result.STATUS_CANCELED
             with self.active_goal_request_lock:
                 self.active_goal_request = None  # Clear the active goal
             return result
-        self.get_logger().info("Goal not canceled")
+        self._node.get_logger().info("Goal not canceled")
 
         # Task must be done, given that we broke out of the while loop and
         # did not land in the above conditional
         result = segment_image_task.result()
 
         # Return the result
-        self.get_logger().info("Segmentation succeeded, returning")
+        self._node.get_logger().info("Segmentation succeeded, returning")
         goal_handle.succeed()
         result.status = result.STATUS_SUCCEEDED
         with self.active_goal_request_lock:
             self.active_goal_request = None  # Clear the active goal
-        self.get_logger().info(
+        self._node.get_logger().info(
             "...Done. Got masks with average depth "
             f"{[m.average_depth for m in result.detected_items]} m."
         )
@@ -785,12 +755,17 @@ def main(args=None):
     """
     rclpy.init(args=args)
 
-    segment_from_point = SegmentFromPointNode()
+    node = ADAFeedingPerceptionNode("segment_from_point")
+    segment_from_point = SegmentFromPointNode(node)  # pylint: disable=unused-variable
 
     # Use a MultiThreadedExecutor to enable processing goals concurrently
     executor = MultiThreadedExecutor(num_threads=5)
 
-    rclpy.spin(segment_from_point, executor=executor)
+    rclpy.spin(node, executor=executor)
+
+    # Terminate this node
+    node.destroy_node()
+    rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
+++ b/ada_feeding_perception/ada_feeding_perception/segment_from_point.py
@@ -99,7 +99,7 @@ class SegmentFromPointNode(Node):
             CameraInfo,
             "~/camera_info",
             self.camera_info_callback,
-            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
@@ -119,7 +119,7 @@ class SegmentFromPointNode(Node):
             aligned_depth_type,
             aligned_depth_topic,
             self.depth_image_callback,
-            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 
@@ -138,7 +138,7 @@ class SegmentFromPointNode(Node):
             image_type,
             image_topic,
             self.image_callback,
-            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             callback_group=MutuallyExclusiveCallbackGroup(),
         )
 

--- a/ada_feeding_perception/config/face_detection.yaml
+++ b/ada_feeding_perception/config/face_detection.yaml
@@ -12,4 +12,20 @@ face_detection:
     # The desired length of the depth image buffer
     depth_buffer_size: 30
     # The rate at which to detect and publish detected faces
-    rate_hz: 3
+    face_detection_rate_hz: 3
+
+# NOTE: If using the combined perception node, be very careful to ensure no name clashes of parameters!
+ada_feeding_perception:
+  ros__parameters:
+    # The name of the face detection model checkpoint to use
+    face_model_name: haarcascade_frontalface_alt2.xml
+    # The URL to download the face detection model checkpoint from if it is not already downloaded
+    face_model_base_url: "https://raw.githubusercontent.com/opencv/opencv/master/data/haarcascades/"
+    # The name of the facial landmark detection model checkpoint to use
+    landmark_model_name: lbfmodel.yaml
+    # The URL to download the facial landmark detection model checkpoint from if it is not already downloaded
+    landmark_model_base_url: "https://raw.githubusercontent.com/kurnianggoro/GSOC2017/master/data/"
+    # The desired length of the depth image buffer
+    depth_buffer_size: 30
+    # The rate at which to detect and publish detected faces
+    face_detection_rate_hz: 3

--- a/ada_feeding_perception/config/food_on_fork_detection.yaml
+++ b/ada_feeding_perception/config/food_on_fork_detection.yaml
@@ -14,7 +14,7 @@ food_on_fork_detection:
       camera_matrix: [614.5933227539062, 0.0, 312.1358947753906, 0.0, 614.6914672851562, 223.70831298828125, 0.0, 0.0, 1.0]
     
     # The rate at which to detect and publish the confidence that there is food on the fork
-    rate_hz: 10.0
+    food_on_fork_detection_rate_hz: 10.0
     # The top-left  and bottom-right corners to crop the depth image to
     crop_top_left: [344, 272]
     crop_bottom_right: [408, 336]
@@ -28,7 +28,42 @@ food_on_fork_detection:
     spatial_num_pixels: 10
 
     # Whether to visualize the output of the detector
-    viz: True
+    food_on_fork_detection_viz: True
+    # The upper and lower thresholds for the visualization to say there is(n't) food-on-fork
+    viz_lower_thresh: 0.25
+    viz_upper_thresh: 0.75
+
+# NOTE: If using the combined perception node, be very careful to ensure no name clashes of parameters!
+ada_feeding_perception:
+  ros__parameters:
+    # The FoodOnFork class to use
+    model_class: "ada_feeding_perception.food_on_fork_detectors.FoodOnForkDistanceToNoFOFDetector"
+    # The path to load the model from. Ignored if the empty string.
+    # Should be relative to the `model_dir` parameter, specified in the launchfile.
+    model_path: "distance_no_fof_detector_with_filters.npz"
+    # Keywords to pass to the FoodOnFork class's constructor
+    model_kws:
+      - camera_matrix
+    # Keyword arguments to pass to the FoodOnFork class's constructor
+    model_kwargs:
+      camera_matrix: [614.5933227539062, 0.0, 312.1358947753906, 0.0, 614.6914672851562, 223.70831298828125, 0.0, 0.0, 1.0]
+    
+    # The rate at which to detect and publish the confidence that there is food on the fork
+    food_on_fork_detection_rate_hz: 10.0
+    # The top-left  and bottom-right corners to crop the depth image to
+    crop_top_left: [344, 272]
+    crop_bottom_right: [408, 336]
+    # The min and max depth to consider for the food on the fork
+    depth_min_mm: 310
+    depth_max_mm: 340
+
+    # The size of the temporal window for the "temporal" post-processor.
+    temporal_window_size: 5
+    # The size of the square kernel for the "spatial" post-processor.
+    spatial_num_pixels: 10
+
+    # Whether to visualize the output of the detector
+    food_on_fork_detection_viz: True
     # The upper and lower thresholds for the visualization to say there is(n't) food-on-fork
     viz_lower_thresh: 0.25
     viz_upper_thresh: 0.75

--- a/ada_feeding_perception/config/segment_from_point.yaml
+++ b/ada_feeding_perception/config/segment_from_point.yaml
@@ -18,4 +18,26 @@ segment_from_point:
     n_contender_masks: 3
 
     # The rate (hz) at which to return feedback
-    rate_hz: 10.0
+    segment_from_point_rate_hz: 10.0
+
+# NOTE: If using the combined perception node, be very careful to ensure no name clashes of parameters!
+ada_feeding_perception:
+  ros__parameters:
+    # The name of the Segment Anything model checkpoint to use
+    sam_model_name: sam_vit_b_01ec64.pth
+    # The URL to download the model checkpoint from if it is not already downloaded
+    sam_model_base_url: "https://dl.fbaipublicfiles.com/segment_anything/"
+
+    # The name of the Efficient Segment Anything model checkpoint to use
+    efficient_sam_model_name: efficient_sam_vitt.pt
+    # The URL to download the model checkpoint from if it is not already downloaded
+    efficient_sam_model_base_url: "https://raw.githubusercontent.com/yformer/EfficientSAM/main/weights/"
+
+    # Whether to use SAM or EfficientSAM
+    use_efficient_sam: true
+
+    # The number of contender masks to return
+    n_contender_masks: 3
+
+    # The rate (hz) at which to return feedback
+    segment_from_point_rate_hz: 10.0

--- a/ada_feeding_perception/config/table_detection.yaml
+++ b/ada_feeding_perception/config/table_detection.yaml
@@ -2,7 +2,16 @@
 table_detection:
   ros__parameters:
     # The rate at which to publish the pose of the detected table
-    rate_hz: 3.0
+    table_detection_rate_hz: 3.0
 
     # A boolean to determine whether to visualize plate detection 
-    viz: True
+    table_detection_viz: True
+
+# NOTE: If using the combined perception node, be very careful to ensure no name clashes of parameters!
+ada_feeding_perception:
+  ros__parameters:
+    # The rate at which to publish the pose of the detected table
+    table_detection_rate_hz: 3.0
+
+    # A boolean to determine whether to visualize plate detection 
+    table_detection_viz: True

--- a/ada_feeding_perception/setup.py
+++ b/ada_feeding_perception/setup.py
@@ -46,6 +46,7 @@ setup(
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
+            "ada_feeding_perception_node = ada_feeding_perception.ada_feeding_perception_node:main",
             "food_on_fork_detection = ada_feeding_perception.food_on_fork_detection:main",
             "republisher = ada_feeding_perception.republisher:main",
             "segment_from_point = ada_feeding_perception.segment_from_point:main",

--- a/nano_bridge/nano_bridge/receiver.py
+++ b/nano_bridge/nano_bridge/receiver.py
@@ -100,9 +100,7 @@ class ReceiverNode(Node):
             self.__pubs[topic_name] = self.create_publisher(
                 msg_type=self.__types[topic_type],
                 topic=repub_topic_name,
-                qos_profile=QoSProfile(
-                    depth=1, reliability=ReliabilityPolicy.BEST_EFFORT
-                ),
+                qos_profile=QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             )
             self.get_logger().info(f"Created publisher for {repub_topic_name}.")
 

--- a/nano_bridge/nano_bridge/receiver_compressed_image.py
+++ b/nano_bridge/nano_bridge/receiver_compressed_image.py
@@ -254,9 +254,7 @@ class ReceiverCompressedImageNode(Node):
             self.__pubs[topic_name] = self.create_publisher(
                 msg_type=CompressedImageOutput,
                 topic=repub_topic_name,
-                qos_profile=QoSProfile(
-                    depth=1, reliability=ReliabilityPolicy.BEST_EFFORT
-                ),
+                qos_profile=QoSProfile(depth=1, reliability=ReliabilityPolicy.RELIABLE),
             )
             self.get_logger().info(f"Created publisher for {repub_topic_name}.")
 

--- a/start.py
+++ b/start.py
@@ -280,7 +280,7 @@ async def main(args: argparse.Namespace, pwd: str) -> None:
                 "ros2 launch rosbridge_server rosbridge_websocket_launch.xml",
             ],
             "perception": [
-                "ros2 launch ada_feeding_perception ada_feeding_perception.launch.py",
+                "ros2 launch ada_feeding_perception ada_feeding_perception.launch.py combine_perception_nodes:=true",
             ],
             "moveit": [
                 "Xvfb :5 -screen 0 800x600x24 &" if not args.dev else "",


### PR DESCRIPTION
# Description

We've recently been facing an issue where sometimes, particularly for face detection, the depth image does not get received for minutes on end (even though the RGB image is actively being received). To address this, this PR does two things:

1. Changes the reliability policy for perception nodes from `BEST_EFFORT` to `RELIABLE`. This is likely the immediate fix.
2. Provides an option (which is now the default in `start.py`) to combine all perception nodes into one. This is useful because then as opposed to having 4 copies of the RGB and depth image subscribers, we have just 1, which will likely make the RMW more efficient.

# Testing procedure

- [x] Launch the code in `real`.
- [x] Eat a whole bite, verify all perception works.
- [x] Keep the code running for 30-ish mins, eat a bite then, verify all perception still works.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [x] `Squash & Merge`
