### PR TITLE
Tune food-on-fork offset

### DIFF
--- a/ada_feeding_perception/ada_feeding_perception/ada_feeding_perception_node.py
+++ b/ada_feeding_perception/ada_feeding_perception/ada_feeding_perception_node.py
@@ -212,19 +212,19 @@ def main(args=None):
 
     face_detection_thread = Thread(target=face_detection_run, daemon=True)
     face_detection_thread.start()
-    food_on_fork_detection_thread = Thread(
-        target=food_on_fork_detection_run, daemon=True
-    )
-    food_on_fork_detection_thread.start()
     table_detection_thread = Thread(target=table_detection_run, daemon=True)
     table_detection_thread.start()
 
-    # Spin in the foreground
-    spin_thread.join()
+    # For debugging purposes, it helps to have food-on-fork running in the main thread.
+    # (If we uncomment `self.model.visualize_img` which opens a Matplotlib plot).
+    food_on_fork_detection_run()
 
     # Terminate this node
     node.destroy_node()
     rclpy.shutdown()
+
+    # Join the spin thread (so it is spinning in the main thread)
+    spin_thread.join()
 
 
 if __name__ == "__main__":

--- a/ada_feeding_perception/ada_feeding_perception/food_on_fork_detectors.py
+++ b/ada_feeding_perception/ada_feeding_perception/food_on_fork_detectors.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 import os
 import time
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 # Third-party imports
 import cv2
@@ -261,7 +261,7 @@ class FoodOnForkDetector(ABC):
         """
 
     @abstractmethod
-    def load(self, path: str) -> None:
+    def load(self, path: str, **kwargs: Any) -> None:
         """
         Loads the model a file.
 
@@ -415,7 +415,7 @@ class FoodOnForkDummyDetector(FoodOnForkDetector):
         return ""
 
     @override
-    def load(self, path: str) -> None:
+    def load(self, path: str, **kwargs: Any) -> None:
         pass
 
     @override
@@ -768,13 +768,29 @@ class FoodOnForkDistanceToNoFOFDetector(FoodOnForkDetector):
         )
         return path + ".npz"
 
-    @override
-    def load(self, path: str) -> None:
+    def load(
+        self,
+        path: str,
+        no_fof_points_offset: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+        **kwargs: Any,
+    ) -> None:
+        """
+        Loads the model a file.
+
+        Parameters
+        ----------
+        path: The path to load the perception algorithm from. If the path does
+            not have an extension, this function will add the appropriate
+            extension.
+        no_fof_points_offset: The offset to apply to the no_fof_points. This is
+            useful to account for things like the fork getting bent, or the camera's
+            extrinsics changing.
+        """
         ext = os.path.splitext(path)[1]
         if len(ext) == 0:
             path = path + ".npz"
         params = np.load(path, allow_pickle=True)
-        self.no_fof_points = params["no_fof_points"]
+        self.no_fof_points = params["no_fof_points"] + no_fof_points_offset
         self.clf = params["clf"][0]
         self.best_aggregator_name = str(params["best_aggregator_name"])
         if self.verbose:

--- a/ada_feeding_perception/config/food_on_fork_detection.yaml
+++ b/ada_feeding_perception/config/food_on_fork_detection.yaml
@@ -33,6 +33,12 @@ food_on_fork_detection:
     viz_lower_thresh: 0.25
     viz_upper_thresh: 0.75
 
+    # The offset to add to no-food-on-fork points. This is useful to acocunt for scenarios like when
+    # the fork gets bent or the camera extrinsics changes slightly.
+    # NOTE: The fact that food-on-fork detection is sensitive to such small offsets is, in itself,
+    # an indication that it needs to be improved.
+    no_fof_points_offset: [0.0, 0.0025, -0.005]
+
 # NOTE: If using the combined perception node, be very careful to ensure no name clashes of parameters!
 ada_feeding_perception:
   ros__parameters:
@@ -67,3 +73,9 @@ ada_feeding_perception:
     # The upper and lower thresholds for the visualization to say there is(n't) food-on-fork
     viz_lower_thresh: 0.25
     viz_upper_thresh: 0.75
+
+    # The offset to add to no-food-on-fork points. This is useful to acocunt for scenarios like when
+    # the fork gets bent or the camera extrinsics changes slightly.
+    # NOTE: The fact that food-on-fork detection is sensitive to such small offsets is, in itself,
+    # an indication that it needs to be improved.
+    no_fof_points_offset: [0.0, 0.0025, -0.005]


### PR DESCRIPTION
# Description

Given how our food-on-fork (FoF) algorithm works (memorizing "fork" points in the camera frame), it is susceptible to changes in the camera extrinsics, and to physical changes like the fork getting bent. To make it easier to fix these sort of issues in the FoF algorithm, this PR adds a `non_fof_points_offset` parameter, which is position offsets to add to the stored `no_fof_points`. This PR also tunes that offset to the current robot/camera.

# Testing procedure

- [x] Launch the code in `real`.
- [x] Turn on FoF sensing: `ros2 service call /toggle_food_on_fork_detection std_srvs/srv/SetBool "{data: true}"`
- [x] Echo the FoF topic: `ros2 topic echo /food_on_fork_detection`
- [x] Move your finger around the fork, mimicing different food poses, verify it works as expected.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
