### PR TITLE
[Bugfix] Workspace walls should get default configurations if customized ones don't exist

### DIFF
--- a/ada_feeding/config/ada_feeding_action_servers_custom.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_custom.yaml
@@ -94,7 +94,18 @@ ada_feeding_action_servers:
     - side_staging_1
     - side_staging_2
     - side_staging_3
-    namespace_to_use: wheelchair_side_table_1
+    - demo
+    demo:
+      MoveFromMouth.tree_kwargs.linear_speed_near_mouth: 0.08
+      MoveFromMouth.tree_kwargs.max_linear_speed_to_staging_configuration: 0.15
+      MoveToMouth.tree_kwargs.linear_speed_near_mouth: 0.06
+      MoveToMouth.tree_kwargs.max_linear_speed: 0.15
+      MoveToMouth.tree_kwargs.plan_distance_from_mouth:
+      - 0.05
+      - 0.0
+      - -0.01
+      planning_scene_namespace_to_use: seated
+    namespace_to_use: demo
     side_staging_1:
       AcquireFood.tree_kwargs.resting_joint_positions:
       - -0.8849039817349507

--- a/ada_feeding/config/ada_feeding_action_servers_default.yaml
+++ b/ada_feeding/config/ada_feeding_action_servers_default.yaml
@@ -5,8 +5,7 @@ ada_feeding_action_servers:
     watchdog_timeout_sec: 0.5 # sec
 
     default:
-      # TODO: Post-deployment, change this back!
-      planning_scene_namespace_to_use: seated_90
+      planning_scene_namespace_to_use: seated
 
       # A list of the names of the action servers to create. Each one must have
       # it's own parameters (below) specifying action_type and tree_class.

--- a/ada_planning_scene/ada_planning_scene/ada_planning_scene.py
+++ b/ada_planning_scene/ada_planning_scene/ada_planning_scene.py
@@ -5,6 +5,7 @@ This module contains the main node for populating and maintaining ADA's planning
 
 # Standard imports
 import threading
+import traceback
 from typing import List
 
 # Third-party imports
@@ -379,6 +380,23 @@ class ADAPlanningScene(Node):
                 self.initialize()
 
         return SetParametersResult(successful=True)
+
+
+def spin(node: Node, executor: MultiThreadedExecutor) -> None:
+    """
+    Spin the node in the executor.
+    """
+    try:
+        rclpy.spin(node, executor=executor)
+    except rclpy._rclpy_pybind11.InvalidHandle:
+        # There is a known issue in rclpy where it doesn't properly handle destruction of
+        # elements in the executor.
+        # - https://github.com/ros2/rclpy/issues/1355
+        # - https://github.com/ros2/rclpy/issues/1206
+        # - https://github.com/ros2/rclpy/issues/1142
+        # This is a **very hacky** workaround to prevent the node from crashing.
+        traceback.print_exc()
+        spin(node, executor)
 
 
 def main(args: List = None) -> None:

--- a/ada_planning_scene/config/ada_planning_scene.yaml
+++ b/ada_planning_scene/config/ada_planning_scene.yaml
@@ -25,7 +25,7 @@ ada_planning_scene:
       - bedside
       - seated_90
       - bedside_90
-    namespace_to_use: seated_90 # bedside_90 # 
+    namespace_to_use: seated
 
     ############################################################################
     # Parameters related to the PlanningSceneInitializer class
@@ -294,7 +294,7 @@ ada_planning_scene:
       - "MoveAbovePlate.tree_kwargs.joint_positions"
       - "MoveToRestingPosition.tree_kwargs.goal_configuration"
       - "MoveToStagingConfiguration.tree_kwargs.goal_configuration"
-      - "MoveToStowLocation.tree_kwargs.tree_kwargs"
+      - "MoveToStowLocation.tree_kwargs.joint_positions"
 
     # Which joints in the robot's URDF are fixed (along with their values).
     # These are used when computing the bounds of different robot arm configurationss.


### PR DESCRIPTION
# Description

This PR makes a few separate but related changes:

1. Adds a customized configuration for demos, which moves the robot arm farther from the user's mouth (5cm).
2. Because that custom configuration does not change any of the default robot arm configurations, it revealed a bug where `ada_planning_scene` failed to compute workspace walls if robot arm configurations have not been customized. This PR addresses that bug, by having `ada_planning_scene` get the default configurations for those that aren't customizing (which aligns with the actual behavior of the `ada_feeding_action_servers` node.
3. Finally, there is a known `rclpy` bug where spinning crashes when some callbacks are destroyed ([#1355](https://github.com/ros2/rclpy/issues/1355), [#1206](https://github.com/ros2/rclpy/issues/1206), [#1142](https://github.com/ros2/rclpy/issues/1142)). This PR creates a very hacky fix, by resuming spinning where it left off.

# Testing procedure

- [x] Verify the issue: 
     - [x] Get the `ada_feeding_action_servers_custom.yaml` file from this PR, but leave everything else unchanged. Re-build your workspace.
     - [x] Run `ros2 launch ada_planning_scene ada_moveit_launch.xml use_rviz:=false sim:=mock`
     - [x] Verify via the logs that `ada_planning_scene` keeps terminating and restarting.
- [x] Verify the fix:
     - [x] Pull this branch, re-build your workspace.
     - [x] Run `ros2 launch ada_planning_scene ada_moveit_launch.xml use_rviz:=false sim:=mock`
     - [x] Verify via the logs that `ada_planning_scene` succesfully populates the workspace walls.

# Before opening a pull request
- [x] Format your code using [black formatter](https://black.readthedocs.io/en/stable/) `python3 -m black .`
- [x] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/) and address all warnings/errors. The only warnings that are acceptable to not address is TODOs that should be addressed in a future PR. From the top-level `ada_feeding` directory, run: `pylint --recursive=y --rcfile=.pylintrc .`.

# Before Merging
- [ ] `Squash & Merge`
