### PR TITLE
Added code to help debug fork off-center issues

### DIFF
--- a/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
+++ b/ada_feeding/ada_feeding/behaviors/acquisition/compute_food_frame.py
@@ -336,6 +336,30 @@ class ComputeFoodFrame(BlackboardBehavior):
             x_unit.vector, x_pos.vector
         )
 
+        # # If you need to send a fixed food frame to the robot arm, e.g., to 
+        # # debug off-centering issues, uncomment this and modify the translation.
+        # deg = 90  # fork roll
+        # world_to_food_transform.transform.translation.x = 0.26262263022586224
+        # world_to_food_transform.transform.translation.y = -0.2783553055166875
+        # world_to_food_transform.transform.translation.z = 0.17773121634396466
+        # world_to_food_transform.transform.rotation.x = 0.0
+        # world_to_food_transform.transform.rotation.y = 0.0
+        # if deg == 0:
+        #     world_to_food_transform.transform.rotation.z = 0.0
+        #     world_to_food_transform.transform.rotation.w = 1.0
+        # elif deg == 90:
+        #     world_to_food_transform.transform.rotation.z = 0.7071068
+        #     world_to_food_transform.transform.rotation.w = 0.7071068
+        # elif deg == -90:
+        #     world_to_food_transform.transform.rotation.z = -0.7071068
+        #     world_to_food_transform.transform.rotation.w = 0.7071068
+        # elif deg == 180:
+        #     world_to_food_transform.transform.rotation.z = 1.0
+        #     world_to_food_transform.transform.rotation.w = 0.0
+        # else:
+        #     self.logger.error(f"Invalid deg: {deg}")
+        #     return py_trees.common.Status.FAILURE
+
         # Write to blackboard outputs
         if len(self.blackboard_get("food_frame_id")) > 0:
             set_static_tf(world_to_food_transform, self.blackboard, self.node)


### PR DESCRIPTION
# Description

When addressing issues of mismatch between the robot URDF and real robot, it can help to command a fixed position to the robot and see how well the fork's real-world position aligns across various commanded orientations. This PR adds some commented out code to do that.

# Testing procedure

See [`ada_ros2`#49](https://github.com/personalrobotics/ada_ros2/pull/49).

# Future Work

Eventually, this (`food_pose_override`) should be made into a parameter passed into the AcquireFood tree, so that it can be set via the config file as opposed to requiring code changes. However, given the time crunch for the upcoming demos, I'm merging this in for now.

# Before Merging
- [ ] `Squash & Merge`
