### PR TITLE
Map weights to CUDA or CPU depending on which is enabled

### DIFF
--- a/ada_feeding_action_select/ada_feeding_action_select/adapters/hapticnet_adapter.py
+++ b/ada_feeding_action_select/ada_feeding_action_select/adapters/hapticnet_adapter.py
@@ -47,10 +47,13 @@ class HapticNetPosthoc(PosthocAdapter):
 
         # Init CUDA
         self.use_cuda = torch.cuda.is_available()
+        self.device = torch.device("cuda") if self.use_cuda else torch.device("cpu")
         if self.use_cuda:
             logger.info("Init HapticNet with CUDA")
             os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
             os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_index)
+        else:
+            logger.info("Init HapticNet with CPU")
 
         # Init HapticNet
         self.config = HapticNetConfig(n_output=n_features)
@@ -60,7 +63,7 @@ class HapticNetPosthoc(PosthocAdapter):
         ckpt_file = os.path.join(
             get_package_share_directory("ada_feeding_action_select"), "data", checkpoint
         )
-        ckpt = torch.load(ckpt_file)
+        ckpt = torch.load(ckpt_file, map_location=self.device)
         self.hapticnet.load_state_dict(ckpt["state_dict"])
         self.hapticnet.eval()
         if self.use_cuda:

--- a/ada_feeding_action_select/ada_feeding_action_select/adapters/spanet_adapter.py
+++ b/ada_feeding_action_select/ada_feeding_action_select/adapters/spanet_adapter.py
@@ -49,10 +49,13 @@ class SPANetContext(ContextAdapter):
 
         # Init CUDA
         self.use_cuda = torch.cuda.is_available()
+        self.device = torch.device("cuda") if self.use_cuda else torch.device("cpu")
         if self.use_cuda:
             logger.info("Init SPANet with CUDA")
             os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
             os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_index)
+        else:
+            logger.info("Init SPANet with CPU")
 
         # Init SPANet
         self.config = SPANetConfig(n_features=n_features)
@@ -62,7 +65,7 @@ class SPANetContext(ContextAdapter):
         ckpt_file = os.path.join(
             get_package_share_directory("ada_feeding_action_select"), "data", checkpoint
         )
-        ckpt = torch.load(ckpt_file)
+        ckpt = torch.load(ckpt_file, map_location=self.device)
         self.spanet.load_state_dict(ckpt["net"])
         self.spanet.eval()
         if self.use_cuda:

--- a/ada_feeding_action_select/ada_feeding_action_select/policy_service.py
+++ b/ada_feeding_action_select/ada_feeding_action_select/policy_service.py
@@ -226,7 +226,7 @@ class PolicyServices(Node):
             )
             if len(pt_files) > 0:
                 with open(pt_files[-1], "rb") as ckpt_file:
-                    ckpt = torch.load(ckpt_file)
+                    ckpt = torch.load(ckpt_file, map_location=self.device)
                     try:
                         if ckpt["context_cls"] != context_cls:
                             self.get_logger().warning(
@@ -252,6 +252,8 @@ class PolicyServices(Node):
         super().__init__("policy_service")
         register_logger(self.get_logger())
         self._declare_parameters()
+
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
         # Name of the Policy
         policy_name = self.get_parameter("policy").value


### PR DESCRIPTION
# Description

This PR adds a check for whether CUDA is enabled before loading our checkpoint weight files. If it isn't enabled, we map the weights to CPU instead. This is particularly relevant since the current instructions for setting up machines to run `ada_feeding` doesn't explicitly require enabling CUDA.

# Testing procedure

1. Launch the feeding software on machines both with and without CUDA enabled, e.g. `lovelace` and one of the lab machines
2. Observe that there are no errors related to loading weights due to incompatible CUDA configurations

# Before opening a pull request

- \[x\] `pre-commit run --all-files`
- \[x\] Run your code through [pylint](https://pylint.readthedocs.io/en/latest/). `pylint --recursive=y --rcfile=.pylintrc .`. All warnings but `fixme` must be addressed.

# Before Merging

- \[ \] `Squash & Merge`
